### PR TITLE
fix: angular 13.x error with color not exist in palette

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
@@ -148,9 +148,9 @@ $mat-decorative-palette: mat.define-palette(
       divider: #000,
     ),
   ),
-  default,
-  lighter,
-  darker
+  surface,
+  surface,
+  surface
 );
 
 // Method color
@@ -168,5 +168,8 @@ $mat-method-palette: mat.define-palette(
       get: #346aa5,
       delete: #bf3133,
     ),
-  )
+  ),
+  patch,
+  patch,
+  patch
 );


### PR DESCRIPTION
**Issue**
na
**Description**

angular 13.x error with color not exist in palette

**Additional context**
![image](https://user-images.githubusercontent.com/4974420/150948781-7662916a-4fb4-4a53-9300-3ec0d938be30.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-nmdzycxwhd.chromatic.com)
<!-- Storybook placeholder end -->
