### PR TITLE
Update Badges with the new design and create Method Badge

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-icons/gio-icons.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-icons/gio-icons.module.ts
@@ -21,6 +21,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 
 @NgModule({
   imports: [CommonModule, HttpClientModule, MatIconModule],
+  exports: [MatIconModule],
   entryComponents: [],
 })
 export class GioIconsModule {

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/README.stories.mdx
@@ -12,25 +12,30 @@ Documentation and examples for badges, a small count and labeling component insp
 
 ## Usage
 
-`gio-badge` is a simple SCSS class that can be used on any html element.
+Multiple `gio-badge-XXXXX` classes are available and can be used on any html element according to the type of badge you want to display.
 
 Here are some examples with simple `span` elements:
 
 ```html
-<span class="gio-badge">Default</span>
+<span class="gio-badge-primary">Primary</span>
 
-<span class="gio-badge gio-badge-accent">Accent</span>
+<span class="gio-badge-neutral">Neutral</span>
 
-<span class="gio-badge gio-badge-success">Success</span>
+<span class="gio-badge-accent">Accent</span>
 
-<span class="gio-badge gio-badge-warning">Warning</span>
+<span class="gio-badge-success">Success</span>
 
-<span class="gio-badge gio-badge-error">Error</span>
+<span class="gio-badge-warning">Warning</span>
 
-<span class="gio-badge gio-badge-error"><mat-icon>lock</mat-icon></span>
+<span class="gio-badge-error">Error</span>
 
-<span class="gio-badge gio-badge-error"><mat-icon class="gio-left">lock</mat-icon> Lock</span>
+<span class="gio-badge-error"><mat-icon svgIcon="gio:lock"></mat-icon></span>
 
-<span class="gio-badge gio-badge-error">Lock<mat-icon class="gio-right">lock</mat-icon></span>
+<span class="gio-badge-error"><mat-icon class="gio-left" svgIcon="gio:lock"></mat-icon> Lock</span>
+
+<span class="gio-badge-error">Lock<mat-icon class="gio-right" svgIcon="gio:lock"></mat-icon></span>
+
+<!-- ⚠ Material icons are also working BUT you should ALWAYS PREFER icons from the Gravitee lib (see Icons story)️  -->
+<span class="gio-badge-error">Lock<mat-icon class="gio-right">lock</mat-icon></span>
 ```
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
@@ -25,6 +25,7 @@
 @mixin theme() {
   .gio-badge {
     display: inline-flex;
+    align-items: center;
 
     margin-left: 4px;
     margin-right: 4px;
@@ -32,9 +33,8 @@
     padding: 4px 8px;
     font-size: mat.font-size(theme.$mat-typography, caption);
     font-weight: mat.font-weight(theme.$mat-typography, caption);
-    border-radius: 10px;
-    border: 1px solid transparent;
-    line-height: 1;
+    border-radius: 16px;
+    line-height: 16px;
     text-align: center;
     white-space: nowrap;
     vertical-align: middle;
@@ -48,42 +48,51 @@
       line-height: inherit;
       width: inherit;
       vertical-align: middle;
+      // Set max height and width when using SVG icons (i.e. not coming from a web font) otherwise they are just HUGE
+      max-height: 16px;
+      max-width: 16px;
 
       &.gio-right {
-        padding-left: 4px;
+        margin-left: 4px;
       }
 
       &.gio-left {
-        padding-right: 4px;
+        margin-right: 4px;
       }
     }
   }
 
+  .gio-badge-primary {
+    @extend .gio-badge;
+  }
+
   .gio-badge-accent {
     @extend .gio-badge;
-    background-color: mat.get-color-from-palette(palettes.$mat-accent-palette, default);
-    color: mat.get-color-from-palette(palettes.$mat-accent-palette, default-contrast);
-    border-color: mat.get-color-from-palette(palettes.$mat-accent-palette, darker);
+    background-color: mat.get-color-from-palette(palettes.$mat-accent-palette, lighter);
+    color: mat.get-color-from-palette(palettes.$mat-accent-palette, lighter-contrast);
+  }
+
+  .gio-badge-neutral {
+    @extend .gio-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-neutral-palette, lighter);
+    color: mat.get-color-from-palette(palettes.$mat-neutral-palette, lighter-contrast);
   }
 
   .gio-badge-success {
     @extend .gio-badge;
-    background-color: mat.get-color-from-palette(palettes.$mat-success-palette, default);
-    color: mat.get-color-from-palette(palettes.$mat-success-palette, default-contrast);
-    border-color: mat.get-color-from-palette(palettes.$mat-success-palette, darker);
+    background-color: mat.get-color-from-palette(palettes.$mat-success-palette, lighter);
+    color: mat.get-color-from-palette(palettes.$mat-success-palette, lighter-contrast);
   }
 
   .gio-badge-error {
     @extend .gio-badge;
-    background-color: mat.get-color-from-palette(palettes.$mat-error-palette, default);
-    color: mat.get-color-from-palette(palettes.$mat-error-palette, default-contrast);
-    border-color: mat.get-color-from-palette(palettes.$mat-error-palette, darker);
+    background-color: mat.get-color-from-palette(palettes.$mat-error-palette, lighter);
+    color: mat.get-color-from-palette(palettes.$mat-error-palette, lighter-contrast);
   }
 
   .gio-badge-warning {
     @extend .gio-badge;
-    background-color: mat.get-color-from-palette(palettes.$mat-warning-palette, default);
-    color: mat.get-color-from-palette(palettes.$mat-warning-palette, default-contrast);
-    border-color: mat.get-color-from-palette(palettes.$mat-warning-palette, darker);
+    background-color: mat.get-color-from-palette(palettes.$mat-warning-palette, lighter);
+    color: mat.get-color-from-palette(palettes.$mat-warning-palette, lighter-contrast);
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.stories.ts
@@ -17,13 +17,12 @@ import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 
 import { GioIconsModule } from '../../../lib/gio-icons/gio-icons.module';
-import { MatIconModule } from '@angular/material/icon';
 
 export default {
   title: 'Components / Badge',
   decorators: [
     moduleMetadata({
-      imports: [MatIconModule, GioIconsModule],
+      imports: [GioIconsModule],
     }),
   ],
 } as Meta;

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.stories.ts
@@ -16,36 +16,56 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 
+import { GioIconsModule } from '../../../lib/gio-icons/gio-icons.module';
 import { MatIconModule } from '@angular/material/icon';
 
 export default {
   title: 'Components / Badge',
   decorators: [
     moduleMetadata({
-      imports: [MatIconModule],
+      imports: [MatIconModule, GioIconsModule],
     }),
   ],
-  render: () => ({}),
 } as Meta;
+
+const classByNames = {
+  Primary: 'gio-badge-primary',
+  Neutral: 'gio-badge-neutral',
+  Accent: 'gio-badge-accent',
+  Success: 'gio-badge-success',
+  Warning: 'gio-badge-warning',
+  Error: 'gio-badge-error',
+};
+
+const simpleCases: string = Object.entries(classByNames).reduce((previousValue, [name, cssClass]) => {
+  return `${previousValue}
+      <div style='margin: 10px'>
+        <span class="${cssClass}">${name}</span>
+      </div>`;
+}, '');
 
 export const All: Story = {
   render: () => ({
     template: `
-      <span class="gio-badge">Default</span>
+      <h4>Text Only</h4>
+      ${simpleCases}
+     
+      <h4>With Icons</h4>
+      <div style='margin: 10px'>      
+        <span class="gio-badge-error"><mat-icon svgIcon="gio:lock"></mat-icon></span>
+      </div>
       
-      <span class="gio-badge gio-badge-accent">Accent</span>
+      <div style='margin: 10px'>      
+        <span class="gio-badge-error"><mat-icon class="gio-left" svgIcon="gio:lock"></mat-icon>Lock</span>
+      </div>
 
-      <span class="gio-badge gio-badge-success">Success</span>
-      
-      <span class="gio-badge gio-badge-warning">Warning</span>
-      
-      <span class="gio-badge gio-badge-error">Error</span>
-
-      <span class="gio-badge gio-badge-error"><mat-icon>lock</mat-icon></span>
-
-      <span class="gio-badge gio-badge-error"><mat-icon class="gio-left">lock</mat-icon> Lock</span>
-
-      <span class="gio-badge gio-badge-error">Lock<mat-icon class="gio-right">lock</mat-icon></span>
+      <div style='margin: 10px'>
+        <span class="gio-badge-error">Lock<mat-icon class="gio-right" svgIcon="gio:lock"></mat-icon></span>
+      </div>  
+            
+      <div style='margin: 10px'>
+        <span class="gio-badge-error">Lock<mat-icon class="gio-right">lock</mat-icon></span>
+      </div>  
     `,
   }),
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/README.stories.mdx
@@ -1,0 +1,31 @@
+import { Meta, Story } from '@storybook/addon-docs';
+
+<Meta title="Components / Method Badge / README" />
+
+# Badges
+
+Documentation and examples for method badges, a labeling component based on badge and dedicated to HTTP verbs.
+
+## Demo
+
+<Story id="components-method-badge--all"></Story>
+
+## Usage
+
+Multiple `gio-method-badge-XXXXX` classes are available and can be used on any html element according to the HTTP verb you want to display.
+
+Here are some examples with simple `span` elements:
+
+```html
+<span class="gio-method-badge-post">POST</span>
+
+<span class="gio-method-badge-get">GET</span>
+
+<span class="gio-method-badge-patch">PATCH</span>
+
+<span class="gio-method-badge-put">PUT</span>
+
+<span class="gio-method-badge-delete">DELETE</span>
+```
+
+ℹ️  &nbsp;The content of `gio-method-badge-XXXXX` class will always be transform to UPPERCASE so you don't need to take care of this on your side.

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.scss
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@use '../../gio-mat-palettes.scss' as palettes;
+@use '../../gio-mat-theme-variable' as theme;
+
+/**
+ * Gravitee.io version of bootstrap "badge" element dedicated to HTTP verbs
+ */
+@mixin theme() {
+  .gio-method-badge {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+
+    margin-left: 4px;
+    margin-right: 4px;
+    width: 72px;
+    height: 24px;
+    padding: 4px 8px;
+    font-size: mat.font-size(theme.$mat-typography, caption);
+    font-weight: mat.font-weight(theme.$mat-typography, caption);
+    border-radius: 6px;
+    line-height: 16px;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    text-transform: uppercase;
+  }
+
+  .gio-method-badge-post {
+    @extend .gio-method-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, post);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, post-contrast);
+  }
+
+  .gio-method-badge-get {
+    @extend .gio-method-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, get);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, get-contrast);
+  }
+
+  .gio-method-badge-patch {
+    @extend .gio-method-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, patch);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, patch-contrast);
+  }
+
+  .gio-method-badge-put {
+    @extend .gio-method-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, put);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, put-contrast);
+  }
+
+  .gio-method-badge-delete {
+    @extend .gio-method-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, delete);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, delete-contrast);
+  }
+
+  .gio-method-badge-option,
+  .gio-method-badge-trace,
+  .gio-method-badge-head {
+    @extend .gio-method-badge;
+    background-color: mat.get-color-from-palette(palettes.$mat-neutral-palette, default);
+    color: mat.get-color-from-palette(palettes.$mat-neutral-palette, default-contrast);
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/types-7-0';
+
+import { MatIconModule } from '@angular/material/icon';
+
+export default {
+  title: 'Components / Method Badge',
+  decorators: [
+    moduleMetadata({
+      imports: [MatIconModule],
+    }),
+  ],
+} as Meta;
+
+const classByNames = {
+  Post: 'gio-method-badge-post',
+  Get: 'gio-method-badge-get',
+  Patch: 'gio-method-badge-patch',
+  Put: 'gio-method-badge-put',
+  Delete: 'gio-method-badge-delete',
+  Option: 'gio-method-badge-option',
+  Trace: 'gio-method-badge-trace',
+  Head: 'gio-method-badge-head',
+};
+
+export const All: Story = {
+  render: () => ({
+    template: Object.entries(classByNames).reduce((previousValue, [name, cssClass]) => {
+      return `${previousValue}
+      <div style='margin: 10px'>
+        <span class='${cssClass}'>${name}</span>
+      </div>`;
+    }, ''),
+  }),
+};

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
@@ -16,13 +16,13 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 
-import { MatIconModule } from '@angular/material/icon';
+import { GioIconsModule } from '../../../lib/gio-icons/gio-icons.module';
 
 export default {
   title: 'Components / Method Badge',
   decorators: [
     moduleMetadata({
-      imports: [MatIconModule],
+      imports: [GioIconsModule],
     }),
   ],
 } as Meta;

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-components.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-components.scss
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 @use './component/gio-badge/gio-badge';
+@use './component/gio-method-badge/gio-method-badge';
 @use './component/gio-code/gio-code';
 @use './component/gio-table-light/gio-table-light';
 
 // All Gravitee.io SCSS components
 @mixin all-components() {
   @include gio-badge.theme();
+  @include gio-method-badge.theme();
   @include gio-code.theme();
   @include gio-table-light.theme();
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7104

**Description**

 - I updated the style of the Badges to match the one in Figma (see screenshots below)
 - I updated the story to display Badge in a column
 - I removed `gio-badge` from the examples to enforce users to use one specific version of the badge. To avoid breaking change `gio-badge` is still available.
 - I created `gio-method-badge-xxxx` classes

**Screenshot**

Figma ref: https://www.figma.com/file/XvLO9G5fPRIrfyhLjPg6a2/Gravitee_Lib_elemZ?node-id=1008%3A3721

_Before_
![image](https://user-images.githubusercontent.com/4112568/153851737-f79ff663-b21a-4e5c-9488-bcc8a0e67cd0.png)


_After_
![image](https://user-images.githubusercontent.com/4112568/153885589-fc1fd3a2-a323-416b-b100-efce68c94c4d.png)


_Method Badge_
![image](https://user-images.githubusercontent.com/4112568/153851985-bca2c354-e64a-401e-a5e7-3edf319c096e.png)



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-iipbcbnvhz.chromatic.com)
<!-- Storybook placeholder end -->
