### PR TITLE
feat(mat-tabs): override material to remove tabs label min-width

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-theme.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-theme.scss
@@ -30,4 +30,5 @@
   @include override.mat-table();
   @include override.mat-card();
   @include override.mat-list();
+  @include override.mat-tabs();
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-tabs.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-tabs.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward 'mat-form-field';
-@forward 'mat-table';
-@forward 'mat-card';
-@forward 'mat-list' show mat-list;
-@forward 'mat-h5';
-@forward 'mat-tabs';
+@mixin mat-tabs() {
+  .mat-tab-group {
+    .mat-tab-label {
+      min-width: unset;
+    }
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-tabs.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-tabs.stories.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/types-7-0';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { MatTabsModule } from '@angular/material/tabs';
+
+export default {
+  title: 'Material Override',
+  decorators: [
+    moduleMetadata({
+      imports: [BrowserAnimationsModule, MatTabsModule],
+    }),
+  ],
+} as Meta;
+
+export const MatTabs: Story = {
+  render: () => ({
+    template: `
+    <p>
+      Unset mat tab label min-width
+    </p>
+    
+
+    <mat-tab-group mat-align-tabs="start">
+      <mat-tab label="First">Content 1</mat-tab>
+      <mat-tab label="Second">Content 2</mat-tab>
+      <mat-tab label="Third">Content 3</mat-tab>
+    </mat-tab-group>
+    
+    <mat-tab-group mat-align-tabs="center">
+      <mat-tab label="First">Content 1</mat-tab>
+      <mat-tab label="Second">Content 2</mat-tab>
+      <mat-tab label="Third">Content 3</mat-tab>
+    </mat-tab-group>
+    
+    <mat-tab-group mat-align-tabs="end">
+      <mat-tab label="First">Content 1</mat-tab>
+      <mat-tab label="Second">Content 2</mat-tab>
+      <mat-tab label="Third">Content 3</mat-tab>
+    </mat-tab-group>  
+    `,
+  }),
+};


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6765

**Description**

Remove unnecessary min-width inside mat tabs to have smaller tabs when the text is not large 

**Additional context**

cockpit seems to have the same feedback. what do you think about doing it globally ?

https://github.com/gravitee-io/gravitee-cockpit/blob/82cefaa5d99ada4d5907ada13ba813e7add31511/gravitee-cockpit-ui/src/app/designer/designer-model-edit/design/components/inspectors/inspector.scss#L17

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

- [x] Validate this with Cockpit teams 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hqfkxofeqs.chromatic.com)
<!-- Storybook placeholder end -->
