### PR TITLE
ci: switch to npm registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,10 @@ jobs:
             export branch=$(git rev-parse --abbrev-ref HEAD | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
             export versionTag=$version-$branch-$commit
 
-            echo //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN > ~/.npmrc
+            echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc
 
             npm version $versionTag --git-tag-version=false
-            npm publish --tag prerelease
+            npm publish --tag prerelease --access=public
 
             echo "export VERSION_TAG=$versionTag" >> $BASH_ENV
       - run:
@@ -108,19 +108,12 @@ jobs:
 
             A prerelease version of this package has been published! 🚀
 
-            **This is still experimental ⚠️**
-
             To use it in your project run the following lines:
             \`\`\`shell
-            echo @gravitee-io:registry=https://npm.pkg.github.com > .npmrc
-
-            npm install @gravitee-io/ui-particles-angular@${VERSION_TAG}
-
-            yarn add @gravitee-io/ui-particles-angular@${VERSION_TAG}
+            npm install @gravitee/ui-particles-angular@${VERSION_TAG}
+            # or
+            yarn add @gravitee/ui-particles-angular@${VERSION_TAG}
             \`\`\`
-
-            You may also need to login to the registry:
-            \`npm login --scope=@gravitee-io --registry=https://npm.pkg.github.com\`
             "
 
   release:
@@ -233,6 +226,9 @@ workflows:
           package_name: ui-particles-angular
           pre-steps:
             - secrethub/env-export:
+                secret-path: graviteeio/cicd/graviteebot/infra/npm_token
+                var-name: NPM_TOKEN
+            - secrethub/env-export:
                 secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
                 var-name: GITHUB_TOKEN
           context: gravitee-qa
@@ -244,7 +240,7 @@ workflows:
           dry_run: true
           pre-steps:
             - secrethub/env-export:
-                secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
+                secret-path: graviteeio/cicd/graviteebot/infra/npm_token
                 var-name: NPM_TOKEN
             - secrethub/env-export:
                 secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
@@ -316,7 +312,7 @@ workflows:
           dry_run: false
           pre-steps:
             - secrethub/env-export:
-                secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
+                secret-path: graviteeio/cicd/graviteebot/infra/npm_token
                 var-name: NPM_TOKEN
             - secrethub/env-export:
                 secret-path: graviteeio/cicd/graviteebot/github_personal_access_token

--- a/README.md
+++ b/README.md
@@ -21,15 +21,10 @@ This project is itself an Angular workspace created by angular-cli. It contains 
 To use it in your project run the following lines:
 
 ```bash
-echo @gravitee-io:registry=https://npm.pkg.github.com > .npmrc
-
-npm install @gravitee-io/ui-particles-angular
+npm install @gravitee/ui-particles-angular
 # or
-yarn add @gravitee-io/ui-particles-angular
+yarn add @gravitee/ui-particles-angular
 ```
-
-You may also need to login to the registry:
-npm login --scope=@gravitee-io --registry=https://npm.pkg.github.com
 
 ## Contributing
 

--- a/ui-particles-angular/projects/ui-particles-angular/package.json
+++ b/ui-particles-angular/projects/ui-particles-angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gravitee-io/ui-particles-angular",
+  "name": "@gravitee/ui-particles-angular",
   "version": "0.0.0-semantically-released",
   "description": "Gravitee.io - UI Particles Angular",
   "repository": {
@@ -19,6 +19,6 @@
     "@angular/material": "^12.2.0"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/stories/theme-color/showcase-color.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/stories/theme-color/showcase-color.component.ts
@@ -54,7 +54,7 @@ export class ShowcaseColorComponent {
   matColorInScss = `
 @use 'sass:map';
 @use '@angular/material' as mat;
-@use '@gravitee-io/ui-particles-angular' as gio;
+@use '@gravitee/ui-particles-angular' as gio;
 
 $accent: map.get(gio.$mat-theme, accent);
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/stories/theme-typography/showcase-typography.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/stories/theme-typography/showcase-typography.component.ts
@@ -23,7 +23,7 @@ export class ShowcaseTypographyComponent {
   typographyInScss = `
 @use 'sass:map';
 @use '@angular/material' as mat;
-@use '@gravitee-io/ui-particles-angular' as gio;
+@use '@gravitee/ui-particles-angular' as gio;
 
 $typography: map.get(gio.$mat-theme, typography);
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6444

**Description**

Previously the packages of this repo were released on GitHub registry, everything was working great EXCEPT the fact users need to be authenticated (with a GitHub account) to download the packages.

So we decided to move back to npmjs like the `ui-component` package.


**Additional context**

 - GitHub post about Github Package Registry without authentication: https://github.community/t/download-from-github-package-registry-without-authentication/14407

