### PR TITLE
fix: manage mat-content-palette like a special palette

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
@@ -62,7 +62,7 @@ $mat-content-palette: mat.define-palette(
     ),
   ),
   default,
-  lighter,
+  default,
   darker
 );
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/theme/color/gio-palettes.stories.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/theme/color/gio-palettes.stories.scss
@@ -26,7 +26,6 @@ $palettes: (
   success: gio.$mat-success-palette,
   warning: gio.$mat-warning-palette,
   error: gio.$mat-error-palette,
-  content: gio.$mat-content-palette,
 );
 
 :export {
@@ -37,6 +36,13 @@ $palettes: (
         #{$paletteName}__#{$colorName}-contrast: mat.get-color-from-palette($palette, #{$colorName}-contrast);
       }
     }
+  }
+
+  // Special palettes
+
+  @each $colorName in (darker, default, disabled) {
+    content__#{$colorName}: mat.get-color-from-palette(gio.$mat-content-palette, $colorName);
+    content__#{$colorName}-contrast: mat.get-color-from-palette(gio.$mat-content-palette, #{$colorName}-contrast);
   }
 
   @each $colorName in (background, lighter-background, surface, divider) {


### PR DESCRIPTION
**Issue**
na

**Description**
corrects the non-presence of lighter in mat-content-palette

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-loneqzsbds.chromatic.com)
<!-- Storybook placeholder end -->
