### PR TITLE
fix: export GioIconsModule

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
@@ -23,3 +23,5 @@ export * from './gio-save-bar/gio-save-bar.harness';
 
 export * from './gio-banner/gio-banner.component';
 export * from './gio-banner/gio-banner.module';
+
+export * from './gio-icons/gio-icons.module';


### PR DESCRIPTION
**Description**

`GioIconsModule` was not exported in `public-api`, therefore we couldn't import it in our app 🙈

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-tkeogqmtbi.chromatic.com)
<!-- Storybook placeholder end -->
