### PR TITLE
Remove unused icons & add color customization

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/assets/gio-icons.svg
+++ b/ui-particles-angular/projects/ui-particles-angular/assets/gio-icons.svg
@@ -1,2184 +1,316 @@
 <svg width="0" height="0" class="hidden">
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="search">
-    <path d="M15.5 15.5L19 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 11C5 14.3137 7.68629 17 11 17C12.6597 17 14.1621 16.3261 15.2483 15.237C16.3308 14.1517 17 12.654 17 11C17 7.68629 14.3137 5 11 5C7.68629 5 5 7.68629 5 11Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="star-dashed">
-    <path d="M13.8062 5L12.8152 3.00376C12.4817 2.33208 11.5184 2.33208 11.185 3.00376L10.6895 4.00188" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.0107 7.427L15.4124 8.23599L16.8646 8.44704" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19.7695 8.86914L21.2217 9.08019C21.967 9.1885 22.2641 10.0994 21.7245 10.6219L20.6739 11.6394" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18.5721 13.6743L17.5215 14.6918L17.7694 16.1292" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18.2657 19.0039L18.5136 20.4413C18.641 21.1797 17.8615 21.7427 17.1946 21.394L15.896 20.715" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.4277 19.5L11.9998 18.678L13.2985 19.357" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5.67145 19.3689L5.48645 20.4414C5.35908 21.1797 6.13859 21.7428 6.80546 21.3941L7.65273 20.9511" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.25241 16L6.47808 14.6917L5.7832 14.0188" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.69875 12L2.27575 10.6219C1.73617 10.0993 2.03322 9.18844 2.77852 9.08012L3.88926 8.9187" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 8.4666L8.58737 8.23591L9.39062 6.61792" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="label-outline">
-    <path d="M3 17.4V6.6C3 6.26863 3.26863 6 3.6 6H16.6789C16.8795 6 17.0668 6.10026 17.1781 6.26718L20.7781 11.6672C20.9125 11.8687 20.9125 12.1313 20.7781 12.3328L17.1781 17.7328C17.0668 17.8997 16.8795 18 16.6789 18H3.6C3.26863 18 3 17.7314 3 17.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bookmark-circled">
-    <path d="M9 16V10C9 8.89543 9.89543 8 11 8H13C14.1046 8 15 8.89543 15 10V16L13.1094 14.7396C12.4376 14.2917 11.5624 14.2917 10.8906 14.7396L9 16Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="star-outline">
-    <path d="M8.58737 8.23597L11.1849 3.00376C11.5183 2.33208 12.4817 2.33208 12.8151 3.00376L15.4126 8.23597L21.2215 9.08017C21.9668 9.18848 22.2638 10.0994 21.7243 10.6219L17.5217 14.6918L18.5135 20.4414C18.6409 21.1798 17.8614 21.7428 17.1945 21.3941L12 18.678L6.80547 21.3941C6.1386 21.7428 5.35909 21.1798 5.48645 20.4414L6.47825 14.6918L2.27575 10.6219C1.73617 10.0994 2.03322 9.18848 2.77852 9.08017L8.58737 8.23597Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="star-half-dashed">
-    <path d="M12.8152 3.00376C12.4817 2.33208 11.5184 2.33208 11.185 3.00376L10.6895 4.00188" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11.9998 18.678L10.4277 19.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5.67145 19.3689L5.48645 20.4414C5.35908 21.1797 6.13859 21.7428 6.80546 21.3941L7.65273 20.9511" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.25241 16L6.47808 14.6917L5.7832 14.0188" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.69875 12L2.27575 10.6219C1.73617 10.0993 2.03322 9.18844 2.77852 9.08012L3.88926 8.9187" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 8.4666L8.58737 8.23591L9.39062 6.61792" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.4126 8.23597L12.8151 3.00376C12.6484 2.66792 12.3242 2.5 12 2.5V18.678L17.1945 21.3941C17.8614 21.7428 18.6409 21.1798 18.5135 20.4414L17.5217 14.6918L21.7243 10.6219C22.2638 10.0994 21.9668 9.18848 21.2215 9.08017L15.4126 8.23597Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="pin">
-    <path d="M11.5719 12.5L3.9292 20.0708M21.1925 8.46432C21.1925 5.34018 18.6599 2.80757 15.5358 2.80757C12.4116 2.80757 9.87903 5.34018 9.87903 8.46432C9.87903 11.5885 12.4116 14.1211 15.5358 14.1211C18.6599 14.1211 21.1925 11.5885 21.1925 8.46432Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12.9027 9.5C12.5038 8.48459 12.7148 7.28504 13.5354 6.46436C14.3942 5.60558 15.6678 5.4145 16.7112 5.8911" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="area-search">
-    <path d="M20.1241 20.1185C20.6654 19.5758 21 18.827 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18C15 19.6569 16.3431 21 18 21C18.8299 21 19.581 20.663 20.1241 20.1185ZM20.1241 20.1185L22 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 2H4V5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 2H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 22H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 2H20V5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 22H4V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="zoom-in">
-    <path d="M9 11H11M13 11H11M11 11V9M11 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.0005 16L20.0005 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11C4 14.866 7.13401 18 11 18C12.9363 18 14.6891 17.2138 15.9563 15.9432C17.2192 14.6769 18 12.9296 18 11C18 7.13401 14.866 4 11 4C7.13401 4 4 7.13401 4 11Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="three-stars">
-    <path d="M4.63495 14.4151L5.67396 12.2121C5.80734 11.9293 6.19266 11.9293 6.32604 12.2121L7.36505 14.4151L9.68859 14.7706C9.98671 14.8162 10.1055 15.1997 9.8897 15.4198L8.2087 17.1334L8.60542 19.5543C8.65637 19.8652 8.34456 20.1022 8.07781 19.9554L6 18.8118L3.92219 19.9554C3.65544 20.1022 3.34363 19.8652 3.39458 19.5543L3.7913 17.1334L2.1103 15.4198C1.89447 15.1997 2.01329 14.8162 2.31141 14.7706L4.63495 14.4151Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.6349 14.4151L17.674 12.2121C17.8073 11.9293 18.1927 11.9293 18.326 12.2121L19.3651 14.4151L21.6886 14.7706C21.9867 14.8162 22.1055 15.1997 21.8897 15.4198L20.2087 17.1334L20.6054 19.5543C20.6564 19.8652 20.3446 20.1022 20.0778 19.9554L18 18.8118L15.9222 19.9554C15.6554 20.1022 15.3436 19.8652 15.3946 19.5543L15.7913 17.1334L14.1103 15.4198C13.8945 15.1997 14.0133 14.8162 14.3114 14.7706L16.6349 14.4151Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.6349 5.41515L11.674 3.21211C11.8073 2.9293 12.1927 2.9293 12.326 3.21211L13.3651 5.41515L15.6886 5.7706C15.9867 5.8162 16.1055 6.19974 15.8897 6.41976L14.2087 8.13337L14.6054 10.5543C14.6564 10.8652 14.3446 11.1022 14.0778 10.9554L12 9.81178L9.92219 10.9554C9.65544 11.1022 9.34363 10.8652 9.39458 10.5543L9.7913 8.13337L8.1103 6.41976C7.89447 6.19974 8.01329 5.8162 8.31141 5.7706L10.6349 5.41515Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="zoom-out">
-    <path d="M9 11H11H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 16L20 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11C4 14.866 7.13401 18 11 18C12.9363 18 14.6891 17.2138 15.9563 15.9432C17.2192 14.6769 18 12.9296 18 11C18 7.13401 14.866 4 11 4C7.13401 4 4 7.13401 4 11Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bookmark-empty">
-    <path d="M5 21V5C5 3.89543 5.89543 3 7 3H17C18.1046 3 19 3.89543 19 5V21L13.0815 17.1953C12.4227 16.7717 11.5773 16.7717 10.9185 17.1953L5 21Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="filter">
-    <path d="M4.0001 3H20.0002C20.5525 3 21.0002 3.44764 21.0002 3.99987L21.0004 5.58569C21.0005 5.85097 20.8951 6.10538 20.7075 6.29295L14.293 12.7071C14.1055 12.8946 14.0001 13.149 14.0001 13.4142L14.0001 19.7192C14.0001 20.3698 13.3887 20.8472 12.7576 20.6894L10.7576 20.1894C10.3124 20.0781 10.0001 19.6781 10.0001 19.2192L10.0001 13.4142C10.0001 13.149 9.89474 12.8946 9.7072 12.7071L3.29299 6.29289C3.10545 6.10536 3.0001 5.851 3.0001 5.58579V4C3.0001 3.44772 3.44781 3 4.0001 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="filter-alt">
-    <path d="M3.0001 7V4C3.0001 3.44772 3.44781 3 4.0001 3H20.0002C20.5524 3 21.0001 3.44766 21.0002 3.9999L21.0005 7M3.0001 7L9.65089 12.7007C9.87254 12.8907 10.0001 13.168 10.0001 13.4599V19.7192C10.0001 20.3698 10.6115 20.8472 11.2426 20.6894L13.2426 20.1894C13.6878 20.0781 14.0001 19.6781 14.0001 19.2192V13.46C14.0001 13.168 14.1277 12.8907 14.3493 12.7007L21.0005 7M3.0001 7H21.0005" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="input-search">
-    <path d="M21 12V10C21 7.23858 18.7614 5 16 5H8C5.23858 5 3 7.23858 3 10V10C3 12.7614 5.23858 15 8 15H12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20.1241 19.1185C20.6654 18.5758 21 17.827 21 17C21 15.3431 19.6569 14 18 14C16.3431 14 15 15.3431 15 17C15 18.6569 16.3431 20 18 20C18.8299 20 19.581 19.663 20.1241 19.1185ZM20.1241 19.1185L22 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-monitor">
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.9998 22H19.4998H20.9998M19.4998 19.4286H21.8332V16H17.1665V19.4286H19.4998Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-restore">
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 22V16M19 16L22 19M19 16L16 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-settings">
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 21C20.1046 21 21 20.1046 21 19C21 17.8954 20.1046 17 19 17C18.6357 17 18.2942 17.0974 18 17.2676C17.4022 17.6134 17 18.2597 17 19C17 19.7403 17.4022 20.3866 18 20.7324C18.2942 20.9026 18.6357 21 19 21Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 22C20.6569 22 22 20.6569 22 19C22 17.3431 20.6569 16 19 16C17.3431 16 16 17.3431 16 19C16 20.6569 17.3431 22 19 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="0.3 2"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-script">
-    <path d="M22 14V6C22 4.34315 20.6569 3 19 3H9C7.34315 3 6 4.34315 6 6V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 21H6C3.79086 21 2 19.2091 2 17C2 14.7909 3.79086 13 6 13H17H18C15.7909 13 14 14.7909 14 17C14 19.2091 15.7909 21 18 21C20.2091 21 22 19.2091 22 17V14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-export">
-    <path d="M19 16V22M19 22L22 19M19 22L16 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="db-error">
-    <path d="M17.1213 21.364L19.2426 19.2427M21.364 17.1214L19.2426 19.2427M19.2426 19.2427L17.1213 17.1214M19.2426 19.2427L21.364 21.364" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="db-warning">
-    <path d="M20 16L20 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 22.01L20.01 21.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-database-script">
-    <path d="M22 14V8.5M6 13V6C6 4.34315 7.34315 3 9 3H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 4L22 4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 21H6C3.79086 21 2 19.2091 2 17C2 14.7909 3.79086 13 6 13H17H18C15.7909 13 14 14.7909 14 17C14 19.2091 15.7909 21 18 21C20.2091 21 22 19.2091 22 17V14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-backup">
-    <path d="M4 6V12C4 12 4 15 11 15C11.5925 15 12.1349 14.9785 12.6313 14.9392" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 6V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M22.6664 17.6667C22.0476 16.097 20.6345 15 18.9901 15C17.2318 15 15.7377 16.2545 15.1968 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20.9951 17.6667H22.6664V17.6667C22.8507 17.6667 23.0001 17.5173 23.0001 17.333V15.4445" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.3336 20.3333C15.9524 21.903 17.3655 23 19.0099 23C20.7682 23 22.2623 21.7455 22.8032 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.0049 20.3333H15.3336V20.3333C15.1493 20.3333 14.9999 20.4827 14.9999 20.667V22.5555" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="db-check">
-    <path d="M14 19L17 22L22 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-stats">
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 21V19" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M18 21V17" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M21 21V15" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-star">
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.3056 17.1133L18.2147 15.1856C18.3314 14.9381 18.6686 14.9381 18.7853 15.1856L19.6944 17.1133L21.7275 17.4243C21.9884 17.4642 22.0923 17.7998 21.9035 17.9923L20.4326 19.4917L20.7797 21.61C20.8243 21.882 20.5515 22.0895 20.3181 21.961L18.5 20.9603L16.6819 21.961C16.4485 22.0895 16.1757 21.882 16.2203 21.61L16.5674 19.4917L15.0965 17.9923C14.9077 17.7998 15.0116 17.4642 15.2725 17.4243L17.3056 17.1133Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="db">
-    <path d="M5 12V18C5 18 5 21 12 21C19 21 19 18 19 18V12" stroke="black" stroke-width="1.5"></path>
-    <path d="M5 6V12C5 12 5 15 12 15C19 15 19 12 19 12V6" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 3C19 3 19 6 19 6C19 6 19 9 12 9C5 9 5 6 5 6C5 6 5 3 12 3Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-database-script">
-    <path d="M22 14V8.5M6 13V6C6 4.34315 7.34315 3 9 3H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.9922 4H19.9922M22.9922 4L19.9922 4M19.9922 4V1M19.9922 4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 21H6C3.79086 21 2 19.2091 2 17C2 14.7909 3.79086 13 6 13H17H18C15.7909 13 14 14.7909 14 17C14 19.2091 15.7909 21 18 21C20.2091 21 22 19.2091 22 17V14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="database-rounded">
-    <path d="M2 15V9C2 5.68629 4.68629 3 8 3H16C19.3137 3 22 5.68629 22 9V15C22 18.3137 19.3137 21 16 21H8C4.68629 21 2 18.3137 2 15Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16.3571 12C17.0714 12 18.5 12 18.5 10C18.5 8 17.0714 8 16.3571 8L13.5 8V12M16.3571 12C15.2143 12 13.9762 12 13.5 12M16.3571 12C17.0714 12 18.5 12 18.5 14C18.5 16 17.0714 16 16.3571 16H13.5V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.35714 8H5.5V12L5.5 16H8.35714C9.07143 16 10.5 16 10.5 14V10C10.5 8 9.07143 8 8.35714 8Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="db-search">
-    <path d="M20.5 20.5L22 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 18.5C16 19.8807 17.1193 21 18.5 21C19.1916 21 19.8175 20.7192 20.2701 20.2654C20.7211 19.8132 21 19.1892 21 18.5C21 17.1193 19.8807 16 18.5 16C17.1193 16 16 17.1193 16 18.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 6V12C4 12 4 15 11 15C18 15 18 12 18 12V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 3C18 3 18 6 18 6C18 6 18 9 11 9C4 9 4 6 4 6C4 6 4 3 11 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21C4 21 4 18 4 18V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="network-right">
-    <rect width="7" height="5" rx="0.6" transform="matrix(0 -1 -1 0 22 21)" stroke="black" stroke-width="1.5"></rect>
-    <rect width="7" height="5" rx="0.6" transform="matrix(0 -1 -1 0 7 15.5)" stroke="black" stroke-width="1.5"></rect>
-    <rect width="7" height="5" rx="0.6" transform="matrix(0 -1 -1 0 22 10)" stroke="black" stroke-width="1.5"></rect>
-    <path d="M17 17.5H13.5C12.3954 17.5 11.5 16.6046 11.5 15.5V8.5C11.5 7.39543 12.3954 6.5 13.5 6.5H17" stroke="black" stroke-width="1.5"></path>
-    <path d="M11.5 12H7" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="antenna-signal">
-    <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="network-left">
-    <rect x="2" y="21" width="7" height="5" rx="0.6" transform="rotate(-90 2 21)" stroke="black" stroke-width="1.5"></rect>
-    <rect x="17" y="15.5" width="7" height="5" rx="0.6" transform="rotate(-90 17 15.5)" stroke="black" stroke-width="1.5"></rect>
-    <rect x="2" y="10" width="7" height="5" rx="0.6" transform="rotate(-90 2 10)" stroke="black" stroke-width="1.5"></rect>
-    <path d="M7 17.5H10.5C11.6046 17.5 12.5 16.6046 12.5 15.5V8.5C12.5 7.39543 11.6046 6.5 10.5 6.5H7" stroke="black" stroke-width="1.5"></path>
-    <path d="M12.5 12H17" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="data-transfer-down">
-    <path d="M17 20L17 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 15L17 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 4V20M7 20L4 17M7 20L10 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 10V4M17 4L14 7M17 4L20 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="server">
-    <path d="M6 18.01L6.01 17.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 6.01L6.01 5.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 9.4V2.6C2 2.26863 2.26863 2 2.6 2H21.4C21.7314 2 22 2.26863 22 2.6V9.4C22 9.73137 21.7314 10 21.4 10H2.6C2.26863 10 2 9.73137 2 9.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M2 21.4V14.6C2 14.2686 2.26863 14 2.6 14H21.4C21.7314 14 22 14.2686 22 14.6V21.4C22 21.7314 21.7314 22 21.4 22H2.6C2.26863 22 2 21.7314 2 21.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="data-transfer-check">
-    <path d="M14 19L17 22L22 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 14V4M17 4L20 7M17 4L14 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 4V20M7 20L10 17M7 20L4 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="server-connection">
-    <path d="M3 19H12M21 19H12M12 19V13M12 13H18V5H6V13H12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 9.01L9.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 9.01L12.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="network">
-    <rect x="3" y="2" width="7" height="5" rx="0.6" stroke="black" stroke-width="1.5"></rect>
-    <rect x="8.5" y="17" width="7" height="5" rx="0.6" stroke="black" stroke-width="1.5"></rect>
-    <rect x="14" y="2" width="7" height="5" rx="0.6" stroke="black" stroke-width="1.5"></rect>
-    <path d="M6.5 7V10.5C6.5 11.6046 7.39543 12.5 8.5 12.5H15.5C16.6046 12.5 17.5 11.6046 17.5 10.5V7" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 12.5V17" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="network-alt">
-    <rect width="7" height="5" rx="0.6" transform="matrix(1 0 0 -1 3 22)" stroke="black" stroke-width="1.5"></rect>
-    <rect width="7" height="5" rx="0.6" transform="matrix(1 0 0 -1 8.5 7)" stroke="black" stroke-width="1.5"></rect>
-    <rect width="7" height="5" rx="0.6" transform="matrix(1 0 0 -1 14 22)" stroke="black" stroke-width="1.5"></rect>
-    <path d="M6.5 17V13.5C6.5 12.3954 7.39543 11.5 8.5 11.5H15.5C16.6046 11.5 17.5 12.3954 17.5 13.5V17" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 11.5V7" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="data-transfer-up">
-    <path d="M7 4L7 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 9L7 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 20V4M17 4L20 7M17 4L14 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 14V20M7 20L10 17M7 20L4 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="data-transfer-warning">
-    <path d="M7 4L7 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 9L7 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 12V4M17 4L20 7M17 4L14 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 16L20 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 22.01L20.01 21.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 14V20M7 20L10 17M7 20L4 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="data-transfer-both">
-    <path d="M17 20V4M17 4L20 7M17 4L14 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 4V20M7 20L10 17M7 20L4 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-search">
-    <path d="M13.5 13L15 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 11C9 12.3807 10.1193 13.5 11.5 13.5C12.1916 13.5 12.8175 13.2192 13.2701 12.7654C13.7211 12.3132 14 11.6892 14 11C14 9.61929 12.8807 8.5 11.5 8.5C10.1193 8.5 9 9.61929 9 11Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="password-pass">
-    <path d="M21 13V8C21 6.89543 20.1046 6 19 6H5C3.89543 6 3 6.89543 3 8V14C3 15.1046 3.89543 16 5 16H12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14.5 18.5L16.5 20.5L20.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 11.01L12.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 11.01L16.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 11.01L8.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="password-cursor">
-    <path d="M21 13V8C21 6.89543 20.1046 6 19 6H5C3.89543 6 3 6.89543 3 8V14C3 15.1046 3.89543 16 5 16H12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M20.8791 16.9174C21.3729 17.2211 21.3426 17.9604 20.8339 18.0181L18.2674 18.309L17.1161 20.6213C16.888 21.0795 16.1829 20.8552 16.0664 20.2873L14.8111 14.1713C14.7126 13.6913 15.1439 13.3892 15.5613 13.646L20.8791 16.9174Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 11.01L12.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 11.01L16.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 11.01L8.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="tower-no-access">
-    <path d="M19.8566 15.2C19.1306 14.4595 18.119 14 17 14C14.7909 14 13 15.7909 13 18C13 19.0902 13.4361 20.0785 14.1434 20.8M19.8566 15.2C20.5639 15.9215 21 16.9098 21 18C21 20.2091 19.2091 22 17 22C15.881 22 14.8694 21.5405 14.1434 20.8M19.8566 15.2L14.1434 20.8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 22H7C5.89543 22 5 21.1046 5 20V11.1817C5 11.0632 4.96494 10.9474 4.89923 10.8488L3.10077 8.15115C3.03506 8.05259 3 7.93679 3 7.81833V2.6C3 2.26863 3.26863 2 3.6 2H5.4C5.73137 2 6 2.26863 6 2.6V4.4C6 4.73137 6.26863 5 6.6 5H9.4C9.73137 5 10 4.73137 10 4.4V2.6C10 2.26863 10.2686 2 10.6 2H13.4C13.7314 2 14 2.26863 14 2.6V4.4C14 4.73137 14.2686 5 14.6 5H17.4C17.7314 5 18 4.73137 18 4.4V2.6C18 2.26863 18.2686 2 18.6 2H20.4C20.7314 2 21 2.26863 21 2.6V7.81833C21 7.93679 20.9649 8.05259 20.8992 8.15115L20 9.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="open-vpn">
-    <path d="M10.8351 15.2894L11.5726 15.426L10.8351 15.2894ZM10.4771 14.582L10.8583 13.9361L10.4771 14.582ZM10.2016 21.8286L10.3402 21.0915L10.2016 21.8286ZM9.75001 21.1507L10.4875 21.2872L9.75001 21.1507ZM16.8489 19.8141L17.586 19.6755L16.8489 19.8141ZM17.7212 20.1916L17.2912 19.5771L17.7212 20.1916ZM7.87166 15.9841L7.13459 15.8455L7.87166 15.9841ZM7.73203 15.4643L7.15066 15.9381L7.73203 15.4643ZM13.5232 14.582L13.9045 15.2279L13.5232 14.582ZM13.1652 15.2894L13.9027 15.1529L13.1652 15.2894ZM16.268 15.4643L15.6866 14.9905L16.268 15.4643ZM16.1283 15.9841L16.8654 15.8455L16.1283 15.9841ZM14.2501 21.1513L13.5126 21.2878L14.2501 21.1513ZM13.7972 21.8297L13.9347 22.567L13.7972 21.8297ZM6.27883 20.1916L5.84889 20.8061L6.27883 20.1916ZM2.75 12C2.75 6.89078 6.89078 2.75 12 2.75V1.25C6.06235 1.25 1.25 6.06235 1.25 12H2.75ZM6.70878 19.5771C4.3153 17.9025 2.75 15.1368 2.75 12H1.25C1.25 15.6498 3.07379 18.8646 5.84889 20.8061L6.70878 19.5771ZM7.13459 15.8455L6.41403 19.6755L7.88817 19.9528L8.60873 16.1228L7.13459 15.8455ZM5.75 12C5.75 13.4936 6.27575 14.8646 7.15066 15.9381L8.3134 14.9905C7.64834 14.1745 7.25 13.1354 7.25 12H5.75ZM12 5.75C8.54868 5.75 5.75 8.54868 5.75 12H7.25C7.25 9.3771 9.3771 7.25 12 7.25V5.75ZM18.25 12C18.25 8.54868 15.4513 5.75 12 5.75V7.25C14.6229 7.25 16.75 9.3771 16.75 12H18.25ZM16.8493 15.9381C17.7243 14.8646 18.25 13.4936 18.25 12H16.75C16.75 13.1354 16.3517 14.1745 15.6866 14.9905L16.8493 15.9381ZM17.586 19.6755L16.8654 15.8455L15.3913 16.1228L16.1118 19.9528L17.586 19.6755ZM21.25 12C21.25 15.1368 19.6847 17.9025 17.2912 19.5771L18.1511 20.8061C20.9262 18.8646 22.75 15.6498 22.75 12H21.25ZM12 2.75C17.1092 2.75 21.25 6.89078 21.25 12H22.75C22.75 6.06235 17.9377 1.25 12 1.25V2.75ZM15.7502 12C15.7502 9.92949 14.0706 8.24996 12.0002 8.24996V9.74996C13.2422 9.74996 14.2502 10.7579 14.2502 12H15.7502ZM13.9045 15.2279C15.0061 14.5777 15.7502 13.3768 15.7502 12H14.2502C14.2502 12.8229 13.8068 13.5437 13.142 13.9361L13.9045 15.2279ZM14.9876 21.0148L13.9027 15.1529L12.4277 15.4259L13.5126 21.2878L14.9876 21.0148ZM12.0002 22.75C12.6654 22.75 13.3108 22.6834 13.9347 22.567L13.6597 21.0925C13.118 21.1935 12.5649 21.25 12.0002 21.25V22.75ZM10.063 22.5657C10.688 22.6832 11.3343 22.75 12.0002 22.75V21.25C11.435 21.25 10.8817 21.1934 10.3402 21.0915L10.063 22.5657ZM10.0977 15.1529L9.01255 21.0141L10.4875 21.2872L11.5726 15.426L10.0977 15.1529ZM8.25018 12C8.25018 13.3767 8.99426 14.5776 10.0958 15.2279L10.8583 13.9361C10.1935 13.5437 9.75018 12.8229 9.75018 12H8.25018ZM12.0002 8.24996C9.92971 8.24996 8.25018 9.92949 8.25018 12H9.75018C9.75018 10.7579 10.7581 9.74996 12.0002 9.74996V8.24996ZM11.5726 15.426C11.6951 14.7643 11.3142 14.2052 10.8583 13.9361L10.0958 15.2279C10.1005 15.2306 10.1042 15.2337 10.1066 15.2361C10.1089 15.2386 10.1082 15.2386 10.1061 15.2346C10.1039 15.2304 10.0997 15.2209 10.0971 15.2059C10.0944 15.1902 10.0942 15.1718 10.0977 15.1529L11.5726 15.426ZM10.3402 21.0915C10.4587 21.1138 10.5 21.2197 10.4875 21.2872L9.01255 21.0141C8.88408 21.708 9.3184 22.4256 10.063 22.5657L10.3402 21.0915ZM16.1118 19.9528C16.2796 20.8445 17.3238 21.385 18.1511 20.8061L17.2912 19.5771C17.3508 19.5354 17.4317 19.533 17.4888 19.5582C17.5413 19.5813 17.577 19.6277 17.586 19.6755L16.1118 19.9528ZM8.60873 16.1228C8.6883 15.6999 8.55779 15.2903 8.3134 14.9905L7.15066 15.9381C7.14395 15.9299 7.12459 15.8987 7.13459 15.8455L8.60873 16.1228ZM13.142 13.9361C12.6861 14.2052 12.3053 14.7642 12.4277 15.4259L13.9027 15.1529C13.9062 15.1718 13.9059 15.1903 13.9032 15.2059C13.9006 15.2209 13.8964 15.2304 13.8942 15.2346C13.8921 15.2386 13.8914 15.2386 13.8938 15.2362C13.8961 15.2337 13.8998 15.2307 13.9045 15.2279L13.142 13.9361ZM15.6866 14.9905C15.4422 15.2903 15.3117 15.6999 15.3913 16.1228L16.8654 15.8455C16.8754 15.8987 16.8561 15.9299 16.8493 15.9381L15.6866 14.9905ZM13.5126 21.2878C13.5001 21.22 13.5417 21.1145 13.6597 21.0925L13.9347 22.567C14.68 22.428 15.1163 21.7101 14.9876 21.0148L13.5126 21.2878ZM5.84889 20.8061C6.67624 21.385 7.72041 20.8445 7.88817 19.9528L6.41403 19.6755C6.42302 19.6277 6.45865 19.5813 6.51117 19.5582C6.56834 19.533 6.64921 19.5354 6.70878 19.5771L5.84889 20.8061Z" fill="black"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="key-alt-back">
-    <path d="M14 12C14 14.2091 15.7909 16 18 16C20.2091 16 22 14.2091 22 12C22 9.79086 20.2091 8 18 8C15.7909 8 14 9.79086 14 12ZM14 12H2V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="lock">
-    <path d="M16 12H17.4C17.7314 12 18 12.2686 18 12.6V19.4C18 19.7314 17.7314 20 17.4 20H6.6C6.26863 20 6 19.7314 6 19.4V12.6C6 12.2686 6.26863 12 6.6 12H8M16 12V8C16 6.66667 15.2 4 12 4C8.8 4 8 6.66667 8 8V12M16 12H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="key-alt-minus">
-    <path d="M14.9922 18H17.9922H20.9922" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12.4123 10.3431C13.9744 11.9052 16.5071 11.9052 18.0692 10.3431C19.6313 8.78105 19.6313 6.24839 18.0692 4.68629C16.5071 3.1242 13.9744 3.1242 12.4123 4.68629C10.8502 6.24839 10.8502 8.78105 12.4123 10.3431ZM12.4123 10.3431L3.92706 18.8284L6.04838 20.9497" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.75537 16L8.87669 18.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="historic-shield-alt">
-    <path d="M11.7317 21.8658L6.21115 19.1056C4.85601 18.428 4 17.043 4 15.5279V2.6C4 2.26863 4.26863 2 4.6 2H19.4C19.7314 2 20 2.26863 20 2.6V15.5279C20 17.043 19.144 18.428 17.7889 19.1056L12.2683 21.8658C12.0994 21.9503 11.9006 21.9503 11.7317 21.8658Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 10V2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 10H20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield">
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-cross">
-    <path d="M9.87132 14.1213L11.9926 12M14.114 9.87868L11.9926 12M11.9926 12L9.87132 9.87868M11.9926 12L14.114 14.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="key-alt-remove">
-    <path d="M15.8708 20.1213L17.9922 18M20.1135 15.8787L17.9922 18M17.9922 18L15.8708 15.8787M17.9922 18L20.1135 20.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12.4123 10.3431C13.9744 11.9052 16.5071 11.9052 18.0692 10.3431C19.6313 8.78105 19.6313 6.24839 18.0692 4.68629C16.5071 3.1242 13.9744 3.1242 12.4123 4.68629C10.8502 6.24839 10.8502 8.78105 12.4123 10.3431ZM12.4123 10.3431L3.92706 18.8284L6.04838 20.9497" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.75537 16L8.87669 18.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-alt">
-    <path d="M3.57143 8C3.39038 6.73263 3.23403 5.63823 3.13088 4.91614C3.05698 4.39885 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.943 4.39885 20.8691 4.91614C20.766 5.63823 20.6096 6.73263 20.4286 8M3.57143 8H20.4286M3.57143 8C3.87997 10.1598 4.26028 12.822 4.57143 15M20.4286 8C20.12 10.1598 19.7397 12.822 19.4286 15M19.4286 15C19.2567 16.2032 19.1059 17.2586 19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18C4.89409 17.2586 4.74331 16.2032 4.57143 15M19.4286 15H4.57143" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-minus">
-    <path d="M9 12H12H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="security-pass">
-    <path d="M9 11L12 14L20 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12C4 7.58172 7.58172 4 12 4C12.9473 4 13.8561 4.16464 14.6994 4.46686" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-eye">
-    <path d="M8 9C8 9 9 8 12 8C15 8 16 9 16 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 14C12.5523 14 13 13.5523 13 13C13 12.4477 12.5523 12 12 12C11.4477 12 11 12.4477 11 13C11 13.5523 11.4477 14 12 14Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="password-error">
-    <path d="M15.1211 20.364L17.2424 18.2427M17.2424 18.2427L19.3637 16.1213M17.2424 18.2427L15.1211 16.1213M17.2424 18.2427L19.3637 20.364" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 13V8C21 6.89543 20.1046 6 19 6H5C3.89543 6 3 6.89543 3 8V14C3 15.1046 3.89543 16 5 16H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 11.01L12.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 11.01L16.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 11.01L8.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="no-lock">
-    <path d="M11.5 12H6.6C6.26863 12 6 12.2686 6 12.6V19.4C6 19.7314 6.26863 20 6.6 20H17.4C17.7314 20 18 19.7314 18 19.4V18.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 12V8C16 6.66667 15.2 4 12 4C11.2532 4 10.6371 4.14525 10.1313 4.38491" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 12H17.4C17.7314 12 18 12.2686 18 12.6V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 8V8.5V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 3L21 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-alert">
-    <path d="M12 7L12 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16.01L12.01 15.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="key-alt">
-    <path d="M10 12C10 14.2091 8.20914 16 6 16C3.79086 16 2 14.2091 2 12C2 9.79086 3.79086 8 6 8C8.20914 8 10 9.79086 10 12ZM10 12H22V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="key-alt-plus">
-    <path d="M14.9922 18H17.9922M20.9922 18H17.9922M17.9922 18V15M17.9922 18V21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12.4123 10.3431C13.9744 11.9052 16.5071 11.9052 18.0692 10.3431C19.6313 8.78105 19.6313 6.24839 18.0692 4.68629C16.5071 3.1242 13.9744 3.1242 12.4123 4.68629C10.8502 6.24839 10.8502 8.78105 12.4123 10.3431ZM12.4123 10.3431L3.92706 18.8284L6.04838 20.9497" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.75537 16L8.87669 18.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="historic-shield">
-    <path d="M4 15.5279V2.6C4 2.26863 4.26863 2 4.6 2H19.4C19.7314 2 20 2.26863 20 2.6V15.5279C20 17.043 19.144 18.428 17.7889 19.1056L12.2683 21.8658C12.0994 21.9503 11.9006 21.9503 11.7317 21.8658L6.21115 19.1056C4.85601 18.428 4 17.043 4 15.5279Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-download">
-    <path d="M12 8V15M12 15L15 12M12 15L9 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-add">
-    <path d="M9 12H12M15 12H12M12 12V9M12 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-broken">
-    <path d="M11.5 7L9 12H12H15L12.5 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-question">
-    <path d="M9 9C9 5.49997 14.5 5.5 14.5 9C14.5 11.5 12 10.9999 12 13.9999" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18.01L12.01 17.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="tower-check">
-    <path d="M13 19L16 22L21 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 22H7C5.89543 22 5 21.1046 5 20V11.1817C5 11.0632 4.96494 10.9474 4.89923 10.8488L3.10077 8.15115C3.03506 8.05259 3 7.93679 3 7.81833V2.6C3 2.26863 3.26863 2 3.6 2H5.4C5.73137 2 6 2.26863 6 2.6V4.4C6 4.73137 6.26863 5 6.6 5H9.4C9.73137 5 10 4.73137 10 4.4V2.6C10 2.26863 10.2686 2 10.6 2H13.4C13.7314 2 14 2.26863 14 2.6V4.4C14 4.73137 14.2686 5 14.6 5H17.4C17.7314 5 18 4.73137 18 4.4V2.6C18 2.26863 18.2686 2 18.6 2H20.4C20.7314 2 21 2.26863 21 2.6V7.81833C21 7.93679 20.9649 8.05259 20.8992 8.15115L19.1008 10.8488C19.0351 10.9474 19 11.0632 19 11.1817V13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-upload">
-    <path d="M12 15V8M12 8L15 11M12 8L9 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-check">
-    <path d="M8.5 11.5L11.5 14.5L16.5 9.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shield-loading">
-    <path d="M8 10.01L8.01 9.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 10.01L12.01 9.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 10.01L16.01 9.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 18L3.13036 4.91253C3.05646 4.39524 3.39389 3.91247 3.90398 3.79912L11.5661 2.09641C11.8519 2.03291 12.1481 2.03291 12.4339 2.09641L20.096 3.79912C20.6061 3.91247 20.9435 4.39524 20.8696 4.91252L19 18C18.9293 18.495 18.5 21.5 12 21.5C5.5 21.5 5.07071 18.495 5 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="tower">
-    <path d="M17 22H7C5.89543 22 5 21.1046 5 20V11.1817C5 11.0632 4.96494 10.9474 4.89923 10.8488L3.10077 8.15115C3.03506 8.05259 3 7.93679 3 7.81833V2.6C3 2.26863 3.26863 2 3.6 2H5.4C5.73137 2 6 2.26863 6 2.6V4.4C6 4.73137 6.26863 5 6.6 5H9.4C9.73137 5 10 4.73137 10 4.4V2.6C10 2.26863 10.2686 2 10.6 2H13.4C13.7314 2 14 2.26863 14 2.6V4.4C14 4.73137 14.2686 5 14.6 5H17.4C17.7314 5 18 4.73137 18 4.4V2.6C18 2.26863 18.2686 2 18.6 2H20.4C20.7314 2 21 2.26863 21 2.6V7.81833C21 7.93679 20.9649 8.05259 20.8992 8.15115L19.1008 10.8488C19.0351 10.9474 19 11.0632 19 11.1817V20C19 21.1046 18.1046 22 17 22Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="tower-warning">
-    <path d="M12 10L12 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17.01L12.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 22H7C5.89543 22 5 21.1046 5 20V11.1817C5 11.0632 4.96494 10.9474 4.89923 10.8488L3.10077 8.15115C3.03506 8.05259 3 7.93679 3 7.81833V2.6C3 2.26863 3.26863 2 3.6 2H5.4C5.73137 2 6 2.26863 6 2.6V4.4C6 4.73137 6.26863 5 6.6 5H9.4C9.73137 5 10 4.73137 10 4.4V2.6C10 2.26863 10.2686 2 10.6 2H13.4C13.7314 2 14 2.26863 14 2.6V4.4C14 4.73137 14.2686 5 14.6 5H17.4C17.7314 5 18 4.73137 18 4.4V2.6C18 2.26863 18.2686 2 18.6 2H20.4C20.7314 2 21 2.26863 21 2.6V7.81833C21 7.93679 20.9649 8.05259 20.8992 8.15115L19.1008 10.8488C19.0351 10.9474 19 11.0632 19 11.1817V20C19 21.1046 18.1046 22 17 22Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="puzzle">
-    <path d="M4 14V18.4C4 18.7314 4.26863 19 4.6 19H10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 14V18.4C19 18.7314 18.7314 19 18.4 19H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 5H18.4C18.7314 5 19 5.26863 19 5.6V10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 10V5.6C4 5.26863 4.26863 5 4.6 5H10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 19V20C14 21.1046 13.1046 22 12 22C10.8954 22 10 21.1046 10 20V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 10H5C6.10457 10 7 10.8954 7 12C7 13.1046 6.10457 14 5 14H4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 10H20C21.1046 10 22 10.8954 22 12C22 13.1046 21.1046 14 20 14H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 5V4C14 2.89543 13.1046 2 12 2C10.8954 2 10 2.89543 10 4V5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="code">
-    <path d="M13.5 6L10 18.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.5 8.5L3 12L6.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.5 8.5L21 12L17.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="code-brackets">
-    <path d="M9.00001 21H8.00001C6.89544 21 6.00001 20.1057 6.00001 19.0011C6.00001 17.4501 6.00001 15.3443 6 14C6 13 4.5 12 4.5 12C4.5 12 6.00001 11 6.00001 10C6.00001 8.827 6.00001 6.62207 6.00001 4.99914C6.00001 3.89457 6.89544 3 8.00001 3H9.00001" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 21H16C17.1046 21 18 20.1057 18 19.0011C18 17.4501 18 15.3443 18 14C18 13 19.5 12 19.5 12C19.5 12 18 11 18 10C18 8.827 18 6.62207 18 4.99914C18 3.89457 17.1046 3 16 3H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="code-brackets-square">
-    <path d="M10 17H9.33334C8.22877 17 7.33334 16.1047 7.33334 15.0002C7.33334 14.3284 7.33334 13.6211 7.33333 13.1111C7.33333 12.5556 6 12 6 12C6 12 7.33333 11.4444 7.33334 10.8889C7.33334 10.4359 7.33334 9.70586 7.33334 8.99998C7.33334 7.89541 8.22877 7 9.33334 7H10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 17H14.6667C15.7712 17 16.6667 16.1047 16.6667 15.0002C16.6667 14.3284 16.6667 13.6211 16.6667 13.1111C16.6667 12.5556 18 12 18 12C18 12 16.6667 11.4444 16.6667 10.8889C16.6667 10.4359 16.6667 9.70586 16.6667 8.99998C16.6667 7.89541 15.7712 7 14.6667 7H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="table-2-columns">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 16.5H21" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 12H21" stroke="black" stroke-width="1.5"></path>
-    <path d="M21 7.5H3" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 21V3" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="grid-remove">
-    <path d="M14.8708 19.1213L16.9922 17M19.1135 14.8787L16.9922 17M16.9922 17L14.8708 14.8787M16.9922 17L19.1135 19.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 9.4V4.6C4 4.26863 4.26863 4 4.6 4H9.4C9.73137 4 10 4.26863 10 4.6V9.4C10 9.73137 9.73137 10 9.4 10H4.6C4.26863 10 4 9.73137 4 9.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M4 19.4V14.6C4 14.2686 4.26863 14 4.6 14H9.4C9.73137 14 10 14.2686 10 14.6V19.4C10 19.7314 9.73137 20 9.4 20H4.6C4.26863 20 4 19.7314 4 19.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 9.4V4.6C14 4.26863 14.2686 4 14.6 4H19.4C19.7314 4 20 4.26863 20 4.6V9.4C20 9.73137 19.7314 10 19.4 10H14.6C14.2686 10 14 9.73137 14 9.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="4x4-cell">
-    <path d="M21 3.6V12H12V3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M21 20.4V12H12V21H20.4C20.7314 21 21 20.7314 21 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 12V3.6C3 3.26863 3.26863 3 3.6 3H12V12H3Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 12V20.4C3 20.7314 3.26863 21 3.6 21H12V12H3Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="table">
-    <path d="M21 3V21H3V3H21Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 16.5H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 12H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 7.5H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 3V21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 3V21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.5 3V21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="grid-add">
-    <path d="M13.9922 17H16.9922M19.9922 17H16.9922M16.9922 17V14M16.9922 17V20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 9.4V4.6C4 4.26863 4.26863 4 4.6 4H9.4C9.73137 4 10 4.26863 10 4.6V9.4C10 9.73137 9.73137 10 9.4 10H4.6C4.26863 10 4 9.73137 4 9.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M4 19.4V14.6C4 14.2686 4.26863 14 4.6 14H9.4C9.73137 14 10 14.2686 10 14.6V19.4C10 19.7314 9.73137 20 9.4 20H4.6C4.26863 20 4 19.7314 4 19.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 9.4V4.6C14 4.26863 14.2686 4 14.6 4H19.4C19.7314 4 20 4.26863 20 4.6V9.4C20 9.73137 19.7314 10 19.4 10H14.6C14.2686 10 14 9.73137 14 9.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="grid-minus">
-    <path d="M13.9922 17H16.9922H19.9922" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 9.4V4.6C4 4.26863 4.26863 4 4.6 4H9.4C9.73137 4 10 4.26863 10 4.6V9.4C10 9.73137 9.73137 10 9.4 10H4.6C4.26863 10 4 9.73137 4 9.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M4 19.4V14.6C4 14.2686 4.26863 14 4.6 14H9.4C9.73137 14 10 14.2686 10 14.6V19.4C10 19.7314 9.73137 20 9.4 20H4.6C4.26863 20 4 19.7314 4 19.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 9.4V4.6C14 4.26863 14.2686 4 14.6 4H19.4C19.7314 4 20 4.26863 20 4.6V9.4C20 9.73137 19.7314 10 19.4 10H14.6C14.2686 10 14 9.73137 14 9.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="view-columns-3">
-    <path d="M9 3H3.6C3.26863 3 3 3.26863 3 3.6V20.4C3 20.7314 3.26863 21 3.6 21H9M9 3V21M9 3H15M9 21H15M15 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H15M15 3V21" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="table-rows">
-    <path d="M3 12H7.5H12H16.5H21M3 12V16.5M3 12V7.5M21 12V16.5M21 12V7.5M3 16.5V20.4C3 20.7314 3.26863 21 3.6 21H7.5H12H16.5H20.4C20.7314 21 21 20.7314 21 20.4V16.5M3 16.5H7.5H12H16.5H21M21 7.5V3.6C21 3.26863 20.7314 3 20.4 3H16.5H12H7.5H3.6C3.26863 3 3 3.26863 3 3.6V7.5M21 7.5H16.5H12H7.5H3" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="battery-indicator">
-    <path d="M14 13H16L18 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 13H8M10 13H8M8 13V11M8 13V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 7H2.6C2.26863 7 2 7.26863 2 7.6V18.4C2 18.7314 2.26863 19 2.6 19H21.4C21.7314 19 22 18.7314 22 18.4V7.6C22 7.26863 21.7314 7 21.4 7H18M6 7V5H8V7M6 7H8M8 7H16M16 7V5H18V7M16 7H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="notes">
-    <path d="M8 14L16 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 10L10 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 18L12 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 3H6C4.89543 3 4 3.89543 4 5V20C4 21.1046 4.89543 22 6 22H18C19.1046 22 20 21.1046 20 20V5C20 3.89543 19.1046 3 18 3H14.5M10 3V1M10 3V5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="triangle-flag-circle">
-    <path d="M9 21.5V15.5M9 15.5V6.99654C9 6.5444 9.48113 6.25472 9.88073 6.46627L16.5505 9.99731C16.9654 10.217 16.9787 10.8067 16.5739 11.0447L9 15.5ZM22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="timer-off">
-    <path d="M9 2L15 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 7L19 21.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 10L12 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.1905 8.5C4.83275 9.93366 4 11.8696 4 14C4 18.4183 7.58172 22 12 22C14.0049 22 15.8375 21.2625 17.2413 20.044M19.4185 17C19.7935 16.0736 20 15.0609 20 14C20 9.58172 16.4183 6 12 6C11.0187 6 10.0786 6.17669 9.20988 6.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="pause-outline">
-    <path d="M6 18.4V5.6C6 5.26863 6.26863 5 6.6 5H9.4C9.73137 5 10 5.26863 10 5.6V18.4C10 18.7314 9.73137 19 9.4 19H6.6C6.26863 19 6 18.7314 6 18.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 18.4V5.6C14 5.26863 14.2686 5 14.6 5H17.4C17.7314 5 18 5.26863 18 5.6V18.4C18 18.7314 17.7314 19 17.4 19H14.6C14.2686 19 14 18.7314 14 18.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="triangle-flag-full">
-    <path d="M8 21L8 16M8 16L17.7231 9.51793C18.0866 9.2756 18.0775 8.73848 17.7061 8.50854L8.91581 3.06693C8.5161 2.81949 8 3.10699 8 3.57709V16Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 11.0001L14.5 6.52393" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="high-priority">
-    <path d="M11.5757 1.42426C11.81 1.18995 12.1899 1.18995 12.4243 1.42426L22.5757 11.5757C22.81 11.81 22.8101 12.1899 22.5757 12.4243L12.4243 22.5757C12.19 22.81 11.8101 22.8101 11.5757 22.5757L1.42426 12.4243C1.18995 12.19 1.18995 11.8101 1.42426 11.5757L11.5757 1.42426Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 8L12 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16.01L12.01 15.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="maximize">
-    <path d="M7 4H4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 4H20V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 20H4V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 20H20V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="lifebelt">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 12C8 14.2091 9.79086 16 12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8C9.79086 8 8 9.79086 8 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9.2351 14.8906L5 19.0001" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14.7646 14.8906L18.9998 19.0001" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14.7646 9.10943L18.9998 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9.2351 9.10943L5 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="triangle-flag">
-    <path d="M8 21L8 16M8 16V3.57709C8 3.10699 8.5161 2.81949 8.91581 3.06693L17.7061 8.50854C18.0775 8.73848 18.0866 9.2756 17.7231 9.51793L8 16Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="priority-down">
-    <path d="M11.5757 1.42426C11.81 1.18995 12.1899 1.18995 12.4243 1.42426L22.5757 11.5757C22.81 11.81 22.8101 12.1899 22.5757 12.4243L12.4243 22.5757C12.19 22.81 11.8101 22.8101 11.5757 22.5757L1.42426 12.4243C1.18995 12.19 1.18995 11.8101 1.42426 11.5757L11.5757 1.42426Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16L16 12M12 16L8 11.8333M12 16L12 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="link">
-    <path d="M14 11.9976C14 9.5059 11.683 7 8.85714 7C8.52241 7 7.41904 7.00001 7.14286 7.00001C4.30254 7.00001 2 9.23752 2 11.9976C2 14.376 3.70973 16.3664 6 16.8714C6.36756 16.9525 6.75006 16.9952 7.14286 16.9952" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 11.9975C10 14.4892 12.317 16.9951 15.1429 16.9951C15.4776 16.9951 16.581 16.9951 16.8571 16.9951C19.6975 16.9951 22 14.7576 22 11.9975C22 9.61908 20.2903 7.62872 18 7.12371C17.6324 7.04266 17.2499 6.99987 16.8571 6.99987" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="selection">
-    <path d="M7 4H4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 4H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 20H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 4H20V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 20H4V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 20H20V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="page-flip">
-    <path d="M12 11H14.5H17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7H14.5H17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 15V3.6C8 3.26863 8.26863 3 8.6 3H20.4C20.7314 3 21 3.26863 21 3.6V17C21 19.2091 19.2091 21 17 21V21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 15H8H12.4C12.7314 15 13.0031 15.2668 13.0298 15.5971C13.1526 17.1147 13.7812 21 17 21H8H6C4.34315 21 3 19.6569 3 18V17C3 15.8954 3.89543 15 5 15Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="compress">
-    <path d="M18 12L6 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22V16M12 16L15 19M12 16L9 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 2V8M12 8L15 5M12 8L9 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="expand">
-    <path d="M9 9L4 4M4 4V8M4 4H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 9L20 4M20 4V8M20 4H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 15L4 20M4 20V16M4 20H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 15L20 20M20 20V16M20 20H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="priority-up">
-    <path d="M11.5757 1.42426C11.81 1.18995 12.1899 1.18995 12.4243 1.42426L22.5757 11.5757C22.81 11.81 22.8101 12.1899 22.5757 12.4243L12.4243 22.5757C12.19 22.81 11.8101 22.8101 11.5757 22.5757L1.42426 12.4243C1.18995 12.19 1.18995 11.8101 1.42426 11.5757L11.5757 1.42426Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7L16 11M12 7L8 11.1667M12 7L12 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="magic-wand">
-    <path d="M17.5412 9.08175L14.9181 6.45871C14.6558 6.19638 14.2625 6.19638 14.0001 6.45871L2.19674 18.2621C1.93442 18.5244 1.93442 18.9178 2.19674 19.1802L4.81977 21.8032C4.95082 21.9342 5.1148 21.9999 5.27878 21.9999C5.44276 21.9999 5.60674 21.9342 5.73778 21.8032L17.5411 9.99979C17.8035 9.73746 17.8035 9.34387 17.5411 9.08175H17.5412ZM5.27879 20.4261L3.5738 18.7211L12.164 10.1309L13.869 11.8359L5.27879 20.4261ZM14.787 10.9178L13.0821 9.21284L14.4591 7.83577L16.1641 9.54077L14.787 10.9178Z" fill="black"></path>
-    <path d="M18.525 12.3606C18.2626 12.0982 17.8693 12.0982 17.6069 12.3606C17.3446 12.6229 17.3446 13.0163 17.6069 13.2786L18.9183 14.59C19.0493 14.7211 19.2133 14.7867 19.3773 14.7867C19.5413 14.7867 19.7053 14.7211 19.8363 14.59C20.0986 14.3277 20.0986 13.9343 19.8363 13.672L18.525 12.3606Z" fill="black"></path>
-    <path d="M21.2135 8.55713H19.5742C19.2135 8.55713 18.9185 8.85215 18.9185 9.2128C18.9185 9.57345 19.2135 9.86847 19.5742 9.86847H21.2135C21.5742 9.86847 21.8692 9.57345 21.8692 9.2128C21.8692 8.85215 21.5742 8.55713 21.2135 8.55713Z" fill="black"></path>
-    <path d="M18.066 6.58994C18.2299 6.58994 18.3939 6.5243 18.525 6.39325L19.8037 5.11455C20.066 4.85222 20.066 4.45886 19.8037 4.1965C19.5414 3.93417 19.148 3.93417 18.8856 4.1965L17.6069 5.47521C17.3446 5.73754 17.3446 6.1309 17.6069 6.39325C17.7382 6.5243 17.9022 6.58994 18.0659 6.58994H18.066Z" fill="black"></path>
-    <path d="M14.6557 4.95073C15.0164 4.95073 15.3114 4.6557 15.3114 4.29505V2.65569C15.3114 2.29501 15.0163 2 14.6557 2C14.295 2 14 2.29503 14 2.65569V4.29505C14 4.65572 14.295 4.95073 14.6557 4.95073Z" fill="black"></path>
-    <path d="M10.7211 6.39367C10.8521 6.52472 11.0161 6.59036 11.1801 6.59036C11.3441 6.59036 11.5081 6.52472 11.6391 6.39367C11.9014 6.13135 11.9014 5.73799 11.6391 5.47564L10.3604 4.16427C10.0981 3.90195 9.70471 3.90195 9.44235 4.16427C9.18002 4.4266 9.18002 4.81996 9.44235 5.08231L10.7211 6.39367Z" fill="black"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="import">
-    <path d="M4 13V19C4 20.1046 4.89543 21 6 21H18C19.1046 21 20 20.1046 20 19V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 3L12 15M12 15L8.5 11.5M12 15L15.5 11.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="collapse">
-    <path d="M20 20L15 15M15 15V19M15 15H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 20L9 15M9 15V19M9 15H5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 4L15 9M15 9V5M15 9H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 4L9 9M9 9V5M9 9H5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="de-compress">
-    <path d="M18 12L6 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16V22M12 22L15 19M12 22L9 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 8V2M12 2L15 5M12 2L9 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="forward-outline">
-    <path d="M2.95592 5.70436C2.55976 5.41246 2 5.69531 2 6.1874V17.8126C2 18.3047 2.55976 18.5875 2.95592 18.2956L10.8445 12.483C11.1699 12.2432 11.1699 11.7568 10.8445 11.517L2.95592 5.70436Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13.9559 5.70436C13.5598 5.41246 13 5.69531 13 6.1874V17.8126C13 18.3047 13.5598 18.5875 13.9559 18.2956L21.8445 12.483C22.1699 12.2432 22.1699 11.7568 21.8445 11.517L13.9559 5.70436Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="white-flag">
-    <path d="M5 15L5.95039 4.54568C5.97849 4.23663 6.23761 4 6.54793 4H20.343C20.6958 4 20.9725 4.30295 20.9405 4.65432L20.0496 14.4543C20.0215 14.7634 19.7624 15 19.4521 15H5ZM5 15L4.4 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-selection">
-    <path d="M8 12H12M16 12H12M12 12V8M12 12V16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 4H4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 4H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 20H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 4H20V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 20H4V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 20H20V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="play-outline">
-    <path d="M6.90588 4.53682C6.50592 4.2998 6 4.58808 6 5.05299V18.947C6 19.4119 6.50592 19.7002 6.90588 19.4632L18.629 12.5162C19.0211 12.2838 19.0211 11.7162 18.629 11.4838L6.90588 4.53682Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-selection">
-    <path d="M7 4H4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 12H12H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 4H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 20H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 4H20V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 20H4V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 20H20V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="skip-next-outline">
-    <path d="M18 7V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.97179 5.2672C6.57832 4.95657 6 5.23682 6 5.73813V18.2619C6 18.7632 6.57832 19.0434 6.97179 18.7328L14.9035 12.4709C15.2078 12.2307 15.2078 11.7693 14.9035 11.5291L6.97179 5.2672Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="enlarge">
-    <path d="M15 9L20 4M20 4V8M20 4H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 15L4 20M4 20V16M4 20H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="divide-selection-2">
-    <path d="M2 12H22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 4H4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 4H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 4H20V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 20H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 20H4V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 20H20V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="divide-selection-1">
-    <path d="M20 20H4V16H20V20Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 12H22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 4H4V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 4H13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 4H20V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="language">
-    <path d="M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04932C13 2.04932 16 5.99994 16 11.9999C16 17.9999 13 21.9506 13 21.9506" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 21.9506C11 21.9506 8 17.9999 8 11.9999C8 5.99994 11 2.04932 11 2.04932" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2.62988 15.5H21.3707" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2.62988 8.5H21.3707" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="gift">
-    <path d="M20 12V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21.4 7H2.6C2.26863 7 2 7.26863 2 7.6V11.4C2 11.7314 2.26863 12 2.6 12H21.4C21.7314 12 22 11.7314 22 11.4V7.6C22 7.26863 21.7314 7 21.4 7Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7H7.5C6.83696 7 6.20107 6.73661 5.73223 6.26777C5.26339 5.79893 5 5.16304 5 4.5C5 3.83696 5.26339 3.20107 5.73223 2.73223C6.20107 2.26339 6.83696 2 7.5 2C11 2 12 7 12 7Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7H16.5C17.163 7 17.7989 6.73661 18.2678 6.26777C18.7366 5.79893 19 5.16304 19 4.5C19 3.83696 18.7366 3.20107 18.2678 2.73223C17.7989 2.26339 17.163 2 16.5 2C13 2 12 7 12 7Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="activity">
-    <path d="M3 12H6L9 3L15 21L18 12H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="skip-prev-outline">
-    <path d="M6 7V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.0282 5.2672C17.4217 4.95657 18 5.23682 18 5.73813V18.2619C18 18.7632 17.4217 19.0434 17.0282 18.7328L9.09651 12.4709C8.79223 12.2307 8.79223 11.7693 9.09651 11.5291L17.0282 5.2672Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="clock-outline">
-    <path d="M12 6L12 12L18 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="alarm">
-    <path d="M17 13H12V8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 3.5L7 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 3.5L17 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C16.9706 22 21 17.9706 21 13C21 8.02944 16.9706 4 12 4C7.02944 4 3 8.02944 3 13C3 17.9706 7.02944 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="timer">
-    <path d="M9 2L15 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 10L12 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C16.4183 22 20 18.4183 20 14C20 9.58172 16.4183 6 12 6C7.58172 6 4 9.58172 4 14C4 18.4183 7.58172 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="rewind-outline">
-    <path d="M21.0441 5.70436C21.4402 5.41246 22 5.69531 22 6.1874V17.8126C22 18.3047 21.4402 18.5875 21.0441 18.2956L13.1555 12.483C12.8301 12.2432 12.8301 11.7568 13.1555 11.517L21.0441 5.70436Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.0441 5.70436C10.4402 5.41246 11 5.69531 11 6.1874V17.8126C11 18.3047 10.4402 18.5875 10.0441 18.2956L2.15555 12.483C1.8301 12.2432 1.8301 11.7568 2.15555 11.517L10.0441 5.70436Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="file-not-found">
-    <path d="M12 8L12 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16.01L12.01 15.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 3H4V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 11V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 3H20V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 21H4V18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 21H20V18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-right-box">
-    <path d="M8 8.5L11.5 12L8 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.5L17.5 12L14 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="nav-arrow-left">
-    <path d="M15 6L9 12L15 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-down">
-    <path d="M12.25 5.5V18M12.25 18L6.25 12M12.25 18L18.25 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-down-left">
-    <path d="M10.25 19.25L6.75 15.75L10.25 12.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.75 15.75H12.75C14.9591 15.75 16.75 13.9591 16.75 11.75V4.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-top-circle">
-    <path d="M8.5 16.5L12 13L15.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 10.5L12 7L15.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-down">
-    <path d="M15.5 7L12 10.5L8.5 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 13L12 16.5L8.5 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-right-circled">
-    <path d="M8 12H16M16 12L12.5 8.5M16 12L12.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-down-right">
-    <path d="M13.25 19.25L16.75 15.75L13.25 12.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.75 15.75H10.75C8.54086 15.75 6.75 13.9591 6.75 11.75V4.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-right-down">
-    <path d="M19 13.5L15.5 17L12 13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 17V11C15.5 8.79086 13.7091 7 11.5 7H4.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-left-circle">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 8.5L13 12L16.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 8.5L7 12L10.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="nav-arrow-up">
-    <path d="M6 15L12 9L18 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="reduce-round-arrow">
-    <path d="M7 9.5L9.5 12L7 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 9.5L14 12L16.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15V9C2 6.79086 3.79086 5 6 5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-up-right">
-    <path d="M13.25 4.75L16.75 8.25L13.25 11.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.75 8.25L10.75 8.25C8.54086 8.25 6.75 10.0409 6.75 12.25L6.75 19.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-right-up">
-    <path d="M19 10.5L15.5 7L12 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 7V13C15.5 15.2091 13.7091 17 11.5 17H4.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="enlarge-round-arrow">
-    <path d="M8.5 9.5L6 12L8.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9.5L18 12L15.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 15V9C2 6.79086 3.79086 5 6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-right">
-    <path d="M6 12H18.5M18.5 12L12.5 6M18.5 12L12.5 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-left-down">
-    <path d="M4.5 13.5L8 17L11.5 13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 17V11C8 8.79086 9.79086 7 12 7H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="left-round-arrow">
-    <path d="M16.75 12H6.75M6.75 12L9.5 14.75M6.75 12L9.5 9.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 15V9C2 6.79086 3.79086 5 6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-union">
-    <path d="M17.5 8L14 11.5L17.5 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 8L9.5 11.5L6 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-right">
-    <path d="M7 8L10.5 11.5L7 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 8L16.5 11.5L13 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-down-circled">
-    <path d="M12 8V16M12 16L15.5 12.5M12 16L8.5 12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-separate">
-    <path d="M9.5 8L6 11.5L9.5 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8L17.5 11.5L14 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="more-vert">
-    <path d="M12 12.5C12.2761 12.5 12.5 12.2761 12.5 12C12.5 11.7239 12.2761 11.5 12 11.5C11.7239 11.5 11.5 11.7239 11.5 12C11.5 12.2761 11.7239 12.5 12 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18.5C12.2761 18.5 12.5 18.2761 12.5 18C12.5 17.7239 12.2761 17.5 12 17.5C11.7239 17.5 11.5 17.7239 11.5 18C11.5 18.2761 11.7239 18.5 12 18.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 6.5C12.2761 6.5 12.5 6.27614 12.5 6C12.5 5.72386 12.2761 5.5 12 5.5C11.7239 5.5 11.5 5.72386 11.5 6C11.5 6.27614 11.7239 6.5 12 6.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="nav-arrow-right">
-    <path d="M9 6L15 12L9 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="more-horiz-circled-outline">
-    <path d="M7 12.5C7.27614 12.5 7.5 12.2761 7.5 12C7.5 11.7239 7.27614 11.5 7 11.5C6.72386 11.5 6.5 11.7239 6.5 12C6.5 12.2761 6.72386 12.5 7 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12.5C12.2761 12.5 12.5 12.2761 12.5 12C12.5 11.7239 12.2761 11.5 12 11.5C11.7239 11.5 11.5 11.7239 11.5 12C11.5 12.2761 11.7239 12.5 12 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 12.5C17.2761 12.5 17.5 12.2761 17.5 12C17.5 11.7239 17.2761 11.5 17 11.5C16.7239 11.5 16.5 11.7239 16.5 12C16.5 12.2761 16.7239 12.5 17 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-left-circled">
-    <path d="M16 12H8M8 12L11.5 15.5M8 12L11.5 8.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="up-round-arrow">
-    <path d="M14.5 13.25L12 10.75L9.5 13.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15V9C2 6.79086 3.79086 5 6 5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="more-horiz">
-    <path d="M18 12.5C18.2761 12.5 18.5 12.2761 18.5 12C18.5 11.7239 18.2761 11.5 18 11.5C17.7239 11.5 17.5 11.7239 17.5 12C17.5 12.2761 17.7239 12.5 18 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12.5C12.2761 12.5 12.5 12.2761 12.5 12C12.5 11.7239 12.2761 11.5 12 11.5C11.7239 11.5 11.5 11.7239 11.5 12C11.5 12.2761 11.7239 12.5 12 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 12.5C6.27614 12.5 6.5 12.2761 6.5 12C6.5 11.7239 6.27614 11.5 6 11.5C5.72386 11.5 5.5 11.7239 5.5 12C5.5 12.2761 5.72386 12.5 6 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-bottom-circle">
-    <path d="M8.5 7.5L12 11L15.5 7.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 13.5L12 17L15.5 13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-right-circle">
-    <path d="M8 8.5L11.5 12L8 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.5L17.5 12L14 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-left-box">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16.5 8.5L13 12L16.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 8.5L7 12L10.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-down-box">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M15.5 7.5L12 11L8.5 7.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 13.5L12 17L8.5 13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-top">
-    <path d="M15.5 16.5L12 13L8.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 10.5L12 7L8.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-left-up">
-    <path d="M4.5 10.5L8 7L11.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 7V13C8 15.2091 9.79086 17 12 17H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-up">
-    <path d="M12.25 18.5V6M12.25 6L18.25 12M12.25 6L6.25 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-up-circled">
-    <path d="M12 16V8M12 8L15.5 11.5M12 8L8.5 11.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="long-arrow-up-left">
-    <path d="M10.25 4.75L6.75 8.25L10.25 11.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.75 8.25L12.75 8.25C14.9591 8.25 16.75 10.0409 16.75 12.25V19.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-union-vertical">
-    <path d="M15.5 6L12 9.5L8.5 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 17.5L12 14L8.5 17.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-up-box">
-    <path d="M15.5 16.5L12 13L8.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 10.5L12 7L8.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="fast-arrow-left">
-    <path d="M16.5 8L13 11.5L16.5 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 8L7 11.5L10.5 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-left">
-    <path d="M18.5 12H6M6 12L12 6M6 12L12 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="nav-arrow-down">
-    <path d="M6 9L12 15L18 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="right-round-arrow">
-    <path d="M6.75 12H16.75M16.75 12L14 14.75M16.75 12L14 9.25" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 15V9C2 6.79086 3.79086 5 6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="down-round-arrow">
-    <path d="M6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15V9C2 6.79086 3.79086 5 6 5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14.5 10.75L12 13.25L9.5 10.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="arrow-separate-vertical">
-    <path d="M15.5 9.5L12 6L8.5 9.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 14L12 17.5L8.5 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="more-vert-circled-outline">
-    <path d="M12 7.5C12.2761 7.5 12.5 7.27614 12.5 7C12.5 6.72386 12.2761 6.5 12 6.5C11.7239 6.5 11.5 6.72386 11.5 7C11.5 7.27614 11.7239 7.5 12 7.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17.5C12.2761 17.5 12.5 17.2761 12.5 17C12.5 16.7239 12.2761 16.5 12 16.5C11.7239 16.5 11.5 16.7239 11.5 17C11.5 17.2761 11.7239 17.5 12 17.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12.5C12.2761 12.5 12.5 12.2761 12.5 12C12.5 11.7239 12.2761 11.5 12 11.5C11.7239 11.5 11.5 11.7239 11.5 12C11.5 12.2761 11.7239 12.5 12 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="triangle">
-    <g clip-path="url(#clip0_807_1295)">
-      <path d="M11.4752 2.94682C11.7037 2.53464 12.2963 2.53464 12.5248 2.94682L21.8985 19.8591C22.1202 20.259 21.831 20.75 21.3738 20.75H2.62625C2.16902 20.75 1.87981 20.259 2.10146 19.8591L11.4752 2.94682Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="empty-page">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 21.4V2.6a.6.6 0 01.6-.6h11.652a.6.6 0 01.424.176l3.148 3.148A.6.6 0 0120 5.75V21.4a.6.6 0 01-.6.6H4.6a.6.6 0 01-.6-.6z"></path>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 5.4V2.354a.354.354 0 01.604-.25l3.292 3.292a.353.353 0 01-.25.604H16.6a.6.6 0 01-.6-.6z"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_1295">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="heptagon">
-    <path d="M11.7397 1.62537C11.9042 1.54614 12.0958 1.54614 12.2603 1.62537L20.3398 5.51624C20.5043 5.59547 20.6238 5.7453 20.6644 5.92331L22.6599 14.666C22.7005 14.844 22.6579 15.0309 22.5441 15.1736L16.9529 22.1848C16.839 22.3275 16.6664 22.4107 16.4838 22.4107H7.51622C7.33363 22.4107 7.16097 22.3275 7.04712 22.1848L1.45595 15.1736C1.3421 15.0309 1.29946 14.844 1.34009 14.666L3.33556 5.92331C3.37619 5.7453 3.49567 5.59547 3.66018 5.51624L11.7397 1.62537Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="circle">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="hexagon">
-    <path d="M11.7 1.1732C11.8856 1.06603 12.1144 1.06603 12.3 1.17321L21.2263 6.3268C21.4119 6.43397 21.5263 6.63205 21.5263 6.84641V17.1536C21.5263 17.3679 21.4119 17.566 21.2263 17.6732L12.3 22.8268C12.1144 22.934 11.8856 22.934 11.7 22.8268L2.77372 17.6732C2.58808 17.566 2.47372 17.3679 2.47372 17.1536V6.84641C2.47372 6.63205 2.58808 6.43397 2.77372 6.32679L11.7 1.1732Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="square">
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="flare">
-    <path d="M11.4563 2.66509C11.6717 2.2034 12.3283 2.2034 12.5437 2.66509L15.4077 8.80229C15.4673 8.93 15.57 9.03266 15.6977 9.09227L21.8349 11.9563C22.2966 12.1717 22.2966 12.8283 21.8349 13.0437L15.6977 15.9077C15.57 15.9673 15.4673 16.07 15.4077 16.1977L12.5437 22.3349C12.3283 22.7966 11.6717 22.7966 11.4563 22.3349L8.59227 16.1977C8.53266 16.07 8.43 15.9673 8.30229 15.9077L2.16509 13.0437C1.7034 12.8283 1.7034 12.1717 2.16509 11.9563L8.30229 9.09227C8.43 9.03266 8.53266 8.93 8.59227 8.80229L11.4563 2.66509Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="minus-hexagon">
-    <path d="M9 12H12H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11.7 1.1732C11.8856 1.06603 12.1144 1.06603 12.3 1.17321L21.2263 6.3268C21.4119 6.43397 21.5263 6.63205 21.5263 6.84641V17.1536C21.5263 17.3679 21.4119 17.566 21.2263 17.6732L12.3 22.8268C12.1144 22.934 11.8856 22.934 11.7 22.8268L2.77372 17.6732C2.58808 17.566 2.47372 17.3679 2.47372 17.1536V6.84641C2.47372 6.63205 2.58808 6.43397 2.77372 6.32679L11.7 1.1732Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="octagon">
-    <path d="M11.7704 1.09511C11.9174 1.03421 12.0826 1.03421 12.2296 1.09511L19.5486 4.12672C19.6956 4.18761 19.8124 4.30442 19.8733 4.45144L22.9049 11.7704C22.9658 11.9174 22.9658 12.0826 22.9049 12.2296L19.8733 19.5486C19.8124 19.6956 19.6956 19.8124 19.5486 19.8733L12.2296 22.9049C12.0826 22.9658 11.9174 22.9658 11.7704 22.9049L4.45144 19.8733C4.30442 19.8124 4.18761 19.6956 4.12672 19.5486L1.09511 12.2296C1.03421 12.0826 1.03421 11.9174 1.09511 11.7704L4.12672 4.45144C4.18761 4.30442 4.30442 4.18761 4.45144 4.12672L11.7704 1.09511Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="hexagon-alt">
-    <g clip-path="url(#clip0_807_1299)">
-      <path d="M6.32671 2.77363C6.43389 2.58799 6.63196 2.47363 6.84632 2.47363L17.1535 2.47363C17.3679 2.47363 17.5659 2.58799 17.6731 2.77363L22.8267 11.6999C22.9339 11.8856 22.9339 12.1143 22.8267 12.2999L17.6731 21.2262C17.5659 21.4118 17.3679 21.5262 17.1535 21.5262L6.84632 21.5262C6.63196 21.5262 6.43389 21.4118 6.32671 21.2262L1.17312 12.2999C1.06594 12.1143 1.06594 11.8856 1.17312 11.6999L6.32671 2.77363Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="network-right">
+    <g>
+      <rect width="7" height="5" stroke="currentColor" stroke-width="1.5" rx=".6" transform="matrix(0 -1 -1 0 22 21)"></rect>
+      <rect width="7" height="5" stroke="currentColor" stroke-width="1.5" rx=".6" transform="matrix(0 -1 -1 0 7 15.5)"></rect>
+      <rect width="7" height="5" stroke="currentColor" stroke-width="1.5" rx=".6" transform="matrix(0 -1 -1 0 22 10)"></rect>
+      <path stroke="currentColor" stroke-width="1.5" d="M17 17.5h-3.5a2 2 0 01-2-2v-7a2 2 0 012-2H17"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M11.5 12H7"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_1299">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="pentagon">
-    <path d="M11.6473 2.25623C11.8576 2.10344 12.1424 2.10344 12.3527 2.25623L22.1089 9.34458C22.3192 9.49737 22.4072 9.76819 22.3269 10.0154L18.6003 21.4846C18.52 21.7318 18.2896 21.8992 18.0297 21.8992H5.97029C5.71035 21.8992 5.47998 21.7318 5.39965 21.4846L1.67309 10.0154C1.59276 9.76819 1.68076 9.49737 1.89105 9.34458L11.6473 2.25623Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="rhombus">
-    <path d="M11.5757 1.42426C11.81 1.18995 12.1899 1.18995 12.4243 1.42426L22.5757 11.5757C22.81 11.81 22.8101 12.1899 22.5757 12.4243L12.4243 22.5757C12.19 22.81 11.8101 22.8101 11.5757 22.5757L1.42426 12.4243C1.18995 12.19 1.18995 11.8101 1.42426 11.5757L11.5757 1.42426Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-hexagon">
-    <path d="M9 12H12M15 12H12M12 12V9M12 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11.7 1.1732C11.8856 1.06603 12.1144 1.06603 12.3 1.17321L21.2263 6.3268C21.4119 6.43397 21.5263 6.63205 21.5263 6.84641V17.1536C21.5263 17.3679 21.4119 17.566 21.2263 17.6732L12.3 22.8268C12.1144 22.934 11.8856 22.934 11.7 22.8268L2.77372 17.6732C2.58808 17.566 2.47372 17.3679 2.47372 17.1536V6.84641C2.47372 6.63205 2.58808 6.43397 2.77372 6.32679L11.7 1.1732Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="empty-page">
-    <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-page">
-    <path d="M9 12L15 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multiple-pages-remove">
-    <path d="M7 2L16.5 2L21 6.5V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 22H16.5C17.3284 22 18 21.3284 18 20.5V8.74853C18 8.5894 17.9368 8.43679 17.8243 8.32426L14.6757 5.17574C14.5632 5.06321 14.4106 5 14.2515 5H4.5C3.67157 5 3 5.67157 3 6.5V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.4V5.35355C14 5.15829 14.1583 5 14.3536 5C14.4473 5 14.5372 5.03725 14.6036 5.10355L17.8964 8.39645C17.9628 8.46275 18 8.55268 18 8.64645C18 8.84171 17.8417 9 17.6464 9H14.6C14.2686 9 14 8.73137 14 8.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M1.99219 19H4.99219H7.99219" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="doc-star">
-    <path d="M16.3056 17.1133L17.2147 15.1856C17.3314 14.9381 17.6686 14.9381 17.7853 15.1856L18.6944 17.1133L20.7275 17.4243C20.9884 17.4642 21.0923 17.7998 20.9035 17.9923L19.4326 19.4917L19.7797 21.61C19.8243 21.882 19.5515 22.0895 19.3181 21.961L17.5 20.9603L15.6819 21.961C15.4485 22.0895 15.1757 21.882 15.2203 21.61L15.5674 19.4917L14.0965 17.9923C13.9077 17.7998 14.0116 17.4642 14.2725 17.4243L16.3056 17.1133Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 12V5.74853C20 5.5894 19.9368 5.43679 19.8243 5.32426L16.6757 2.17574C16.5632 2.06321 16.4106 2 16.2515 2H4.6C4.26863 2 4 2.26863 4 2.6V21.4C4 21.7314 4.26863 22 4.6 22H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="page-star">
-    <path d="M20 12V5.74853C20 5.5894 19.9368 5.43679 19.8243 5.32426L16.6757 2.17574C16.5632 2.06321 16.4106 2 16.2515 2H4.6C4.26863 2 4 2.26863 4 2.6V21.4C4 21.7314 4.26863 22 4.6 22H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 10H16M8 6H12M8 14H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.3056 17.1133L17.2147 15.1856C17.3314 14.9381 17.6686 14.9381 17.7853 15.1856L18.6944 17.1133L20.7275 17.4243C20.9884 17.4642 21.0923 17.7998 20.9035 17.9923L19.4326 19.4917L19.7797 21.61C19.8243 21.882 19.5515 22.0895 19.3181 21.961L17.5 20.9603L15.6819 21.961C15.4485 22.0895 15.1757 21.882 15.2203 21.61L15.5674 19.4917L14.0965 17.9923C13.9077 17.7998 14.0116 17.4642 14.2725 17.4243L16.3056 17.1133Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-folder">
-    <path d="M18 6H20H22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21.4 20H2.6C2.26863 20 2 19.7314 2 19.4V11H21.4C21.7314 11 22 11.2686 22 11.6V19.4C22 19.7314 21.7314 20 21.4 20Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 11V4.6C2 4.26863 2.26863 4 2.6 4H8.77805C8.92127 4 9.05977 4.05124 9.16852 4.14445L12.3315 6.85555C12.4402 6.94876 12.5787 7 12.722 7H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multiple-pages-delete">
-    <path d="M2.87083 21.1213L4.99215 19M7.11347 16.8787L4.99215 19M4.99215 19L2.87083 16.8787M4.99215 19L7.11347 21.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 2L16.5 2L21 6.5V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 22H16.5C17.3284 22 18 21.3284 18 20.5V8.74853C18 8.5894 17.9368 8.43679 17.8243 8.32426L14.6757 5.17574C14.5632 5.06321 14.4106 5 14.2515 5H4.5C3.67157 5 3 5.67157 3 6.5V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.4V5.35355C14 5.15829 14.1583 5 14.3536 5C14.4473 5 14.5372 5.03725 14.6036 5.10355L17.8964 8.39645C17.9628 8.46275 18 8.55268 18 8.64645C18 8.84171 17.8417 9 17.6464 9H14.6C14.2686 9 14 8.73137 14 8.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multiple-pages-empty">
-    <path d="M7 2L16.5 2L21 6.5V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.5V6.5C3 5.67157 3.67157 5 4.5 5H14.2515C14.4106 5 14.5632 5.06321 14.6757 5.17574L17.8243 8.32426C17.9368 8.43679 18 8.5894 18 8.74853V20.5C18 21.3284 17.3284 22 16.5 22H4.5C3.67157 22 3 21.3284 3 20.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.4V5.35355C14 5.15829 14.1583 5 14.3536 5C14.4473 5 14.5372 5.03725 14.6036 5.10355L17.8964 8.39645C17.9628 8.46275 18 8.55268 18 8.64645C18 8.84171 17.8417 9 17.6464 9H14.6C14.2686 9 14 8.73137 14 8.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="doc-star-alt">
-    <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.6349 10.4151L11.674 8.21211C11.8073 7.9293 12.1927 7.9293 12.326 8.21211L13.3651 10.4151L15.6886 10.7706C15.9867 10.8162 16.1055 11.1997 15.8897 11.4198L14.2087 13.1334L14.6054 15.5543C14.6564 15.8652 14.3446 16.1022 14.0778 15.9554L12 14.8118L9.92219 15.9554C9.65544 16.1022 9.34363 15.8652 9.39458 15.5543L9.7913 13.1334L8.1103 11.4198C7.89447 11.1997 8.01329 10.8162 8.31141 10.7706L10.6349 10.4151Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multiple-pages-add">
-    <path d="M1.99219 19H4.99219M7.99219 19H4.99219M4.99219 19V16M4.99219 19V22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 2L16.5 2L21 6.5V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 22H16.5C17.3284 22 18 21.3284 18 20.5V8.74853C18 8.5894 17.9368 8.43679 17.8243 8.32426L14.6757 5.17574C14.5632 5.06321 14.4106 5 14.2515 5H4.5C3.67157 5 3 5.67157 3 6.5V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.4V5.35355C14 5.15829 14.1583 5 14.3536 5C14.4473 5 14.5372 5.03725 14.6036 5.10355L17.8964 8.39645C17.9628 8.46275 18 8.55268 18 8.64645C18 8.84171 17.8417 9 17.6464 9H14.6C14.2686 9 14 8.73137 14 8.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-folder">
-    <path d="M18 6H20M22 6H20M20 6V4M20 6V8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21.4 20H2.6C2.26863 20 2 19.7314 2 19.4V11H21.4C21.7314 11 22 11.2686 22 11.6V19.4C22 19.7314 21.7314 20 21.4 20Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 11V4.6C2 4.26863 2.26863 4 2.6 4H8.77805C8.92127 4 9.05977 4.05124 9.16852 4.14445L12.3315 6.85555C12.4402 6.94876 12.5787 7 12.722 7H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="folder-alert">
-    <path d="M18 3L18 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 11.01L18.01 10.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M22 7V11V19.4C22 19.7314 21.7314 20 21.4 20H2.6C2.26863 20 2 19.7314 2 19.4V11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 7H12.722C12.5787 7 12.4402 6.94876 12.3315 6.85555L9.16852 4.14445C9.05977 4.05124 8.92127 4 8.77805 4H2.6C2.26863 4 2 4.26863 2 4.6V11H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="doc-search-alt">
-    <path d="M14 15L15.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 12.5C8.5 14.1569 9.84315 15.5 11.5 15.5C12.3299 15.5 13.081 15.163 13.6241 14.6185C14.1654 14.0758 14.5 13.327 14.5 12.5C14.5 10.8431 13.1569 9.5 11.5 9.5C9.84315 9.5 8.5 10.8431 8.5 12.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="archive">
-    <path d="M7 6L17 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 9L17 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 17H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 12H2.6C2.26863 12 2 12.2686 2 12.6V21.4C2 21.7314 2.26863 22 2.6 22H21.4C21.7314 22 22 21.7314 22 21.4V12.6C22 12.2686 21.7314 12 21.4 12H21M3 12V2.6C3 2.26863 3.26863 2 3.6 2H20.4C20.7314 2 21 2.26863 21 2.6V12M3 12H21" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-page">
-    <path d="M9 12H12M15 12H12M12 12V9M12 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="page-search">
-    <path d="M20 12V5.74853C20 5.5894 19.9368 5.43679 19.8243 5.32426L16.6757 2.17574C16.5632 2.06321 16.4106 2 16.2515 2H4.6C4.26863 2 4 2.26863 4 2.6V21.4C4 21.7314 4.26863 22 4.6 22H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 10H16M8 6H12M8 14H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20.5 20.5L22 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 18C15 19.6569 16.3431 21 18 21C18.8299 21 19.581 20.663 20.1241 20.1185C20.6654 19.5758 21 18.827 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="doc-search">
-    <path d="M20.5 20.5L22 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 18C15 19.6569 16.3431 21 18 21C18.8299 21 19.581 20.663 20.1241 20.1185C20.6654 19.5758 21 18.827 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 12V5.74853C20 5.5894 19.9368 5.43679 19.8243 5.32426L16.6757 2.17574C16.5632 2.06321 16.4106 2 16.2515 2H4.6C4.26863 2 4 2.26863 4 2.6V21.4C4 21.7314 4.26863 22 4.6 22H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="google-docs">
-    <path d="M19 3L5 3C3.89543 3 3 3.89543 3 5L3 19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 7L17 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 12L17 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 17L13 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="journal-page">
-    <path d="M6 6L14 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 10H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 14L18 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 21.4V2.6C2 2.26863 2.26863 2 2.6 2H18.2515C18.4106 2 18.5632 2.06321 18.6757 2.17574L21.8243 5.32426C21.9368 5.43679 22 5.5894 22 5.74853V21.4C22 21.7314 21.7314 22 21.4 22H2.6C2.26863 22 2 21.7314 2 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 5.4V2.35355C18 2.15829 18.1583 2 18.3536 2C18.4473 2 18.5372 2.03725 18.6036 2.10355L21.8964 5.39645C21.9628 5.46275 22 5.55268 22 5.64645C22 5.84171 21.8417 6 21.6464 6H18.6C18.2686 6 18 5.73137 18 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 18V14H8V18H6Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="attachment">
-    <path d="M21.4383 11.6622L12.2483 20.8522C11.1225 21.9781 9.59552 22.6106 8.00334 22.6106C6.41115 22.6106 4.88418 21.9781 3.75834 20.8522C2.63249 19.7264 2 18.1994 2 16.6072C2 15.015 2.63249 13.4881 3.75834 12.3622L12.9483 3.17222C13.6989 2.42166 14.7169 2 15.7783 2C16.8398 2 17.8578 2.42166 18.6083 3.17222C19.3589 3.92279 19.7806 4.94077 19.7806 6.00222C19.7806 7.06368 19.3589 8.08166 18.6083 8.83222L9.40834 18.0222C9.03306 18.3975 8.52406 18.6083 7.99334 18.6083C7.46261 18.6083 6.95362 18.3975 6.57834 18.0222C6.20306 17.6469 5.99222 17.138 5.99222 16.6072C5.99222 16.0765 6.20306 15.5675 6.57834 15.1922L15.0683 6.71222" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="page">
-    <path d="M4 21.4V2.6C4 2.26863 4.26863 2 4.6 2H16.2515C16.4106 2 16.5632 2.06321 16.6757 2.17574L19.8243 5.32426C19.9368 5.43679 20 5.5894 20 5.74853V21.4C20 21.7314 19.7314 22 19.4 22H4.6C4.26863 22 4 21.7314 4 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 5.4V2.35355C16 2.15829 16.1583 2 16.3536 2C16.4473 2 16.5372 2.03725 16.6036 2.10355L19.8964 5.39645C19.9628 5.46275 20 5.55268 20 5.64645C20 5.84171 19.8417 6 19.6464 6H16.6C16.2686 6 16 5.73137 16 5.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 10L16 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 18L16 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 14L12 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="folder">
-    <path d="M2 11V4.6C2 4.26863 2.26863 4 2.6 4H8.77805C8.92127 4 9.05977 4.05124 9.16852 4.14445L12.3315 6.85555C12.4402 6.94876 12.5787 7 12.722 7H21.4C21.7314 7 22 7.26863 22 7.6V11M2 11V19.4C2 19.7314 2.26863 20 2.6 20H21.4C21.7314 20 22 19.7314 22 19.4V11M2 11H22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multiple-pages">
-    <path d="M7 18H10.5H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 14H7.5H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 10H8.5H10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 2L16.5 2L21 6.5V19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.5V6.5C3 5.67157 3.67157 5 4.5 5H14.2515C14.4106 5 14.5632 5.06321 14.6757 5.17574L17.8243 8.32426C17.9368 8.43679 18 8.5894 18 8.74853V20.5C18 21.3284 17.3284 22 16.5 22H4.5C3.67157 22 3 21.3284 3 20.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 8.4V5.35355C14 5.15829 14.1583 5 14.3536 5C14.4473 5 14.5372 5.03725 14.6036 5.10355L17.8964 8.39645C17.9628 8.46275 18 8.55268 18 8.64645C18 8.84171 17.8417 9 17.6464 9H14.6C14.2686 9 14 8.73137 14 8.4Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="journal">
-    <path d="M6 6L18 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 10H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 14L18 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 21.4V2.6C2 2.26863 2.26863 2 2.6 2H21.4C21.7314 2 22 2.26863 22 2.6V21.4C22 21.7314 21.7314 22 21.4 22H2.6C2.26863 22 2 21.7314 2 21.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 18V14H8V18H6Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="lock-key">
-    <path d="M14.6667 12H15.4C15.7314 12 16 12.2686 16 12.6V16.4C16 16.7314 15.7314 17 15.4 17H8.6C8.26863 17 8 16.7314 8 16.4V12.6C8 12.2686 8.26863 12 8.6 12H9.33333M14.6667 12V9.5C14.6667 8.66667 14.1333 7 12 7C9.86667 7 9.33333 8.66667 9.33333 9.5V12M14.6667 12H9.33333" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 19V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="accessibility-tech">
-    <path d="M3 19V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M9.71942 11.7864C8.7031 12.2668 8 13.3013 8 14.5001C8 16.157 9.34315 17.5001 11 17.5001C11.9211 17.5001 12.7453 17.085 13.2956 16.4315" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 14H14.5L15.5 15.5L16.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 9.5V11M12 14L12 11M12 11H14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7.5C11.7239 7.5 11.5 7.27614 11.5 7C11.5 6.72386 11.7239 6.5 12 6.5C12.2761 6.5 12.5 6.72386 12.5 7C12.5 7.27614 12.2761 7.5 12 7.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="log-denied">
-    <path d="M17.8566 9.2C17.1306 8.45946 16.119 8 15 8C12.7909 8 11 9.79086 11 12C11 13.0902 11.4361 14.0785 12.1434 14.8M17.8566 9.2C18.5639 9.9215 19 10.9098 19 12C19 14.2091 17.2091 16 15 16C13.881 16 12.8694 15.5405 12.1434 14.8M17.8566 9.2L12.1434 14.8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 6V5C19 3.89543 18.1046 3 17 3H7C5.89543 3 5 3.89543 5 5V19C5 20.1046 5.89543 21 7 21H17C18.1046 21 19 20.1046 19 19V18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="eject">
-    <path d="M5 14L4.40799 13.5395C4.23212 13.7657 4.20041 14.0722 4.32626 14.3295C4.45212 14.5868 4.71355 14.75 5 14.75V14ZM19 14V14.75C19.2865 14.75 19.5479 14.5868 19.6737 14.3295C19.7996 14.0722 19.7679 13.7657 19.592 13.5395L19 14ZM5 14.75H19V13.25H5V14.75ZM10.6186 5.55443L4.40799 13.5395L5.59201 14.4605L11.8027 6.47534L10.6186 5.55443ZM19.592 13.5395L13.3814 5.55442L12.1973 6.47534L18.408 14.4605L19.592 13.5395ZM11.8027 6.47534C11.9028 6.34665 12.0972 6.34665 12.1973 6.47534L13.3814 5.55442C12.6807 4.65362 11.3193 4.65362 10.6186 5.55443L11.8027 6.47534Z" fill="black"></path>
-    <path d="M5 17.25C4.58579 17.25 4.25 17.5858 4.25 18C4.25 18.4142 4.58579 18.75 5 18.75V17.25ZM19 18.75C19.4142 18.75 19.75 18.4142 19.75 18C19.75 17.5858 19.4142 17.25 19 17.25V18.75ZM5 18.75H19V17.25H5V18.75Z" fill="black"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="terminal-outline">
-    <path d="M13 16H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 8L10 12L6 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 18V6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bin-minus">
-    <path d="M8.99219 13H11.9922H14.9922" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.03919 4.2939C3.01449 4.10866 3.0791 3.92338 3.23133 3.81499C3.9272 3.31953 6.3142 2 12 2C17.6858 2 20.0728 3.31952 20.7687 3.81499C20.9209 3.92338 20.9855 4.10866 20.9608 4.2939L19.2616 17.0378C19.0968 18.2744 18.3644 19.3632 17.2813 19.9821L16.9614 20.1649C13.8871 21.9217 10.1129 21.9217 7.03861 20.1649L6.71873 19.9821C5.6356 19.3632 4.90325 18.2744 4.73838 17.0378L3.03919 4.2939Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 5C5.57143 7.66666 18.4286 7.66662 21 5" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="input-field">
-    <path d="M4 6H20C21.1046 6 22 6.89543 22 8V16C22 17.1046 21.1046 18 20 18H4C2.89543 18 2 17.1046 2 16V8C2 6.89543 2.89543 6 4 6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 8.5H6.5M8 8.5H6.5M6.5 8.5V15.5M6.5 15.5H5M6.5 15.5H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="log-in">
-    <path d="M19 12H12M12 12L15 15M12 12L15 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 6V5C19 3.89543 18.1046 3 17 3H7C5.89543 3 5 3.89543 5 5V19C5 20.1046 5.89543 21 7 21H17C18.1046 21 19 20.1046 19 19V18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="system-shut">
-    <path d="M12 7V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="log-out">
-    <path d="M12 12H19M19 12L16 15M19 12L16 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 6V5C19 3.89543 18.1046 3 17 3H7C5.89543 3 5 3.89543 5 5V19C5 20.1046 5.89543 21 7 21H17C18.1046 21 19 20.1046 19 19V18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="settings">
-    <path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19.6224 10.3954L18.5247 7.7448L20 6L18 4L16.2647 5.48295L13.5578 4.36974L12.9353 2H10.981L10.3491 4.40113L7.70441 5.51596L6 4L4 6L5.45337 7.78885L4.3725 10.4463L2 11V13L4.40111 13.6555L5.51575 16.2997L4 18L6 20L7.79116 18.5403L10.397 19.6123L11 22H13L13.6045 19.6132L16.2551 18.5155C16.6969 18.8313 18 20 18 20L20 18L18.5159 16.2494L19.6139 13.598L21.9999 12.9772L22 11L19.6224 10.3954Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="switch-off-outline">
-    <path d="M7 13C7.55228 13 8 12.5523 8 12C8 11.4477 7.55228 11 7 11C6.44772 11 6 11.4477 6 12C6 12.5523 6.44772 13 7 13Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H17C19.7614 7 22 9.23858 22 12C22 14.7614 19.7614 17 17 17Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="dashboard">
-    <path d="M15 15.8C15 14.0327 12 11 12 11C12 11 9 14.0327 9 15.8C9 17.5673 10.3431 19 12 19C13.6569 19 15 17.5673 15 15.8Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 4L12 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.5 7.5L6.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.5 10.5L20.5 7.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 17H6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 17H22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cursor-pointer">
-    <g clip-path="url(#clip0_807_1302)">
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M19.5027 9.96946C20.7073 10.4587 20.6154 12.194 19.3658 12.5532L13.0605 14.3657L10.1807 20.2605C9.60996 21.4287 7.88499 21.2179 7.6124 19.9466L4.67677 6.25634C4.44638 5.18192 5.5121 4.28768 6.53019 4.70114L19.5027 9.96946Z" stroke="black" stroke-width="1.5"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="search">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.5 15.5L19 19"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 11a6 6 0 1012 0 6 6 0 00-12 0z"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_1302">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="off-rounded">
-    <path d="M1 15V9C1 5.68629 3.68629 3 7 3H17C20.3137 3 23 5.68629 23 9V15C23 18.3137 20.3137 21 17 21H7C3.68629 21 1 18.3137 1 15Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M7 9C8.65685 9 10 10.3431 10 12C10 13.6569 8.65685 15 7 15C5.34315 15 4 13.6569 4 12C4 10.3431 5.34315 9 7 9Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 15V9L15 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 15V9L20 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11.9999 12H14.5713" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.9999 12H19.5713" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="on-rounded">
-    <path d="M1 15V9C1 5.68629 3.68629 3 7 3H17C20.3137 3 23 5.68629 23 9V15C23 18.3137 20.3137 21 17 21H7C3.68629 21 1 18.3137 1 15Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M9 9C10.6569 9 12 10.3431 12 12C12 13.6569 10.6569 15 9 15C7.34315 15 6 13.6569 6 12C6 10.3431 7.34315 9 9 9Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 15V9L18 15V9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="system-restart">
-    <path d="M12 2V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18V22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M22 12H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 12H2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4.92871 4.92896L7.75714 7.75738" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.2427 16.2427L19.0711 19.0711" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19.0713 4.92896L16.2429 7.75738" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.75732 16.2427L4.9289 19.0711" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="accessibility-sign">
-    <path d="M12 16L15.8889 16L17.4444 18.5H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 8.5L12 11M12 16V11M12 11H15.8889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 6.5C10.8954 6.5 10 5.60457 10 4.5C10 3.39543 10.8954 2.5 12 2.5C13.1046 2.5 14 3.39543 14 4.5C14 5.60457 13.1046 6.5 12 6.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14.8818 19.5157C13.8773 20.8374 12.2885 21.6907 10.5003 21.6907C7.46273 21.6907 5.0003 19.2283 5.0003 16.1907C5.0003 13.7921 6.53575 11.7521 8.67737 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bin-add">
-    <path d="M8.99219 14H11.9922M14.9922 14H11.9922M11.9922 14V11M11.9922 14V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.03919 4.2939C3.01449 4.10866 3.0791 3.92338 3.23133 3.81499C3.9272 3.31953 6.3142 2 12 2C17.6858 2 20.0728 3.31952 20.7687 3.81499C20.9209 3.92338 20.9855 4.10866 20.9608 4.2939L19.2616 17.0378C19.0968 18.2744 18.3644 19.3632 17.2813 19.9821L16.9614 20.1649C13.8871 21.9217 10.1129 21.9217 7.03861 20.1649L6.71873 19.9821C5.6356 19.3632 4.90325 18.2744 4.73838 17.0378L3.03919 4.2939Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 5C5.57143 7.66666 18.4286 7.66662 21 5" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multi-window">
-    <path d="M7 19V11C7 9.89543 7.89543 9 9 9H20C21.1046 9 22 9.89543 22 11V19C22 20.1046 21.1046 21 20 21H9C7.89543 21 7 20.1046 7 19Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M6.5 16H4C2.89543 16 2 15.1046 2 14V6C2 4.89543 2.89543 4 4 4H15C16.1046 4 17 4.89543 17 6V9" stroke="black" stroke-width="1.5"></path>
-    <path d="M10 12H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 7H6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bin-full">
-    <path d="M19.2616 17.0378L20.9383 4.46293C20.9746 4.19069 20.8214 3.92855 20.5664 3.82655L16 2H10.5L9.81818 3.5L5 2L3.20966 3.79034C3.07751 3.92249 3.01449 4.10866 3.03919 4.2939L4.73838 17.0378C4.90325 18.2744 5.6356 19.3632 6.71873 19.9821L7.03861 20.1649C10.1129 21.9217 13.8871 21.9217 16.9614 20.1649L17.2813 19.9821C18.3644 19.3632 19.0968 18.2744 19.2616 17.0378Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16 2L14 7" stroke="black" stroke-width="1.5"></path>
-    <path d="M9 6.5L9.81818 3.5" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 5.00002C5.57143 7.66668 18.4286 7.66664 21 5.00002" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="terminal-simple">
-    <path d="M13 17H20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 7L10 12L5 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="dashboard-dots">
-    <path d="M12 7.01L12.01 6.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 9.01L16.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 9.01L8.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 13.01L18.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 13.01L6.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 17.01L17.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 17.01L7.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17L13 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 20.001H4C2.74418 18.3295 2 16.2516 2 14C2 8.47715 6.47715 4 12 4C17.5228 4 22 8.47715 22 14C22 16.2516 21.2558 18.3295 20 20.001L15.5 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 23C13.6569 23 15 21.6569 15 20C15 18.3431 13.6569 17 12 17C10.3431 17 9 18.3431 9 20C9 21.6569 10.3431 23 12 23Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bin">
-    <path d="M3.03919 4.2939C3.01449 4.10866 3.0791 3.92338 3.23133 3.81499C3.9272 3.31953 6.3142 2 12 2C17.6858 2 20.0728 3.31952 20.7687 3.81499C20.9209 3.92338 20.9855 4.10866 20.9608 4.2939L19.2616 17.0378C19.0968 18.2744 18.3644 19.3632 17.2813 19.9821L16.9614 20.1649C13.8871 21.9217 10.1129 21.9217 7.03861 20.1649L6.71873 19.9821C5.6356 19.3632 4.90325 18.2744 4.73838 17.0378L3.03919 4.2939Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 5C5.57143 7.66666 18.4286 7.66662 21 5" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="calendar">
-    <path d="M15 4V2M15 4V6M15 4H10.5M3 10V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V10H3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 10V6C3 4.89543 3.89543 4 5 4H7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 2V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 10V6C21 4.89543 20.1046 4 19 4H18.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multi-mac-os-window">
-    <path d="M7 19V11C7 9.89543 7.89543 9 9 9H20C21.1046 9 22 9.89543 22 11V19C22 20.1046 21.1046 21 20 21H9C7.89543 21 7 20.1046 7 19Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M10 12.01L10.01 11.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12.01L12.01 11.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 12.01L14.01 11.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6.5 16H4C2.89543 16 2 15.1046 2 14V6C2 4.89543 2.89543 4 4 4H15C16.1046 4 17 4.89543 17 6V9" stroke="black" stroke-width="1.5"></path>
-    <path d="M5 7.01L5.01 6.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 7.01L7.01 6.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 7.01L9.01 6.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="dashboard-speed">
-    <path d="M12 4L12 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 8L6.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.5 10.5L20 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 17H6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17L13 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 17H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 20.001H4C2.74418 18.3295 2 16.2516 2 14C2 8.47715 6.47715 4 12 4C17.5228 4 22 8.47715 22 14C22 16.2516 21.2558 18.3295 20 20.001L15.5 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 23C13.6569 23 15 21.6569 15 20C15 18.3431 13.6569 17 12 17C10.3431 17 9 18.3431 9 20C9 21.6569 10.3431 23 12 23Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="switch-on-outline">
-    <path d="M17 13C17.5523 13 18 12.5523 18 12C18 11.4477 17.5523 11 17 11C16.4477 11 16 11.4477 16 12C16 12.5523 16.4477 13 17 13Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H17C19.7614 7 22 9.23858 22 12C22 14.7614 19.7614 17 17 17Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="settings-profiles">
-    <path d="M11.6065 2.34184C11.8322 2.14578 12.1678 2.14578 12.3935 2.34184L14.3418 4.03445C14.4646 4.14111 14.6254 4.19336 14.7874 4.17924L17.3586 3.9551C17.6564 3.92913 17.9279 4.1264 17.9953 4.41768L18.5766 6.93224C18.6133 7.09069 18.7126 7.22748 18.852 7.31129L21.0639 8.64123C21.3201 8.79529 21.4238 9.11447 21.307 9.3897L20.2994 11.7657C20.2359 11.9155 20.2359 12.0845 20.2994 12.2343L21.307 14.6103C21.4238 14.8855 21.3201 15.2047 21.0639 15.3588L18.852 16.6887C18.7126 16.7725 18.6133 16.9093 18.5766 17.0678L17.9953 19.5823C17.9279 19.8736 17.6564 20.0709 17.3586 20.0449L14.7874 19.8208C14.6254 19.8066 14.4646 19.8589 14.3418 19.9655L12.3935 21.6582C12.1678 21.8542 11.8322 21.8542 11.6065 21.6582L9.65816 19.9655C9.53539 19.8589 9.37458 19.8066 9.21256 19.8208L6.64142 20.0449C6.34359 20.0709 6.07208 19.8736 6.00474 19.5823L5.42338 17.0678C5.38675 16.9093 5.28736 16.7725 5.14798 16.6887L2.93615 15.3588C2.67993 15.2047 2.57622 14.8855 2.69295 14.6103L3.70065 12.2343C3.76414 12.0845 3.76414 11.9155 3.70065 11.7657L2.69295 9.3897C2.57622 9.11447 2.67993 8.79529 2.93615 8.64123L5.14798 7.31129C5.28736 7.22748 5.38675 7.09069 5.42338 6.93224L6.00474 4.41768C6.07208 4.1264 6.34359 3.92913 6.64142 3.9551L9.21256 4.17924C9.37458 4.19336 9.53539 4.14111 9.65816 4.03445L11.6065 2.34184Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M9 13L11 15L16 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="web-window">
-    <path d="M3 17V7C3 5.89543 3.89543 5 5 5H19C20.1046 5 21 5.89543 21 7V17C21 18.1046 20.1046 19 19 19H5C3.89543 19 3 18.1046 3 17Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M6 8H7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bin-half">
-    <path d="M3.03919 4.2939C3.01449 4.10866 3.0791 3.92338 3.23133 3.81499C3.9272 3.31953 6.3142 2 12 2C17.6858 2 20.0728 3.31952 20.7687 3.81499C20.9209 3.92338 20.9855 4.10866 20.9608 4.2939L19.2616 17.0378C19.0968 18.2744 18.3644 19.3632 17.2813 19.9821L16.9614 20.1649C13.8871 21.9217 10.1129 21.9217 7.03861 20.1649L6.71873 19.9821C5.6356 19.3632 4.90325 18.2744 4.73838 17.0378L3.03919 4.2939Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 5C5.57143 7.66666 18.4286 7.66662 21 5" stroke="black" stroke-width="1.5"></path>
-    <path d="M11 18L14 14.5M14 14.5L19 17M14 14.5L20 11.5" stroke="black" stroke-width="1.5"></path>
-    <path d="M4.5 16L7.73595 15.5377C7.90405 15.5137 8.07446 15.562 8.20491 15.6708L11 18L14 21" stroke="black" stroke-width="1.5"></path>
-    <path d="M8 15.5L10.6149 12.4493C10.8284 12.2001 11.2025 12.1688 11.4546 12.3788L14 14.5" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="calculator">
-    <path d="M1 21V3C1 1.89543 1.89543 1 3 1H21C22.1046 1 23 1.89543 23 3V21C23 22.1046 22.1046 23 21 23H3C1.89543 23 1 22.1046 1 21Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M15 7L17 7H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 15.5H17L19 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 18.5H17H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5 7H7M9 7H7M7 7V5M7 7V9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M5.5856 18.4142L6.99981 17M8.41403 15.5858L6.99981 17M6.99981 17L5.5856 15.5858M6.99981 17L8.41403 18.4142" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="accessibility">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 9L12 10M17 9L12 10M12 10V13M12 13L10 18M12 13L14 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7C11.7239 7 11.5 6.77614 11.5 6.5C11.5 6.22386 11.7239 6 12 6C12.2761 6 12.5 6.22386 12.5 6.5C12.5 6.77614 12.2761 7 12 7Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="drag-hand-gesture">
-    <path d="M7 10.5L4.99591 13.1721C4.41845 13.9421 4.47127 15.0141 5.1216 15.7236L8.9055 19.8515C9.28432 20.2647 9.81826 20.5 10.3789 20.5C11.4651 20.5 13.2415 20.5 15 20.5C17.4 20.5 19 19 19 16.5C19 16.5 19 16.5 19 16.5C19 16.5 19 9.64287 19 7.92859" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 8.49995C16 8.49995 16 8.37483 16 7.92852C16 5.6428 19 5.6428 19 7.92852" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 8.50008C13 8.50008 13 7.91978 13 7.02715M13 6.50008C13 6.50008 13 6.804 13 7.02715M16 8.50008C16 8.50008 16 8.37496 16 7.92865C16 7.70549 16 7.25031 16 7.02715C16 4.74144 13 4.74144 13 7.02715" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 8.50008C13 8.50008 13 7.91978 13 7.02715C13 4.74144 16 4.74144 16 7.02715C16 7.25031 16 7.70549 16 7.92865C16 8.37496 16 8.50008 16 8.50008" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 8.50005C10 8.50005 10 7.85719 10 6.50005C10 4.21434 13 4.21434 13 6.50005C13 6.50005 13 6.50005 13 6.50005C13 6.50005 13 6.80397 13 7.02713C13 7.91975 13 8.50005 13 8.50005" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 13.5001V6.50006C7 5.67164 7.67157 5.00006 8.5 5.00006V5.00006C9.32843 5.00006 10 5.55527 10 6.38369C10 6.42151 10 6.4603 10 6.50006C10 7.85721 10 8.50006 10 8.50006" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="open-select-hand-gesture">
-    <path d="M8 14.5714L6.17716 12.8354C5.53522 12.224 4.51329 12.2705 3.92953 12.9377V12.9377C3.40196 13.5406 3.41749 14.4453 3.96544 15.0298L9.90739 21.3679C10.2855 21.7712 10.8127 22 11.3655 22C12.4505 22 14.2343 22 16 22C18.4 22 20 20 20 18C20 18 20 18 20 18C20 18 20 11.1429 20 9.42859" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 9.99995C17 9.99995 17 9.87483 17 9.42852C17 7.1428 20 7.1428 20 9.42852" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 9.99998C14 9.99998 14 9.17832 14 8.2857C14 5.99998 17 5.99998 17 8.2857C17 8.50885 17 9.2054 17 9.42855C17 9.87487 17 9.99998 17 9.99998" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 10.0001C11 10.0001 11 8.61584 11 7.50005C11 5.21434 14 5.21434 14 7.50005C14 7.50005 14 7.50005 14 7.50005C14 7.50005 14 8.06261 14 8.28577C14 9.17839 14 10.0001 14 10.0001" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 14.5714V3.5C8 2.67157 8.67157 2 9.5 2V2C10.3284 2 11 2.67056 11 3.49899C11 4.68968 11 6.34156 11 7.5C11 8.61578 11 10 11 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="one-finger-select-hand-gesture">
-    <path d="M7.5 12L5.49591 14.6721C4.91845 15.4421 4.97127 16.5141 5.6216 17.2236L9.4055 21.3515C9.78431 21.7647 10.3183 22 10.8789 22C11.9651 22 13.7415 22 15.5 22C17.9 22 19.5 20 19.5 18C19.5 18 19.5 18 19.5 18C19.5 18 19.5 11.1429 19.5 9.42859" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 9.99995C16.5 9.99995 16.5 9.87483 16.5 9.42852C16.5 7.1428 19.5 7.1428 19.5 9.42852" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13.5 9.99998C13.5 9.99998 13.5 9.17832 13.5 8.2857C13.5 5.99998 16.5 5.99998 16.5 8.2857C16.5 8.50885 16.5 9.2054 16.5 9.42855C16.5 9.87487 16.5 9.99998 16.5 9.99998" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 10.0001C10.5 10.0001 10.5 8.61584 10.5 7.50005C10.5 5.21434 13.5 5.21434 13.5 7.50005C13.5 7.50005 13.5 7.50005 13.5 7.50005C13.5 7.50005 13.5 8.06261 13.5 8.28577C13.5 9.17839 13.5 10.0001 13.5 10.0001" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 10C10.5 10 10.5 8.61578 10.5 7.5C10.5 6.34156 10.5 4.68968 10.5 3.49899C10.5 2.67056 9.82843 2 9 2V2C8.17157 2 7.5 2.67157 7.5 3.5V12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="user-square-alt">
-    <path d="M7 18V17C7 14.2386 9.23858 12 12 12V12C14.7614 12 17 14.2386 17 17V18" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M12 12C13.6569 12 15 10.6569 15 9C15 7.34315 13.6569 6 12 6C10.3431 6 9 7.34315 9 9C9 10.6569 10.3431 12 12 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="user">
-    <path d="M5 20V19C5 15.134 8.13401 12 12 12V12C15.866 12 19 15.134 19 19V20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12C14.2091 12 16 10.2091 16 8C16 5.79086 14.2091 4 12 4C9.79086 4 8 5.79086 8 8C8 10.2091 9.79086 12 12 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="group">
-    <path d="M1 20V19C1 15.134 4.13401 12 8 12V12C11.866 12 15 15.134 15 19V20" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M13 14V14C13 11.2386 15.2386 9 18 9V9C20.7614 9 23 11.2386 23 14V14.5" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M8 12C10.2091 12 12 10.2091 12 8C12 5.79086 10.2091 4 8 4C5.79086 4 4 5.79086 4 8C4 10.2091 5.79086 12 8 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 9C19.6569 9 21 7.65685 21 6C21 4.34315 19.6569 3 18 3C16.3431 3 15 4.34315 15 6C15 7.65685 16.3431 9 18 9Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="verified-user">
-    <path d="M2 20V19C2 15.134 5.13401 12 9 12V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.8038 12.3135C16.4456 11.6088 17.5544 11.6088 18.1962 12.3135V12.3135C18.5206 12.6697 18.9868 12.8628 19.468 12.8403V12.8403C20.4201 12.7958 21.2042 13.5799 21.1597 14.532V14.532C21.1372 15.0132 21.3303 15.4794 21.6865 15.8038V15.8038C22.3912 16.4456 22.3912 17.5544 21.6865 18.1962V18.1962C21.3303 18.5206 21.1372 18.9868 21.1597 19.468V19.468C21.2042 20.4201 20.4201 21.2042 19.468 21.1597V21.1597C18.9868 21.1372 18.5206 21.3303 18.1962 21.6865V21.6865C17.5544 22.3912 16.4456 22.3912 15.8038 21.6865V21.6865C15.4794 21.3303 15.0132 21.1372 14.532 21.1597V21.1597C13.5799 21.2042 12.7958 20.4201 12.8403 19.468V19.468C12.8628 18.9868 12.6697 18.5206 12.3135 18.1962V18.1962C11.6088 17.5544 11.6088 16.4456 12.3135 15.8038V15.8038C12.6697 15.4794 12.8628 15.0132 12.8403 14.532V14.532C12.7958 13.5799 13.5799 12.7958 14.532 12.8403V12.8403C15.0132 12.8628 15.4794 12.6697 15.8038 12.3135V12.3135Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M15.3638 17L16.4547 18.0909L18.6365 15.9091" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 12C11.2091 12 13 10.2091 13 8C13 5.79086 11.2091 4 9 4C6.79086 4 5 5.79086 5 8C5 10.2091 6.79086 12 9 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="profile-circled">
-    <path d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4.271 18.3457C4.271 18.3457 6.50002 15.5 12 15.5C17.5 15.5 19.7291 18.3457 19.7291 18.3457" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12C13.6569 12 15 10.6569 15 9C15 7.34315 13.6569 6 12 6C10.3431 6 9 7.34315 9 9C9 10.6569 10.3431 12 12 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="user-circle-alt">
-    <path d="M7 18V17C7 14.2386 9.23858 12 12 12V12C14.7614 12 17 14.2386 17 17V18" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M12 12C13.6569 12 15 10.6569 15 9C15 7.34315 13.6569 6 12 6C10.3431 6 9 7.34315 9 9C9 10.6569 10.3431 12 12 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <circle cx="12" cy="12" r="10" stroke="black" stroke-width="1.5"></circle>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-user">
-    <g clip-path="url(#clip0_807_1336)">
-      <path d="M18.6213 12.1213L20.7426 10M22.864 7.87868L20.7426 10M20.7426 10L18.6213 7.87868M20.7426 10L22.864 12.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M1 20V19C1 15.134 4.13401 12 8 12V12C11.866 12 15 15.134 15 19V20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M8 12C10.2091 12 12 10.2091 12 8C12 5.79086 10.2091 4 8 4C5.79086 4 4 5.79086 4 8C4 10.2091 5.79086 12 8 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="nav-arrow-left">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 6l-6 6 6 6"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_1336">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-user">
-    <path d="M17 10H20M23 10H20M20 10V7M20 10V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M1 20V19C1 15.134 4.13401 12 8 12V12C11.866 12 15 15.134 15 19V20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 12C10.2091 12 12 10.2091 12 8C12 5.79086 10.2091 4 8 4C5.79086 4 4 5.79086 4 8C4 10.2091 5.79086 12 8 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="people-rounded">
-    <path d="M3 16V8C3 5.23858 5.23858 3 8 3H16C18.7614 3 21 5.23858 21 8V16C21 18.7614 18.7614 21 16 21H8C5.23858 21 3 18.7614 3 16Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16.5 14.5C16.5 14.5 15 16.5 12 16.5C9 16.5 7.5 14.5 7.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 10C8.22386 10 8 9.77614 8 9.5C8 9.22386 8.22386 9 8.5 9C8.77614 9 9 9.22386 9 9.5C9 9.77614 8.77614 10 8.5 10Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 10C15.2239 10 15 9.77614 15 9.5C15 9.22386 15.2239 9 15.5 9C15.7761 9 16 9.22386 16 9.5C16 9.77614 15.7761 10 15.5 10Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-desync">
-    <g clip-path="url(#clip0_807_942)">
-      <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M16.4203 19.4874L14.6525 21.2552C13.0904 22.8173 10.5577 22.8173 8.99564 21.2552L8.64209 20.9016" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M16.0665 21.9623L16.42 19.4874L13.9452 19.841L16.0665 21.9623Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M7.58071 16.9016L9.34848 15.1339C10.9106 13.5718 13.4432 13.5718 15.0053 15.1339L15.3589 15.4874" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M7.93401 14.4268L7.58045 16.9017L10.0553 16.5481L7.93401 14.4268Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="user">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 20v-1a7 7 0 017-7v0a7 7 0 017 7v1"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 12a4 4 0 100-8 4 4 0 000 8z"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_942">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-check">
-    <path d="M8 18L11 21L16 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-upload">
-    <path d="M12 22V13M12 13L15.5 16.5M12 13L8.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-sync">
-    <g clip-path="url(#clip0_807_941)">
-      <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M7.58071 19.4874L9.34848 21.2552C10.9106 22.8173 13.4432 22.8173 15.0053 21.2552L15.3589 20.9016" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M7.93401 21.9623L7.58045 19.4874L10.0553 19.841L7.93401 21.9623Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M16.2982 16.9016L14.5304 15.1339C12.9683 13.5718 10.4357 13.5718 8.87357 15.1339L8.52002 15.4874" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M15.9444 14.4268L16.298 16.9017L13.8231 16.5481L15.9444 14.4268Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="nav-arrow-up">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 15l6-6 6 6"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_941">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-book-alt">
-    <path d="M8.5 12H15.5V22L12 20L8.5 22V12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-error">
-    <g clip-path="url(#clip0_807_940)">
-      <path d="M9 22L12.0005 19M15 16L12.0005 19M12.0005 19L9 16M12.0005 19L15 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-      <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <symbol fill="none" viewBox="0 0 24 24" id="cancel">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6.757 17.243L12 12m5.243-5.243L12 12m0 0L6.757 6.757M12 12l5.243 5.243"></path>
     </g>
-    <defs>
-      <clipPath id="clip0_807_940">
-        <rect width="24" height="24" fill="white"></rect>
-      </clipPath>
-    </defs>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cloud-download">
-    <path d="M12 13V22M12 22L15.5 18.5M12 22L8.5 18.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M20 17.6073C21.4937 17.0221 23 15.6889 23 13C23 9 19.6667 8 18 8C18 6 18 2 12 2C6 2 6 6 6 8C4.33333 8 1 9 1 13C1 15.6889 2.50628 17.0221 4 17.6073" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="undo-circle">
-    <path d="M7 10.625H14.2C14.2 10.625 14.2 10.625 14.2 10.625C14.2 10.625 17 10.625 17 13.625C17 17 14.2 17 14.2 17H13.4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 14L7 10.625L10.5 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="double-check">
-    <path d="M1.5 12.5L5.57574 16.5757C5.81005 16.8101 6.18995 16.8101 6.42426 16.5757L9 14" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M16 7L12 11" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M7 12L11.5757 16.5757C11.8101 16.8101 12.1899 16.8101 12.4243 16.5757L22 7" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="redo-action">
-    <path d="M19 7V9.5V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 9.5C16 9.5 12 9.5 9 9.5C3.5 9.5 3.5 18 9 18C12 18 19 18 19 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12.5 13L16 9.5L12.5 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="download-square-outline">
-    <path d="M6 18L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 6V14M12 14L15.5 10.5M12 14L8.5 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="cancel">
-    <path d="M6.75729 17.2426L11.9999 12M17.2426 6.75736L11.9999 12M11.9999 12L6.75729 6.75736M11.9999 12L17.2426 17.2426" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="prohibition">
-    <path d="M19.1414 5C17.3265 3.14864 14.7974 2 12 2C6.47715 2 2 6.47715 2 12C2 14.7255 3.09032 17.1962 4.85857 19M19.1414 5C20.9097 6.80375 22 9.27455 22 12C22 17.5228 17.5228 22 12 22C9.20261 22 6.67349 20.8514 4.85857 19M19.1414 5L4.85857 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="delete-circled-outline">
-    <path d="M9.1712 14.8284L11.9996 12M14.8281 9.17157L11.9996 12M11.9996 12L9.1712 9.17157M11.9996 12L14.8281 14.8284" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="menu-scale">
-    <path d="M3 5H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 12H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 19H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="upload-square-outline">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M6 18L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 14V6M12 6L15.5 9.5M12 6L8.5 9.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="undo-action">
-    <path d="M5 7V9.5V12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.875 9.5H14.875C20.375 9.5 20.375 18 14.875 18C11.875 18 4.875 18 4.875 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11.375 13L7.875 9.5L11.375 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="minus-square">
-    <path d="M9 12H12H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="refresh-double">
-    <path d="M21.1679 8C19.6247 4.46819 16.1006 2 11.9999 2C6.81459 2 2.55104 5.94668 2.04932 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 8H21.4C21.7314 8 22 7.73137 22 7.4V3" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2.88146 16C4.42458 19.5318 7.94874 22 12.0494 22C17.2347 22 21.4983 18.0533 22 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.04932 16H2.64932C2.31795 16 2.04932 16.2686 2.04932 16.6V21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-circled-outline">
-    <path d="M8 12H12M16 12H12M12 12V8M12 12V16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="download">
-    <path d="M6 20L18 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 4V16M12 16L15.5 12.5M12 16L8.5 12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="download-circled-outline">
-    <path d="M9 17L15 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 6V13M12 13L15.5 9.5M12 13L8.5 9.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="add-square">
-    <path d="M9 12H12M15 12H12M12 12V9M12 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="warning-square-outline">
-    <path d="M12 7V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17.01L12.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="eye-off">
-    <path d="M3 3L21 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.5 10.6771C10.1888 11.0297 10 11.4928 10 12C10 13.1046 10.8954 14 12 14C12.5072 14 12.9703 13.8112 13.3229 13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.36185 7.56107C5.68002 8.73965 4.27894 10.4188 3 12C4.88856 14.991 8.2817 18 12 18C13.5499 18 15.0434 17.4772 16.3949 16.6508" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 6C16.0084 6 18.7015 9.1582 21 12C20.6815 12.5043 20.3203 13.0092 19.922 13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="share-ios">
-    <path d="M20 13V19C20 20.1046 19.1046 21 18 21H6C4.89543 21 4 20.1046 4 19V13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 15V3M12 3L8.5 6.5M12 3L15.5 6.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="question-square-outline">
-    <path d="M9 9C9 5.49997 14.5 5.5 14.5 9C14.5 11.5 12 10.9999 12 13.9999" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18.01L12.01 17.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="check">
-    <path d="M5 13L9 17L19 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="plus">
-    <path d="M6 12H12M18 12H12M12 12V6M12 12V18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="eye-close">
-    <path d="M4.5 8C7.5 14.5 16.5 14.5 19.5 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.8164 11.3175L19.5002 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12.875V16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.18383 11.3175L4.5 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-square">
-    <path d="M9.87864 14.1213L12 12M14.1213 9.87868L12 12M12 12L9.87864 9.87868M12 12L14.1213 14.1213" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="refresh-circular">
-    <circle cx="12" cy="12" r="10" stroke="black" stroke-width="1.5"></circle>
-    <path d="M16.5829 9.66667C15.8095 8.09697 14.043 7 11.9876 7C9.38854 7 7.25148 8.75408 7 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14.4941 9.72222H16.4003C16.7317 9.72222 17.0003 9.45359 17.0003 9.12222V7.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.41707 13.6667C8.19054 15.6288 9.95698 17 12.0124 17C14.6115 17 16.7485 14.8074 17 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9.50586 13.6222H7.59967C7.2683 13.6222 6.99967 13.8909 6.99967 14.2222V16.4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="redo-circle">
-    <path d="M17 10.625H9.8C9.8 10.625 9.8 10.625 9.8 10.625C9.8 10.625 7 10.625 7 13.625C7 17 9.8 17 9.8 17H10.6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13.5 14L17 10.625L13.5 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="warning-circled-outline">
-    <path d="M12 7L12 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17.01L12.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="save-action-floppy">
-    <path d="M3 7.5V5C3 3.89543 3.89543 3 5 3H16.1716C16.702 3 17.2107 3.21071 17.5858 3.58579L20.4142 6.41421C20.7893 6.78929 21 7.29799 21 7.82843V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19V16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 21V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 21V13.6C18 13.2686 17.7314 13 17.4 13H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 3V8.4C16 8.73137 15.7314 9 15.4 9H13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 3V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M1 12H12M12 12L9 9M12 12L9 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="refresh">
-    <path d="M21.8883 13.5C21.1645 18.3113 17.013 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C16.1006 2 19.6248 4.46819 21.1679 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 8H21.4C21.7314 8 22 7.73137 22 7.4V3" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="redo">
-    <path d="M19 9.5C15.5 9.5 12.5 9.5 9 9.5C8.83847 9.5 5 9.5 5 13.5C5 18 8.70237 18 9 18C12 18 14 18 17 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 13C16.8668 11.6332 17.6332 10.8668 19 9.5C17.6332 8.13317 16.8668 7.36683 15.5 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="line-space">
-    <path d="M11 7H20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 12H20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 17H20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 17V7M6 17L4 14.5M6 17L8 14.5M6 7L4 9M6 7L8 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="trash">
-    <path d="M19 11V20.4C19 20.7314 18.7314 21 18.4 21H5.6C5.26863 21 5 20.7314 5 20.4V11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 17V11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 17V11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 7L16 7M3 7L8 7M8 7V3.6C8 3.26863 8.26863 3 8.6 3L15.4 3C15.7314 3 16 3.26863 16 3.6V7M8 7L16 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="info-empty">
-    <path d="M12 11.5V16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7.51L12.01 7.49889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="load-action-floppy">
-    <path d="M3 6.5V5C3 3.89543 3.89543 3 5 3H16.1716C16.702 3 17.2107 3.21071 17.5858 3.58579L20.4142 6.41421C20.7893 6.78929 21 7.29799 21 7.82843V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19V17.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 3H16V8.4C16 8.73137 15.7314 9 15.4 9H8.6C8.26863 9 8 8.73137 8 8.4V3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 21V13.6C18 13.2686 17.7314 13 17.4 13H15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 21V17.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12H1M1 12L4 9M1 12L4 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="remove-empty">
-    <path d="M8 12H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="check-circled-outline">
-    <path d="M7 12.5L10 15.5L17 8.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="share-android">
-    <path d="M18 22C19.6569 22 21 20.6569 21 19C21 17.3431 19.6569 16 18 16C16.3431 16 15 17.3431 15 19C15 20.6569 16.3431 22 18 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 8C19.6569 8 21 6.65685 21 5C21 3.34315 19.6569 2 18 2C16.3431 2 15 3.34315 15 5C15 6.65685 16.3431 8 18 8Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 15C7.65685 15 9 13.6569 9 12C9 10.3431 7.65685 9 6 9C4.34315 9 3 10.3431 3 12C3 13.6569 4.34315 15 6 15Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 6.5L8.5 10.5" stroke="black" stroke-width="1.5"></path>
-    <path d="M8.5 13.5L15.5 17.5" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="warning-triangle-outline">
-    <path d="M20.0429 21H3.95705C2.41902 21 1.45658 19.3364 2.22324 18.0031L10.2662 4.01533C11.0352 2.67792 12.9648 2.67791 13.7338 4.01532L21.7768 18.0031C22.5434 19.3364 21.581 21 20.0429 21Z" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M12 9V13" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M12 17.01L12.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="question-mark">
-    <path d="M7.90039 8.07954C7.90039 3.30678 15.4004 3.30682 15.4004 8.07955C15.4004 11.4886 11.9913 10.8067 11.9913 14.8976" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 19.01L12.01 18.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="eye-empty">
-    <path d="M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 12C19.1114 14.991 15.7183 18 12 18C8.2817 18 4.88856 14.991 3 12C5.29855 9.15825 7.99163 6 12 6C16.0084 6 18.7015 9.1582 21 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="question-mark-circle">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 9.00001C9 5.49999 14.5 5.50002 14.5 9.00002C14.5 11.5 12 10.9999 12 13.9999" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18.01L12.01 17.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="wrap-text">
-    <path d="M4 7H20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 17H9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 12H17.5C18.8807 12 20 13.1193 20 14.5V14.5C20 15.8807 18.8807 17 17.5 17H12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 15.5L12.5 17L15 18.5V15.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="undo">
-    <path d="M5 9.5C8.5 9.5 11.5 9.5 15 9.5C15.1615 9.5 19 9.5 19 13.5C19 18 15.2976 18 15 18C12 18 10 18 7 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 13C7.13317 11.6332 6.36683 10.8668 5 9.5C6.36683 8.13317 7.13317 7.36683 8.5 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="open-in-window">
-    <path d="M8 21H20.4C20.7314 21 21 20.7314 21 20.4V3.6C21 3.26863 20.7314 3 20.4 3H3.6C3.26863 3 3 3.26863 3 3.6V16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.5 20.5L12 12M12 12V16M12 12H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="open-in-browser">
-    <path d="M8 21H20.4C20.7314 21 21 20.7314 21 20.4V3.6C21 3.26863 20.7314 3 20.4 3H3.6C3.26863 3 3 3.26863 3 3.6V16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 6L18 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 6H7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3.5 20.5L12 12M12 12V16M12 12H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="menu">
-    <path d="M3 5H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 12H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 19H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="upload">
-    <path d="M6 20L18 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16V4M12 4L15.5 7.5M12 4L8.5 7.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="minus">
-    <path d="M6 12H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="eye-alt">
-    <path d="M4.5 12.5C7.5 6 16.5 6 19.5 12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16C10.8954 16 10 15.1046 10 14C10 12.8954 10.8954 12 12 12C13.1046 12 14 12.8954 14 14C14 15.1046 13.1046 16 12 16Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="no-credit-card">
-    <path d="M3 3L21 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 15C7.55228 15 8 14.5523 8 14C8 13.4477 7.55228 13 7 13C6.44772 13 6 13.4477 6 14C6 14.5523 6.44772 15 7 15Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18.5 19H2.6C2.26863 19 2 18.7314 2 18.4V9H8.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 9V5.6C2 5.26863 2.26863 5 2.6 5H4.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 9H22V17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M22 9V5.6C22 5.26863 21.7314 5 21.4 5H10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="credit-card">
-    <path d="M7 15C7.55228 15 8 14.5523 8 14C8 13.4477 7.55228 13 7 13C6.44772 13 6 13.4477 6 14C6 14.5523 6.44772 15 7 15Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 9V5.6C2 5.26863 2.26863 5 2.6 5H21.4C21.7314 5 22 5.26863 22 5.6V9M2 9V18.4C2 18.7314 2.26863 19 2.6 19H21.4C21.7314 19 22 18.7314 22 18.4V9M2 9H22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="credit-card-2">
-    <path d="M2 9V5.6C2 5.26863 2.26863 5 2.6 5H21.4C21.7314 5 22 5.26863 22 5.6V9V18.4C22 18.7314 21.7314 19 21.4 19H2.6C2.26863 19 2 18.7314 2 18.4V9ZM2 9H16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <rect x="15" y="12" width="4" height="4" rx="0.6" fill="black"></rect>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-look-right">
-    <path d="M15.5 9C15.7761 9 16 8.77614 16 8.5C16 8.22386 15.7761 8 15.5 8C15.2239 8 15 8.22386 15 8.5C15 8.77614 15.2239 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21.5422 15C21.8396 14.053 22 13.0452 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C16.4776 22 20.2679 19.0571 21.5422 15ZM21.5422 15H17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-think-left">
-    <path d="M10 15H7M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-sing-right-note">
-    <path d="M20.8 8.1C20.8 8.59706 20.3971 9 19.9 9C19.4029 9 19 8.59706 19 8.1C19 7.60294 19.4029 7.2 19.9 7.2C20.3971 7.2 20.8 7.60294 20.8 8.1Z" fill="black"></path>
-    <path d="M20.8 8.1C20.8 8.59706 20.3971 9 19.9 9C19.4029 9 19 8.59706 19 8.1C19 7.60294 19.4029 7.2 19.9 7.2C20.3971 7.2 20.8 7.60294 20.8 8.1ZM20.8 8.1V3.6C20.8 3.26863 21.0686 3 21.4 3H23" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M16 17C14.8954 17 14 16.1046 14 15C14 13.8954 14.8954 13 16 13C17.1046 13 18 13.8954 18 15C18 16.1046 17.1046 17 16 17Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21.9506 13C21.4489 18.0533 17.1853 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C13.4222 2 14.7751 2.2969 16 2.83209" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-blink-left">
-    <path d="M10 9H8M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 14.5C16.5 14.5 15 16.5 12 16.5C9 16.5 7.5 14.5 7.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-look-bottom">
-    <path d="M8.5 14C8.22386 14 8 13.7761 8 13.5C8 13.2239 8.22386 13 8.5 13C8.77614 13 9 13.2239 9 13.5C9 13.7761 8.77614 14 8.5 14Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 14C15.2239 14 15 13.7761 15 13.5C15 13.2239 15.2239 13 15.5 13C15.7761 13 16 13.2239 16 13.5C16 13.7761 15.7761 14 15.5 14Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 18H14M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji">
-    <path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 14.5C16.5 14.5 15 16.5 12 16.5C9 16.5 7.5 14.5 7.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-talking-happy">
-    <path d="M10 9H8M16 9H14M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12ZM14 13H10V16C10 16.6667 10.4 18 12 18C13.6 18 14 16.6667 14 16V13Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-sing-left">
-    <path d="M8 17C6.89543 17 6 16.1046 6 15C6 13.8954 6.89543 13 8 13C9.10457 13 10 13.8954 10 15C10 16.1046 9.10457 17 8 17Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-think-right">
-    <path d="M14 15H17M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-blink-right">
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 9H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.5 14.5C7.5 14.5 9 16.5 12 16.5C15 16.5 16.5 14.5 16.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-ball">
-    <path d="M10 9H8M16 9H14M18 15H6M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-surprise">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 17C11.4477 17 11 16.5523 11 16C11 15.4477 11.4477 15 12 15C12.5523 15 13 15.4477 13 16C13 16.5523 12.5523 17 12 17Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-sing-right">
-    <path d="M16 17C14.8954 17 14 16.1046 14 15C14 13.8954 14.8954 13 16 13C17.1046 13 18 13.8954 18 15C18 16.1046 17.1046 17 16 17Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-sad">
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.5 15.5C7.5 15.5 9 13.5 12 13.5C15 13.5 16.5 15.5 16.5 15.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-look-top">
-    <path d="M8.5 7C8.22386 7 8 6.77614 8 6.5C8 6.22386 8.22386 6 8.5 6C8.77614 6 9 6.22386 9 6.5C9 6.77614 8.77614 7 8.5 7Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 7C15.2239 7 15 6.77614 15 6.5C15 6.22386 15.2239 6 15.5 6C15.7761 6 16 6.22386 16 6.5C16 6.77614 15.7761 7 15.5 7Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 11H14M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-look-left">
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2.4578 15C2.16035 14.053 2 13.0452 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C7.52236 22 3.73207 19.0571 2.4578 15ZM2.4578 15H7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-sing-left-note">
-    <path d="M2.8 8.1C2.8 8.59706 2.39706 9 1.9 9C1.40294 9 1 8.59706 1 8.1C1 7.60294 1.40294 7.2 1.9 7.2C2.39706 7.2 2.8 7.60294 2.8 8.1Z" fill="black"></path>
-    <path d="M2.8 8.1C2.8 8.59706 2.39706 9 1.9 9C1.40294 9 1 8.59706 1 8.1C1 7.60294 1.40294 7.2 1.9 7.2C2.39706 7.2 2.8 7.60294 2.8 8.1ZM2.8 8.1V3.6C2.8 3.26863 3.06863 3 3.4 3H5" stroke="black" stroke-width="1.5" stroke-linecap="round"></path>
-    <path d="M8 17C9.10457 17 10 16.1046 10 15C10 13.8954 9.10457 13 8 13C6.89543 13 6 13.8954 6 15C6 16.1046 6.89543 17 8 17Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2.04938 13C2.5511 18.0533 6.81465 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C10.5778 2 9.22492 2.2969 8 2.83209" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.7761 9 16 8.77614 16 8.5C16 8.22386 15.7761 8 15.5 8C15.2239 8 15 8.22386 15 8.5C15 8.77614 15.2239 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.77614 9 9 8.77614 9 8.5C9 8.22386 8.77614 8 8.5 8C8.22386 8 8 8.22386 8 8.5C8 8.77614 8.22386 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-talking-angry">
-    <path d="M10 9H8M16 9H14M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12ZM14 18H10V15C10 14.3333 10.4 13 12 13C13.6 13 14 14.3333 14 15V18Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-satisfied">
-    <path d="M10 9H8M16 9H14M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16.5 14.5C16.5 14.5 15 16.5 12 16.5C9 16.5 7.5 14.5 7.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-really">
-    <path d="M10 9H8M16 9H14M15 15H9M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-quite">
-    <path d="M9 15H15M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="emoji-surprise-alt">
-    <path d="M12 17C10.8954 17 10 16.1046 10 15C10 13.8954 10.8954 13 12 13C13.1046 13 14 13.8954 14 15C14 16.1046 13.1046 17 12 17Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.22386 9 8 8.77614 8 8.5C8 8.22386 8.22386 8 8.5 8C8.77614 8 9 8.22386 9 8.5C9 8.77614 8.77614 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 9C15.2239 9 15 8.77614 15 8.5C15 8.22386 15.2239 8 15.5 8C15.7761 8 16 8.22386 16 8.5C16 8.77614 15.7761 9 15.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="underline">
-    <path d="M16 5V11C16 13.2091 14.2091 15 12 15V15C9.79086 15 8 13.2091 8 11V5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 19L18 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="underline-square-outline">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16 6V10C16 12.2091 14.2091 14 12 14V14C9.79086 14 8 12.2091 8 10V6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 18L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="list">
-    <path d="M8 6L20 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 6.01L4.01 5.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 12.01L4.01 11.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 18.01L4.01 17.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 12L20 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 18L20 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="search-font">
-    <path d="M19.5 19.5L21 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 17C14 18.6569 15.3431 20 17 20C17.8299 20 18.581 19.663 19.1241 19.1185C19.6654 18.5758 20 17.827 20 17C20 15.3431 18.6569 14 17 14C15.3431 14 14 15.3431 14 17Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 5L9 17M9 17H7M9 17H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 7V5L3 5L3 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="align-justify">
-    <path d="M3 6H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 10H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 14H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 18H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="font-size">
-    <path d="M18 21V11M18 21L16 18.5M18 21L20 18.5M18 11L16 13M18 11L20 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 5L9 17M9 17H7M9 17H11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 7V5L3 5L3 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="number">
-    <path d="M6.32645 16.7556L6.6771 16.3991H6.6771L6.32645 16.7556ZM6.23327 6.85556L6.48743 6.42497L5.73327 5.97982V6.85556H6.23327ZM6.38857 6.94722L6.66089 7.36656L7.33784 6.92694L6.64273 6.51664L6.38857 6.94722ZM4.01249 8.49028L3.74016 8.07094L3.73828 8.07218L4.01249 8.49028ZM3.59318 8.44444L3.19555 8.74759L3.21715 8.77591L3.24253 8.80088L3.59318 8.44444ZM3.67083 7.95556L3.90724 8.39613L3.92518 8.38651L3.94228 8.37545L3.67083 7.95556ZM6.38857 6.19861L6.13441 5.76803L6.12565 5.77319L6.11712 5.77871L6.38857 6.19861ZM6.52834 6.15278V6.65278H6.58892L6.64775 6.63831L6.52834 6.15278ZM6.65258 6.15278L6.53317 6.63831L6.55784 6.64438L6.58299 6.64791L6.65258 6.15278ZM6.82341 6.25972L6.40949 6.54022L6.42173 6.55827L6.43548 6.57518L6.82341 6.25972ZM6.79235 16.7556L7.14299 17.112L7.143 17.112L6.79235 16.7556ZM10.1836 16.7097L10.5758 16.3996L10.1836 16.7097ZM10.1836 15.6861L10.5572 16.0184L10.5668 16.0076L10.5758 15.9962L10.1836 15.6861ZM10.8669 15.6861L10.453 15.9666L10.4715 15.9938L10.4933 16.0184L10.8669 15.6861ZM10.8669 16.7097L10.4747 16.3996L10.4633 16.414L10.453 16.4292L10.8669 16.7097ZM14.8316 16.2667L14.4916 16.6334L14.4954 16.6368L14.8316 16.2667ZM13.6202 14.2653L13.1426 14.4133L13.1443 14.4187L13.6202 14.2653ZM13.6202 8.73472L13.1443 8.58133L13.1432 8.58505L13.6202 8.73472ZM14.8316 6.74861L15.1677 7.11879L15.1715 7.11529L14.8316 6.74861ZM18.9004 6.74861L18.5569 7.11206L18.5643 7.11877L18.9004 6.74861ZM20.0962 8.73472L19.6186 8.88275L19.6209 8.88982L20.0962 8.73472ZM20.0962 14.2653L19.6203 14.1119L19.6186 14.1173L20.0962 14.2653ZM18.9004 16.2667L19.2401 16.6336L19.2403 16.6333L18.9004 16.2667ZM18.5122 15.7319L18.1701 15.3672L18.1658 15.3713L18.5122 15.7319ZM19.5061 14.0056L19.0285 13.8572L19.0267 13.8634L19.5061 14.0056ZM19.5061 8.97917L19.0267 9.1213L19.0286 9.12748L19.5061 8.97917ZM18.5122 7.26806L18.1657 7.62879L18.1746 7.63692L18.5122 7.26806ZM15.2043 7.26806L15.5461 7.63293L15.5464 7.63273L15.2043 7.26806ZM14.2104 8.97917L13.7328 8.83084L13.731 8.83704L14.2104 8.97917ZM14.2104 14.0056L13.731 14.1477L13.7329 14.1539L14.2104 14.0056ZM15.2043 15.7319L14.8579 16.0926L14.8622 16.0966L15.2043 15.7319ZM6.5594 16.3472C6.56819 16.3472 6.58846 16.3488 6.61436 16.359C6.64091 16.3695 6.66236 16.3846 6.6771 16.3991L5.9758 17.112C6.13837 17.2719 6.34507 17.3472 6.5594 17.3472V16.3472ZM6.6771 16.3991C6.68617 16.408 6.70203 16.4269 6.71495 16.4566C6.72818 16.4869 6.73327 16.517 6.73327 16.5417H5.73327C5.73327 16.7672 5.8255 16.9641 5.9758 17.112L6.6771 16.3991ZM6.73327 16.5417V6.85556H5.73327V16.5417H6.73327ZM5.97911 7.28614L6.13441 7.37781L6.64273 6.51664L6.48743 6.42497L5.97911 7.28614ZM6.11625 6.52789L3.74017 8.07094L4.28481 8.90961L6.66089 7.36656L6.11625 6.52789ZM3.73828 8.07218C3.73308 8.07559 3.73871 8.07108 3.75478 8.06533C3.77144 8.05937 3.80139 8.05139 3.84166 8.05139V9.05139C4.02462 9.05139 4.17688 8.98041 4.2867 8.90838L3.73828 8.07218ZM3.84166 8.05139C3.86072 8.05139 3.8842 8.05543 3.90732 8.06538C3.92962 8.07498 3.94148 8.0857 3.94383 8.08801L3.24253 8.80088C3.39917 8.95498 3.60473 9.05139 3.84166 9.05139V8.05139ZM3.9908 8.1413C3.98038 8.12763 3.98187 8.1264 3.98647 8.13771C3.9915 8.15007 4 8.17707 4 8.21528H3C3 8.43484 3.09513 8.61586 3.19555 8.74759L3.9908 8.1413ZM4 8.21528C4 8.24863 3.99002 8.29612 3.96045 8.34108C3.93325 8.38243 3.90577 8.39693 3.90724 8.39613L3.43442 7.51498C3.18844 7.64697 3 7.8871 3 8.21528H4ZM3.94228 8.37545L6.66002 6.61851L6.11712 5.77871L3.39938 7.53566L3.94228 8.37545ZM6.64273 6.6292C6.64422 6.62832 6.63581 6.63355 6.61813 6.63934C6.60014 6.64525 6.56926 6.65278 6.52834 6.65278V5.65278C6.366 5.65278 6.23052 5.7113 6.13441 5.76803L6.64273 6.6292ZM6.64775 6.63831C6.61072 6.64742 6.57019 6.64742 6.53317 6.63831L6.77199 5.66725C6.65214 5.63777 6.52878 5.63777 6.40893 5.66725L6.64775 6.63831ZM6.58299 6.64791C6.55598 6.64412 6.52052 6.63361 6.48432 6.61095C6.44823 6.58836 6.42392 6.56151 6.40949 6.54022L7.23732 5.97923C7.11741 5.80229 6.93597 5.68769 6.72216 5.65764L6.58299 6.64791ZM6.43548 6.57518C6.41391 6.54866 6.40029 6.52081 6.39279 6.49683C6.38567 6.47404 6.38553 6.45961 6.38553 6.45833H7.38553C7.38553 6.29045 7.34139 6.10419 7.21133 5.94426L6.43548 6.57518ZM6.38553 6.45833V16.5417H7.38553V6.45833H6.38553ZM6.38553 16.5417C6.38553 16.517 6.39062 16.4869 6.40384 16.4566C6.41677 16.4269 6.43263 16.408 6.4417 16.3991L7.143 17.112C7.29329 16.9641 7.38553 16.7672 7.38553 16.5417H6.38553ZM6.4417 16.3991C6.45644 16.3846 6.47788 16.3695 6.50443 16.359C6.53034 16.3488 6.55061 16.3472 6.5594 16.3472V17.3472C6.77373 17.3472 6.98043 17.2719 7.14299 17.112L6.4417 16.3991ZM10.4942 16.3472C10.4837 16.3472 10.4952 16.3455 10.518 16.3556C10.543 16.3667 10.5634 16.3838 10.5758 16.3996L9.79138 17.0198C9.97381 17.2506 10.2329 17.3472 10.4942 17.3472V16.3472ZM10.5758 16.3996C10.576 16.3998 10.5765 16.4006 10.5772 16.4017C10.5778 16.4029 10.5779 16.4035 10.5778 16.4031C10.5776 16.4025 10.5749 16.394 10.5749 16.3736H9.57489C9.57489 16.6028 9.63991 16.8282 9.79138 17.0198L10.5758 16.3996ZM10.5749 16.3736V16.0222H9.57489V16.3736H10.5749ZM10.5749 16.0222C10.5749 15.9925 10.5787 15.9822 10.5778 15.9851C10.5773 15.9868 10.5756 15.9914 10.572 15.9978C10.5683 16.0044 10.5634 16.0115 10.5572 16.0184L9.81 15.3538C9.6337 15.552 9.57489 15.7956 9.57489 16.0222H10.5749ZM10.5758 15.9962C10.5634 16.012 10.543 16.0291 10.518 16.0402C10.4952 16.0503 10.4837 16.0486 10.4942 16.0486V15.0486C10.2329 15.0486 9.97381 15.1453 9.79138 15.376L10.5758 15.9962ZM10.4942 16.0486H10.5563V15.0486H10.4942V16.0486ZM10.5563 16.0486C10.5779 16.0486 10.5675 16.0522 10.5403 16.0402C10.5262 16.034 10.5098 16.0244 10.4932 16.0107C10.4766 15.9969 10.4632 15.9816 10.453 15.9666L11.2808 15.4056C11.0977 15.1354 10.8101 15.0486 10.5563 15.0486V16.0486ZM10.4933 16.0184C10.4872 16.0115 10.4822 16.0044 10.4786 15.9978C10.4749 15.9914 10.4733 15.9868 10.4727 15.9851C10.4718 15.9822 10.4756 15.9925 10.4756 16.0222H11.4756C11.4756 15.7956 11.4168 15.552 11.2405 15.3538L10.4933 16.0184ZM10.4756 16.0222V16.3736H11.4756V16.0222H10.4756ZM10.4756 16.3736C10.4756 16.394 10.4729 16.4025 10.4727 16.4031C10.4726 16.4035 10.4727 16.4029 10.4734 16.4017C10.474 16.4006 10.4746 16.3998 10.4747 16.3996L11.2591 17.0198C11.4106 16.8282 11.4756 16.6028 11.4756 16.3736H10.4756ZM10.453 16.4292C10.4632 16.4142 10.4766 16.3989 10.4932 16.3851C10.5098 16.3714 10.5262 16.3619 10.5403 16.3556C10.5674 16.3436 10.5779 16.3472 10.5563 16.3472V17.3472C10.8101 17.3472 11.0977 17.2604 11.2808 16.9902L10.453 16.4292ZM10.5563 16.3472H10.4942V17.3472H10.5563V16.3472ZM16.866 16.5C16.1557 16.5 15.6024 16.2913 15.1677 15.8965L14.4954 16.6368C15.1375 17.2198 15.9405 17.5 16.866 17.5V16.5ZM15.1715 15.9C14.7072 15.4696 14.3442 14.8814 14.0961 14.1119L13.1443 14.4187C13.4347 15.3195 13.8792 16.0656 14.4917 16.6333L15.1715 15.9ZM14.0978 14.1173C13.8559 13.3367 13.732 12.4657 13.732 11.5H12.732C12.732 12.551 12.8669 13.5235 13.1426 14.4133L14.0978 14.1173ZM13.732 11.5C13.732 10.5235 13.8561 9.65323 14.0973 8.8844L13.1432 8.58505C12.8667 9.46621 12.732 10.4395 12.732 11.5H13.732ZM14.0961 8.88811C14.344 8.11898 14.7062 7.53781 15.1677 7.11877L14.4954 6.37846C13.8802 6.93719 13.4348 7.6801 13.1443 8.58134L14.0961 8.88811ZM15.1715 7.11529C15.6066 6.71195 16.1586 6.5 16.866 6.5V5.5C15.9376 5.5 15.1333 5.78713 14.4917 6.38193L15.1715 7.11529ZM16.866 6.5C17.5858 6.5 18.1349 6.71305 18.557 7.11198L19.2439 6.38524C18.6099 5.78602 17.8027 5.5 16.866 5.5V6.5ZM18.5643 7.11877C19.0243 7.53646 19.3809 8.1156 19.6186 8.88273L20.5738 8.58671C20.2939 7.68348 19.8533 6.93854 19.2365 6.37846L18.5643 7.11877ZM19.6209 8.88982C19.8712 9.65691 20 10.5252 20 11.5H21C21 10.4377 20.8596 9.46253 20.5716 8.57963L19.6209 8.88982ZM20 11.5C20 12.4639 19.8714 13.333 19.6203 14.1119L20.5721 14.4187C20.8595 13.5272 21 12.5528 21 11.5H20ZM19.6186 14.1173C19.3808 14.8848 19.0233 15.4709 18.5605 15.9L19.2403 16.6333C19.8542 16.0642 20.294 15.3161 20.5738 14.4133L19.6186 14.1173ZM18.5607 15.8998C18.1391 16.2902 17.5887 16.5 16.866 16.5V17.5C17.7998 17.5 18.6057 17.2209 19.2401 16.6336L18.5607 15.8998ZM16.866 16.8583C17.6437 16.8583 18.3209 16.6088 18.8585 16.0926L18.1658 15.3713C17.8337 15.6902 17.4135 15.8583 16.866 15.8583V16.8583ZM18.8542 16.0966C19.3786 15.6048 19.7491 14.9448 19.9855 14.1477L19.0267 13.8634C18.8282 14.533 18.5361 15.0239 18.1701 15.3673L18.8542 16.0966ZM19.9836 14.1539C20.2291 13.3633 20.3477 12.4767 20.3477 11.5H19.3477C19.3477 12.3974 19.2386 13.1811 19.0286 13.8572L19.9836 14.1539ZM20.3477 11.5C20.3477 10.5137 20.2293 9.62189 19.9836 8.83086L19.0286 9.12748C19.2384 9.80311 19.3477 10.5918 19.3477 11.5H20.3477ZM19.9855 8.83704C19.749 8.03964 19.3776 7.38229 18.8497 6.8992L18.1746 7.63692C18.5371 7.96864 18.8283 8.45203 19.0267 9.12129L19.9855 8.83704ZM18.8585 6.90742C18.3209 6.39117 17.6437 6.14167 16.866 6.14167V7.14167C17.4135 7.14167 17.8337 7.30975 18.1658 7.62869L18.8585 6.90742ZM16.866 6.14167C16.0882 6.14167 15.4084 6.39105 14.8622 6.90338L15.5464 7.63273C15.8906 7.30987 16.3186 7.14167 16.866 7.14167V6.14167ZM14.8624 6.90318C14.3487 7.38453 13.9791 8.03813 13.7329 8.83086L14.6879 9.12748C14.8972 8.45354 15.1902 7.9664 15.5461 7.63293L14.8624 6.90318ZM13.731 8.83704C13.4971 9.62596 13.3842 10.5156 13.3842 11.5H14.3842C14.3842 10.5899 14.4888 9.79904 14.6897 9.12129L13.731 8.83704ZM13.3842 11.5C13.3842 12.4748 13.4972 13.3592 13.731 14.1477L14.6897 13.8634C14.4887 13.1852 14.3842 12.3993 14.3842 11.5H13.3842ZM13.7329 14.1539C13.979 14.9463 14.3477 15.6025 14.858 16.0926L15.5506 15.3713C15.1912 15.0262 14.8973 14.5315 14.6879 13.8572L13.7329 14.1539ZM14.8622 16.0966C15.4084 16.6089 16.0882 16.8583 16.866 16.8583V15.8583C16.3186 15.8583 15.8906 15.6901 15.5464 15.3673L14.8622 16.0966Z" fill="#292C35"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="italic-square-outline">
-    <path d="M12 6L14 6M16 6L14 6M14 6L10 18M10 18L8 18M10 18L12 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="scissor">
-    <path d="M7.23611 7C7.71115 6.46924 8 5.76835 8 5C8 3.34315 6.65685 2 5 2C3.34315 2 2 3.34315 2 5C2 6.65685 3.34315 8 5 8C5.8885 8 6.68679 7.61375 7.23611 7ZM7.23611 7L20 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.23611 17C7.71115 17.5308 8 18.2316 8 19C8 20.6569 6.65685 22 5 22C3.34315 22 2 20.6569 2 19C2 17.3431 3.34315 16 5 16C5.8885 16 6.68679 16.3863 7.23611 17ZM7.23611 17L20 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="integer">
-    <path d="M4.1948 16.7556L4.55385 16.4076L4.55385 16.4076L4.1948 16.7556ZM4.10596 6.85556L4.36916 6.43043L3.60596 5.95794V6.85556H4.10596ZM4.25403 6.94722L4.53551 7.36047L5.17158 6.92721L4.51722 6.5221L4.25403 6.94722ZM1.98862 8.49028L1.70714 8.07703L1.70525 8.07833L1.98862 8.49028ZM1.58884 8.44444L1.18439 8.73842L1.20518 8.76703L1.22979 8.79242L1.58884 8.44444ZM1.66287 7.95556L1.90811 8.39129L1.92625 8.38108L1.94348 8.36939L1.66287 7.95556ZM4.25403 6.19861L3.99084 5.77349L3.98202 5.77895L3.97343 5.78477L4.25403 6.19861ZM4.38729 6.15278V6.65278H4.45074L4.51218 6.63693L4.38729 6.15278ZM4.50574 6.15278L4.38086 6.63693L4.40656 6.64356L4.43283 6.64743L4.50574 6.15278ZM4.66862 6.25972L4.24865 6.53106L4.26031 6.54911L4.27347 6.56609L4.66862 6.25972ZM4.639 16.7556L4.99805 17.1035L4.99805 17.1035L4.639 16.7556ZM14.328 16.3278L14.687 15.9798L14.687 15.9798L14.328 16.3278ZM14.328 16.7708L14.654 17.15L14.6712 17.1351L14.687 17.1188L14.328 16.7708ZM8.15363 16.7861L7.88265 17.2063L7.90294 17.2194L7.92439 17.2305L8.15363 16.7861ZM8.10921 16.3278L7.73186 15.9997L7.71379 16.0205L7.69811 16.0432L8.10921 16.3278ZM11.5888 12.325L11.2165 11.9911L11.2114 11.997L11.5888 12.325ZM12.9362 10.4917L12.4959 10.2546L12.4944 10.2574L12.9362 10.4917ZM9.96004 6.825L10.1556 7.28519L10.1556 7.28519L9.96004 6.825ZM9.07164 7.39028L8.7345 7.02091L8.72741 7.02765L9.07164 7.39028ZM8.5238 8.16944L8.98305 8.36726L8.98555 8.36124L8.5238 8.16944ZM8.39054 8.36806L8.69654 8.76348L8.70277 8.75867L8.70884 8.75366L8.39054 8.36806ZM8.00557 8.35278L7.67958 8.7319L7.7 8.74946L7.7222 8.76472L8.00557 8.35278ZM7.93153 8.0625L8.40732 8.2162L8.41307 8.19841L8.41747 8.18024L7.93153 8.0625ZM7.99076 7.89444L7.53823 7.6818L7.53338 7.69212L7.52901 7.70265L7.99076 7.89444ZM8.70148 6.9625L8.37209 6.58626L8.36641 6.59138L8.70148 6.9625ZM9.79717 6.275L9.99385 6.73473L9.99938 6.73228L9.79717 6.275ZM12.6104 6.36667L12.3694 6.80474L12.3734 6.80692L12.6104 6.36667ZM13.6617 7.39028L13.2261 7.63573L13.2261 7.63573L13.6617 7.39028ZM12.0774 12.6917L11.7039 12.3591L11.6972 12.367L12.0774 12.6917ZM8.89396 16.4194L8.48952 16.7134L8.86237 17.2264L9.27419 16.7441L8.89396 16.4194ZM8.76071 16.2361V15.7361H7.77914L8.35626 16.5301L8.76071 16.2361ZM16.9919 15.5028L16.7627 15.9471L16.8126 15.9729L16.867 15.9869L16.9919 15.5028ZM17.14 15.625L16.7554 15.9445L16.7607 15.9509L16.7662 15.9571L17.14 15.625ZM17.9248 16.175L18.1102 15.7107L18.1102 15.7107L17.9248 16.175ZM20.4271 15.9917L20.186 15.5536L20.1818 15.5559L20.4271 15.9917ZM21.4783 14.9681L21.0512 14.7081L21.047 14.7153L21.4783 14.9681ZM21.4487 11.8972L21.0396 12.1847L21.0431 12.1896L21.4487 11.8972ZM20.3678 11.0111L20.1643 11.4679L20.1734 11.4718L20.3678 11.0111ZM18.7983 10.7361V11.2361H18.8269L18.8553 11.2329L18.7983 10.7361ZM18.5466 10.7514L18.4827 10.2554L18.4737 10.2567L18.5466 10.7514ZM18.2061 10.675L17.8171 10.9892L17.8313 11.0067L17.847 11.023L18.2061 10.675ZM18.1617 10.3083L17.7117 10.0903L18.1617 10.3083ZM18.2505 10.1708L17.8762 9.83934L17.8654 9.85156L17.8554 9.86447L18.2505 10.1708ZM21.3895 6.62639L21.8513 6.4346L21.5448 5.69684L21.0152 6.29489L21.3895 6.62639ZM21.4783 6.84028V7.34028H22.2274L21.9401 6.64849L21.4783 6.84028ZM16.5033 6.74861L16.1443 7.09658L16.1443 7.09659L16.5033 6.74861ZM16.5033 6.32083L16.8293 6.69995L16.8465 6.68513L16.8624 6.66881L16.5033 6.32083ZM22.0854 6.36667L21.6262 6.56447L21.6306 6.57469L21.6355 6.5847L22.0854 6.36667ZM22.115 6.67222L21.6651 6.45419L21.6499 6.48545L21.6392 6.51851L22.115 6.67222ZM22.041 6.77917L21.6819 6.43119L21.6737 6.43968L21.6659 6.44855L22.041 6.77917ZM18.9168 10.3236L18.7689 10.8013L19.078 10.8969L19.2919 10.6542L18.9168 10.3236ZM18.6207 10.2319H18.1207V10.6006L18.4728 10.7096L18.6207 10.2319ZM18.8576 10.1403L18.768 9.64834L18.7626 9.64938L18.8576 10.1403ZM20.7824 10.4611L20.5605 10.9092L20.564 10.9109L20.7824 10.4611ZM22.0114 11.5764L21.5889 11.8438L21.5927 11.8497L22.0114 11.5764ZM22.0114 15.3194L22.4373 15.5814L22.4373 15.5814L22.0114 15.3194ZM20.7084 16.5569L20.4694 16.1177L20.4661 16.1196L20.7084 16.5569ZM17.7175 16.7708L17.5307 17.2348L17.5409 17.2386L17.7175 16.7708ZM16.6514 16.0222L17.0211 15.6856L17.0159 15.6798L17.0104 15.6742L16.6514 16.0222ZM16.5774 15.9306L16.0914 16.0483L16.1114 16.1307L16.1574 16.2019L16.5774 15.9306ZM16.6514 15.5792L16.2668 15.2597L16.2668 15.2597L16.6514 15.5792ZM4.4169 16.3472C4.43077 16.3472 4.45574 16.3498 4.4855 16.3621C4.51572 16.3746 4.53882 16.3921 4.55385 16.4076L3.83576 17.1035C3.9937 17.2665 4.1994 17.3472 4.4169 17.3472V16.3472ZM4.55385 16.4076C4.56351 16.4175 4.57827 16.4364 4.58993 16.4645C4.60175 16.4929 4.60596 16.5203 4.60596 16.5417H3.60596C3.60596 16.7593 3.69058 16.9537 3.83576 17.1035L4.55385 16.4076ZM4.60596 16.5417V6.85556H3.60596V16.5417H4.60596ZM3.84277 7.28068L3.99084 7.37235L4.51722 6.5221L4.36916 6.43043L3.84277 7.28068ZM3.97255 6.53398L1.70714 8.07703L2.27009 8.90352L4.53551 7.36047L3.97255 6.53398ZM1.70525 8.07833C1.69316 8.08665 1.7374 8.05139 1.82575 8.05139V9.05139C2.0128 9.05139 2.16563 8.97539 2.27199 8.90223L1.70525 8.07833ZM1.82575 8.05139C1.85041 8.05139 1.87877 8.05682 1.90561 8.06893C1.93132 8.08054 1.94491 8.0934 1.94789 8.09647L1.22979 8.79242C1.3809 8.94833 1.58504 9.05139 1.82575 9.05139V8.05139ZM1.99329 8.15047C1.98349 8.13699 1.98452 8.13529 1.9884 8.14531C1.99265 8.15626 2 8.18062 2 8.21528H1C1 8.4278 1.08791 8.60568 1.18439 8.73842L1.99329 8.15047ZM2 8.21528C2 8.24384 1.99185 8.28805 1.96432 8.33196C1.9384 8.37328 1.91073 8.38981 1.90811 8.39129L1.41764 7.51983C1.17311 7.65745 1 7.89933 1 8.21528H2ZM1.94348 8.36939L4.53463 6.61245L3.97343 5.78477L1.38227 7.54172L1.94348 8.36939ZM4.51722 6.62373C4.51697 6.62389 4.51444 6.62545 4.50968 6.62777C4.50493 6.6301 4.49732 6.6335 4.48698 6.63705C4.46652 6.64409 4.43225 6.65278 4.38729 6.65278V5.65278C4.22091 5.65278 4.08436 5.71559 3.99084 5.77349L4.51722 6.62373ZM4.51218 6.63693C4.46974 6.64788 4.42329 6.64788 4.38086 6.63693L4.63063 5.66863C4.50923 5.63731 4.3838 5.63731 4.2624 5.66863L4.51218 6.63693ZM4.43283 6.64743C4.40094 6.64273 4.36199 6.63015 4.32385 6.60511C4.28618 6.58037 4.26213 6.55193 4.24865 6.53106L5.08858 5.98838C4.97468 5.81208 4.79683 5.69028 4.57866 5.65812L4.43283 6.64743ZM4.27347 6.56609C4.25269 6.53929 4.24039 6.51227 4.23389 6.49045C4.22771 6.46975 4.22784 6.45755 4.22784 6.45833H5.22784C5.22784 6.29571 5.18745 6.11289 5.06376 5.95336L4.27347 6.56609ZM4.22784 6.45833V16.5417H5.22784V6.45833H4.22784ZM4.22784 16.5417C4.22784 16.5203 4.23205 16.4929 4.24388 16.4645C4.25554 16.4364 4.2703 16.4175 4.27996 16.4076L4.99805 17.1035C5.14322 16.9537 5.22784 16.7593 5.22784 16.5417H4.22784ZM4.27996 16.4076C4.29499 16.3921 4.31808 16.3746 4.3483 16.3621C4.37807 16.3498 4.40304 16.3472 4.4169 16.3472V17.3472C4.63441 17.3472 4.84011 17.2665 4.99805 17.1035L4.27996 16.4076ZM14.1207 16.7361C14.0938 16.7361 14.0616 16.7305 14.0295 16.7163C13.9983 16.7025 13.9785 16.6856 13.9689 16.6758L14.687 15.9798C14.5418 15.8299 14.3462 15.7361 14.1207 15.7361V16.7361ZM13.9689 16.6758C13.9593 16.6658 13.9445 16.6469 13.9329 16.6189C13.921 16.5904 13.9168 16.563 13.9168 16.5417H14.9168C14.9168 16.324 14.8322 16.1296 14.687 15.9798L13.9689 16.6758ZM13.9168 16.5417C13.9168 16.533 13.9184 16.5129 13.9284 16.487C13.9387 16.4604 13.9539 16.4384 13.9689 16.4229L14.687 17.1188C14.8441 16.9568 14.9168 16.7522 14.9168 16.5417H13.9168ZM14.002 16.3917C14.0149 16.3806 14.0341 16.3681 14.0589 16.359C14.0836 16.3499 14.1055 16.3472 14.1207 16.3472V17.3472C14.3178 17.3472 14.503 17.2798 14.654 17.15L14.002 16.3917ZM14.1207 16.3472H8.40535V17.3472H14.1207V16.3472ZM8.40535 16.3472C8.39629 16.3472 8.39098 16.3459 8.38288 16.3418L7.92439 17.2305C8.07422 17.3078 8.23673 17.3472 8.40535 17.3472V16.3472ZM8.42462 16.3659C8.4666 16.393 8.50029 16.4329 8.51972 16.4755C8.53686 16.5131 8.53518 16.5355 8.53518 16.5264H7.53518C7.53518 16.761 7.61854 17.036 7.88265 17.2063L8.42462 16.3659ZM8.53518 16.5264C8.53518 16.564 8.52748 16.5914 8.5222 16.6055C8.5172 16.619 8.51414 16.6213 8.52032 16.6124L7.69811 16.0432C7.6142 16.1644 7.53518 16.3291 7.53518 16.5264H8.53518ZM8.48657 16.6558L11.9661 12.653L11.2114 11.997L7.73186 15.9997L8.48657 16.6558ZM11.961 12.6588C12.5881 11.9596 13.0657 11.3147 13.3779 10.7259L12.4944 10.2574C12.2341 10.7483 11.8135 11.3256 11.2165 11.9912L11.961 12.6588ZM13.3764 10.7287C13.6961 10.135 13.8804 9.55818 13.8804 9.00972H12.8804C12.8804 9.3372 12.7685 9.74834 12.4959 10.2546L13.3764 10.7287ZM13.8804 9.00972C13.8804 8.17917 13.627 7.46364 13.0839 6.91598L12.3739 7.62013C12.6994 7.94839 12.8804 8.39398 12.8804 9.00972H13.8804ZM13.0839 6.91598C12.5386 6.36609 11.8191 6.11111 10.9817 6.11111V7.11111C11.6053 7.11111 12.0505 7.29409 12.3739 7.62013L13.0839 6.91598ZM10.9817 6.11111C10.5653 6.11111 10.1585 6.19743 9.76452 6.36481L10.1556 7.28519C10.4328 7.16739 10.7071 7.11111 10.9817 7.11111V6.11111ZM9.76452 6.36481C9.37952 6.52839 9.03496 6.7468 8.73457 7.02098L9.40872 7.75957C9.62163 7.56524 9.86933 7.4068 10.1556 7.28519L9.76452 6.36481ZM8.72741 7.02765C8.43515 7.30508 8.20992 7.62163 8.06205 7.97765L8.98555 8.36124C9.07458 8.14689 9.21458 7.94399 9.41588 7.75291L8.72741 7.02765ZM8.06459 7.97164C8.0595 7.98346 8.05515 7.99236 8.05174 7.99877C8.04833 8.00519 8.0462 8.00848 8.04567 8.00927C8.04513 8.01007 8.04666 8.00767 8.05069 8.00308C8.05473 7.99847 8.06176 7.99111 8.07224 7.98246L8.70884 8.75366C8.84425 8.64188 8.928 8.49497 8.98301 8.36724L8.06459 7.97164ZM8.08454 7.97263C8.12916 7.9381 8.16988 7.92389 8.19162 7.91828C8.21262 7.91286 8.22174 7.91389 8.21286 7.91389V8.91389C8.34242 8.91389 8.53149 8.89121 8.69654 8.76348L8.08454 7.97263ZM8.21286 7.91389C8.21667 7.91389 8.22766 7.91444 8.2432 7.91902C8.25914 7.92372 8.275 7.93124 8.28894 7.94083L7.7222 8.76472C7.87299 8.86845 8.04312 8.91389 8.21286 8.91389V7.91389ZM8.33155 7.97366C8.34611 7.98617 8.36969 8.01108 8.38889 8.05071C8.40867 8.09152 8.41673 8.13343 8.41673 8.16944H7.41673C7.41673 8.40143 7.52179 8.59622 7.67958 8.7319L8.33155 7.97366ZM8.41673 8.16944C8.41673 8.16755 8.41714 8.18583 8.40732 8.2162L7.45575 7.9088C7.42619 8.00028 7.41673 8.08986 7.41673 8.16944H8.41673ZM8.41747 8.18024C8.41719 8.18143 8.41894 8.1742 8.42532 8.15612C8.43141 8.13884 8.44024 8.11579 8.45251 8.08624L7.52901 7.70265C7.49623 7.78156 7.46469 7.86593 7.44559 7.94476L8.41747 8.18024ZM8.44329 8.10709C8.56916 7.83921 8.76282 7.58075 9.03654 7.33362L8.36641 6.59138C8.00839 6.91462 7.72823 7.27745 7.53823 7.6818L8.44329 8.10709ZM9.03083 7.3387C9.31635 7.08873 9.63665 6.88751 9.99384 6.7347L9.6005 5.8153C9.14826 6.00878 8.7381 6.2659 8.37212 6.5863L9.03083 7.3387ZM9.99938 6.73228C10.3579 6.57373 10.699 6.5 11.0261 6.5V5.5C10.5438 5.5 10.0656 5.60961 9.59495 5.81772L9.99938 6.73228ZM11.0261 6.5C11.5712 6.5 12.0129 6.60854 12.3694 6.80472L12.8515 5.92861C12.3196 5.63591 11.705 5.5 11.0261 5.5V6.5ZM12.3734 6.80692C12.7465 7.00775 13.027 7.2824 13.2261 7.63573L14.0973 7.14483C13.8028 6.62223 13.3825 6.21447 12.8474 5.92641L12.3734 6.80692ZM13.2261 7.63573C13.4231 7.98538 13.5319 8.41687 13.5319 8.94861H14.5319C14.5319 8.2785 14.3938 7.6711 14.0973 7.14483L13.2261 7.63573ZM13.5319 8.94861C13.5319 9.36652 13.4045 9.85261 13.1139 10.4149L14.0022 10.874C14.3434 10.2141 14.5319 9.56959 14.5319 8.94861H13.5319ZM13.1139 10.4149C12.8239 10.9759 12.3591 11.6236 11.704 12.3591L12.4508 13.0242C13.1382 12.2524 13.6605 11.5352 14.0022 10.874L13.1139 10.4149ZM11.6972 12.367L8.51374 16.0947L9.27419 16.7441L12.4576 13.0164L11.6972 12.367ZM9.29841 16.1255L9.16515 15.9421L8.35626 16.5301L8.48952 16.7134L9.29841 16.1255ZM8.76071 16.7361H14.1207V15.7361H8.76071V16.7361ZM16.8735 15.9722C16.8237 15.9722 16.7851 15.9587 16.7627 15.9471L17.2212 15.0584C17.1198 15.0061 17.0023 14.9722 16.8735 14.9722V15.9722ZM16.867 15.9869C16.8242 15.9759 16.793 15.9604 16.7747 15.9499C16.7561 15.9393 16.7446 15.9301 16.7403 15.9266C16.7327 15.9204 16.7377 15.9232 16.7554 15.9445L17.5246 15.3055C17.4831 15.2555 17.4337 15.2023 17.3769 15.1554C17.3245 15.1122 17.2364 15.0495 17.1168 15.0186L16.867 15.9869ZM16.7662 15.9571C17.0354 16.2601 17.3617 16.4885 17.7393 16.6393L18.1102 15.7107C17.8758 15.6171 17.6789 15.4788 17.5138 15.2929L16.7662 15.9571ZM17.7393 16.6393C18.1133 16.7887 18.5232 16.8583 18.9612 16.8583V15.8583C18.6292 15.8583 18.3482 15.8057 18.1102 15.7107L17.7393 16.6393ZM18.9612 16.8583C19.5822 16.8583 20.1565 16.7177 20.6723 16.4274L20.1818 15.5559C19.829 15.7545 19.4261 15.8583 18.9612 15.8583V16.8583ZM20.6681 16.4297C21.1914 16.1418 21.6076 15.7365 21.9097 15.2209L21.047 14.7153C20.8358 15.0755 20.5511 15.3527 20.186 15.5536L20.6681 16.4297ZM21.9055 15.228C22.224 14.7045 22.3781 14.1139 22.3781 13.4708H21.3781C21.3781 13.9481 21.2657 14.3557 21.0512 14.7081L21.9055 15.228ZM22.3781 13.4708C22.3781 12.7484 22.2194 12.1114 21.8544 11.6049L21.0431 12.1896C21.2506 12.4775 21.3781 12.8895 21.3781 13.4708H22.3781ZM21.8578 11.6098C21.5208 11.1302 21.0879 10.7723 20.5623 10.5505L20.1734 11.4718C20.5164 11.6165 20.8041 11.8495 21.0396 12.1847L21.8578 11.6098ZM20.5713 10.5544C20.0761 10.3337 19.5627 10.2208 19.0353 10.2208V11.2208C19.4159 11.2208 19.791 11.3015 20.1644 11.4678L20.5713 10.5544ZM19.0353 10.2208C18.9425 10.2208 18.844 10.2276 18.7414 10.2394L18.8553 11.2329C18.9304 11.2242 18.9898 11.2208 19.0353 11.2208V10.2208ZM18.7983 10.2361C18.6905 10.2361 18.5851 10.2423 18.4827 10.2555L18.6106 11.2473C18.6661 11.2401 18.7285 11.2361 18.7983 11.2361V10.2361ZM18.4737 10.2567C18.4403 10.2617 18.4166 10.265 18.4012 10.267C18.3976 10.2674 18.3947 10.2678 18.3927 10.268C18.3905 10.2683 18.3897 10.2684 18.3898 10.2684C18.3899 10.2683 18.3905 10.2683 18.3915 10.2682C18.3925 10.2681 18.3942 10.268 18.3965 10.2678C18.3987 10.2676 18.4023 10.2674 18.407 10.2672C18.4112 10.267 18.4187 10.2667 18.4282 10.2667V11.2667C18.4726 11.2667 18.5215 11.2597 18.5292 11.2587C18.5533 11.2556 18.5839 11.2513 18.6195 11.246L18.4737 10.2567ZM18.4282 10.2667C18.442 10.2667 18.467 10.2693 18.4968 10.2816C18.527 10.294 18.5501 10.3115 18.5651 10.327L17.847 11.023C18.005 11.1859 18.2107 11.2667 18.4282 11.2667V10.2667ZM18.5951 10.3608C18.6141 10.3845 18.6243 10.4074 18.6291 10.4231C18.6335 10.4375 18.632 10.4417 18.632 10.4306H17.632C17.632 10.6124 17.677 10.8156 17.8171 10.9892L18.5951 10.3608ZM18.632 10.4306C18.632 10.4734 18.6211 10.5068 18.6116 10.5264L17.7117 10.0903C17.6627 10.1914 17.632 10.3062 17.632 10.4306H18.632ZM18.6116 10.5264C18.611 10.5276 18.6127 10.5239 18.6186 10.5148C18.6244 10.5058 18.6332 10.4933 18.6456 10.4772L17.8554 9.86447C17.8027 9.93233 17.7515 10.0082 17.7117 10.0903L18.6116 10.5264ZM18.6248 10.5023L21.7638 6.95789L21.0152 6.29489L17.8762 9.83934L18.6248 10.5023ZM20.9278 6.81818L21.0166 7.03207L21.9401 6.64849L21.8513 6.4346L20.9278 6.81818ZM21.4783 6.34028H16.7106V7.34028H21.4783V6.34028ZM16.7106 6.34028C16.7376 6.34028 16.7698 6.34592 16.8018 6.36008C16.833 6.3739 16.8529 6.39082 16.8624 6.40064L16.1443 7.09659C16.2896 7.24649 16.4851 7.34028 16.7106 7.34028V6.34028ZM16.8624 6.40064C16.872 6.4106 16.8868 6.42945 16.8984 6.45751C16.9103 6.48599 16.9145 6.51334 16.9145 6.53472H15.9145C15.9145 6.75236 15.9991 6.94679 16.1443 7.09658L16.8624 6.40064ZM16.9145 6.53472C16.9145 6.54261 16.9131 6.56889 16.8984 6.60429C16.8829 6.64172 16.8582 6.67507 16.8293 6.69995L16.1773 5.94171C15.9881 6.10444 15.9145 6.3253 15.9145 6.53472H16.9145ZM16.8624 6.66881C16.8529 6.67862 16.833 6.69555 16.8018 6.70937C16.7698 6.72353 16.7376 6.72917 16.7106 6.72917V5.72917C16.4851 5.72917 16.2896 5.82296 16.1443 5.97286L16.8624 6.66881ZM16.7106 6.72917H21.8337V5.72917H16.7106V6.72917ZM21.8337 6.72917C21.8416 6.72917 21.8056 6.73098 21.7532 6.70234C21.6925 6.66922 21.6486 6.61638 21.6262 6.56447L22.5446 6.16887C22.4828 6.02529 22.3771 5.90369 22.2326 5.82474C22.0962 5.75027 21.9541 5.72917 21.8337 5.72917V6.72917ZM21.6355 6.5847C21.6418 6.59787 21.6464 6.60814 21.6496 6.61575C21.6511 6.6195 21.6522 6.62236 21.653 6.62438C21.6538 6.6264 21.6541 6.62736 21.654 6.62731C21.654 6.62728 21.6536 6.62592 21.6529 6.62334C21.6522 6.62078 21.6512 6.61654 21.6501 6.61077C21.648 6.60019 21.6446 6.57901 21.6446 6.55H22.6446C22.6446 6.38564 22.577 6.23458 22.5354 6.14863L21.6355 6.5847ZM21.6446 6.55C21.6446 6.50716 21.6556 6.47377 21.6651 6.45419L22.565 6.89026C22.614 6.78919 22.6446 6.67432 22.6446 6.55H21.6446ZM21.6392 6.51851C21.6536 6.47418 21.6716 6.44659 21.678 6.43728C21.6852 6.42694 21.6881 6.42485 21.6819 6.43119L22.4 7.12714C22.4579 7.06745 22.5457 6.96544 22.5908 6.82593L21.6392 6.51851ZM21.6659 6.44855L18.5417 9.99299L19.2919 10.6542L22.4161 7.10978L21.6659 6.44855ZM19.0646 9.84597L18.7685 9.7543L18.4728 10.7096L18.7689 10.8013L19.0646 9.84597ZM19.1207 10.2319C19.1207 10.4557 18.9768 10.5771 18.9415 10.6045C18.9159 10.6242 18.8945 10.6361 18.8832 10.6419C18.8712 10.6481 18.8629 10.6514 18.8603 10.6524C18.8575 10.6535 18.8817 10.6449 18.9525 10.6312L18.7626 9.64938C18.6755 9.66623 18.5813 9.68815 18.4995 9.7198C18.4613 9.73456 18.395 9.76289 18.3295 9.8136C18.2744 9.85625 18.1207 9.99294 18.1207 10.2319H19.1207ZM18.9471 10.6322C19.1034 10.6037 19.2027 10.5944 19.2574 10.5944V9.59444C19.1146 9.59444 18.9474 9.6157 18.768 9.64837L18.9471 10.6322ZM19.2574 10.5944C19.6995 10.5944 20.1322 10.697 20.5605 10.9092L21.0043 10.0131C20.4455 9.73629 19.8616 9.59444 19.2574 9.59444V10.5944ZM20.564 10.9109C20.9791 11.1124 21.3199 11.4188 21.5889 11.8438L22.4339 11.309C22.0711 10.7359 21.5926 10.2987 21.0008 10.0113L20.564 10.9109ZM21.5927 11.8497C21.8523 12.2474 22 12.7769 22 13.4708H23C23 12.637 22.822 11.9035 22.4301 11.3031L21.5927 11.8497ZM22 13.4708C22 14.0935 21.8567 14.6165 21.5855 15.0575L22.4373 15.5814C22.8176 14.9631 23 14.2538 23 13.4708H22ZM21.5855 15.0575C21.3052 15.5132 20.9351 15.8644 20.4694 16.1177L20.9474 16.9962C21.5675 16.6588 22.0661 16.1849 22.4373 15.5814L21.5855 15.0575ZM20.4661 16.1196C20.01 16.3723 19.5114 16.5 18.9612 16.5V17.5C19.6745 17.5 20.3408 17.3323 20.9507 16.9943L20.4661 16.1196ZM18.9612 16.5C18.5983 16.5 18.2434 16.4349 17.894 16.3031L17.5409 17.2386C18.0009 17.4123 18.4753 17.5 18.9612 17.5V16.5ZM17.9042 16.307C17.5722 16.1733 17.2786 15.9685 17.0211 15.6856L16.2817 16.3588C16.6361 16.7482 17.0533 17.0424 17.5307 17.2346L17.9042 16.307ZM17.0104 15.6742C16.9999 15.6633 16.9966 15.6581 16.9973 15.6592L16.1574 16.2019C16.1976 16.2641 16.2437 16.32 16.2923 16.3702L17.0104 15.6742ZM17.0633 15.8128C17.0629 15.811 17.0627 15.8099 17.0626 15.8093C17.0626 15.8087 17.0625 15.8085 17.0625 15.8083H16.0625C16.0625 15.8899 16.0725 15.9701 16.0914 16.0483L17.0633 15.8128ZM17.0625 15.8083C17.0625 15.8298 17.0584 15.8515 17.051 15.8707C17.0439 15.889 17.0364 15.8981 17.036 15.8987L16.2668 15.2597C16.1438 15.4077 16.0625 15.5942 16.0625 15.8083H17.0625ZM17.036 15.8987C17.0256 15.9111 17.0037 15.9324 16.9683 15.9495C16.9322 15.9668 16.898 15.9722 16.8735 15.9722V14.9722C16.6287 14.9722 16.4163 15.0797 16.2668 15.2597L17.036 15.8987Z" fill="#292C35"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="expand-lines">
-    <path d="M18 2L6 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 22L6 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 14V19M12 19L15 16M12 19L9 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 10V5M12 5L15 8M12 5L9 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bold">
-    <path d="M12 11.6667H8M12 11.6667C12 11.6667 15.3333 11.6667 15.3333 8.33333C15.3333 5.00002 12 5 12 5C12 5 12 5 12 5H8.6C8.26863 5 8 5.26863 8 5.6V11.6667M12 11.6667C12 11.6667 16 11.6667 16 15.3333C16 19 12 19 12 19C12 19 12 19 12 19H8.6C8.26863 19 8 18.7314 8 18.4V11.6667" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="missing-font">
-    <path d="M3.46826 18.3744L4.53272 16.0325M14.1129 18.3744L13.0484 16.0325M13.0484 16.0325L8.79056 6.66528L4.53272 16.0325M13.0484 16.0325H4.53272" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.1772 8.79421C15.1772 5.06857 21.0318 5.0686 21.0318 8.79421C21.0318 11.4554 18.3706 10.9231 18.3706 14.1164" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18.3706 18.385L18.3813 18.3732" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="text-size">
-    <path d="M4 8L4 6L16 6V8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 6L10 18M10 18H12M10 18H8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 13.5L14 12L20 12V13.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 12V18M17 18H15.5M17 18H18.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="text">
-    <path d="M19 7V5L5 5V7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 5L12 19M12 19H10M12 19H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="align-right">
-    <path d="M7 10L21 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 6H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 18L21 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 14H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="compress-lines">
-    <path d="M18 2L6 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 22L6 22" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 5V10M12 10L15 7M12 10L9 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 19V14M12 14L15 17M12 14L9 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="edit-pencil">
-    <path d="M13.0207 5.82839L15.8491 2.99996L20.7988 7.94971L17.9704 10.7781M13.0207 5.82839L3.41405 15.435C3.22652 15.6225 3.12116 15.8769 3.12116 16.1421V20.6776H7.65669C7.92191 20.6776 8.17626 20.5723 8.3638 20.3847L17.9704 10.7781M13.0207 5.82839L17.9704 10.7781" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="text-alt">
-    <path d="M21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 9V7L17 7V9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 7V17M12 17H10M12 17H14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="scissor-alt">
-    <path d="M10.2361 8C10.7111 7.46924 11 6.76835 11 6C11 4.34315 9.65685 3 8 3C6.34315 3 5 4.34315 5 6C5 7.65685 6.34315 9 8 9C8.8885 9 9.68679 8.61375 10.2361 8ZM10.2361 8L20 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10.2361 16C10.7111 16.5308 11 17.2316 11 18C11 19.6569 9.65685 21 8 21C6.34315 21 5 19.6569 5 18C5 16.3431 6.34315 15 8 15C8.8885 15 9.68679 15.3863 10.2361 16ZM10.2361 16L20 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="edit">
-    <path d="M3 21L12 21H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12.2218 5.82839L15.0503 2.99996L20 7.94971L17.1716 10.7781M12.2218 5.82839L6.61522 11.435C6.42769 11.6225 6.32233 11.8769 6.32233 12.1421L6.32233 16.6776L10.8579 16.6776C11.1231 16.6776 11.3774 16.5723 11.565 16.3847L17.1716 10.7781M12.2218 5.82839L17.1716 10.7781" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bold-square-outline">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M12 12H9M12 12C12 12 14.5 12 14.5 9.5C14.5 7.00001 12 7 12 7C12 7 12 7 12 7H9.6C9.26863 7 9 7.26863 9 7.6V12M12 12C12 12 15 12 15 14.75C15 17.5 12 17.5 12 17.5C12 17.5 12 17.5 12 17.5H9.6C9.26863 17.5 9 17.2314 9 16.9V12" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="italic">
-    <path d="M11 5L14 5M17 5L14 5M14 5L10 19M10 19L7 19M10 19L13 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="align-center">
-    <path d="M3 6H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 14H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 10L18 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 18L18 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="sort-down">
-    <path d="M14 10L2 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 14H2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 18H2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 6L2 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 10V20M19 20L22 17M19 20L16 17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="sort-up">
-    <path d="M14 14L2 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 10H2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 6H2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 18H2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 14V4M19 4L22 7M19 4L16 7" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="align-left">
-    <path d="M3 10L17 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 6H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 18L17 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 14H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="git-branch">
-    <path d="M18 9C19.6569 9 21 7.65685 21 6C21 4.34315 19.6569 3 18 3C16.3431 3 15 4.34315 15 6C15 7.65685 16.3431 9 18 9Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 21C7.65685 21 9 19.6569 9 18C9 16.3431 7.65685 15 6 15C4.34315 15 3 16.3431 3 18C3 19.6569 4.34315 21 6 21Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 15V3" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 18C12.5 18 18 15.9 18 9.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="git-merge">
-    <path d="M18 21C19.6569 21 21 19.6569 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18C15 19.6569 16.3431 21 18 21Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 9C7.65685 9 9 7.65685 9 6C9 4.34315 7.65685 3 6 3C4.34315 3 3 4.34315 3 6C3 7.65685 4.34315 9 6 9ZM6 9V21M6 9C6 12.5 8.5 18 14.5 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="git-commit">
-    <path d="M12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 12H3" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 12H21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bell-notification">
-    <path d="M18.1336 11C18.7155 16.3755 21 18 21 18H3C3 18 6 15.8667 6 8.4C6 6.70261 6.63214 5.07475 7.75736 3.87452C8.88258 2.67428 10.4087 2 12 2C12.3373 2 12.6717 2.0303 13 2.08949" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 8C20.6569 8 22 6.65685 22 5C22 3.34315 20.6569 2 19 2C17.3431 2 16 3.34315 16 5C16 6.65685 17.3431 8 19 8Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13.73 21C13.5542 21.3031 13.3019 21.5547 12.9982 21.7295C12.6946 21.9044 12.3504 21.9965 12 21.9965C11.6496 21.9965 11.3054 21.9044 11.0018 21.7295C10.6982 21.5547 10.4458 21.3031 10.27 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble-error">
-    <path d="M9.5 14.5L11.9926 12M14.5 9.5L11.9926 12M11.9926 12L9.5 9.5M11.9926 12L14.5 14.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="message-alert">
-    <path d="M12 7V9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 13.01L12.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.2895V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V15C21 16.1046 20.1046 17 19 17H7.96125C7.35368 17 6.77906 17.2762 6.39951 17.7506L4.06852 20.6643C3.71421 21.1072 3 20.8567 3 20.2895Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble">
-    <path d="M17 12.5C17.2761 12.5 17.5 12.2761 17.5 12C17.5 11.7239 17.2761 11.5 17 11.5C16.7239 11.5 16.5 11.7239 16.5 12C16.5 12.2761 16.7239 12.5 17 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 12.5C12.2761 12.5 12.5 12.2761 12.5 12C12.5 11.7239 12.2761 11.5 12 11.5C11.7239 11.5 11.5 11.7239 11.5 12C11.5 12.2761 11.7239 12.5 12 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 12.5C7.27614 12.5 7.5 12.2761 7.5 12C7.5 11.7239 7.27614 11.5 7 11.5C6.72386 11.5 6.5 11.7239 6.5 12C6.5 12.2761 6.72386 12.5 7 12.5Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-outcome">
-    <path d="M16 5H22M22 5L19 8M22 5L19 2" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="mail">
-    <path d="M7 9L12 12.5L17 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 17V7C2 5.89543 2.89543 5 4 5H20C21.1046 5 22 5.89543 22 7V17C22 18.1046 21.1046 19 20 19H4C2.89543 19 2 18.1046 2 17Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-search">
-    <path d="M20.5 6.5L22 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 4.5C16 5.88071 17.1193 7 18.5 7C19.1916 7 19.8175 6.71921 20.2701 6.26541C20.7211 5.81319 21 5.18916 21 4.5C21 3.11929 19.8807 2 18.5 2C17.1193 2 16 3.11929 16 4.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bell">
-    <path d="M18 8.4C18 6.70261 17.3679 5.07475 16.2426 3.87452C15.1174 2.67428 13.5913 2 12 2C10.4087 2 8.88258 2.67428 7.75736 3.87452C6.63214 5.07475 6 6.70261 6 8.4C6 15.8667 3 18 3 18H21C21 18 18 15.8667 18 8.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13.73 21C13.5542 21.3031 13.3019 21.5547 12.9982 21.7295C12.6946 21.9044 12.3504 21.9965 12 21.9965C11.6496 21.9965 11.3054 21.9044 11.0018 21.7295C10.6982 21.5547 10.4458 21.3031 10.27 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-lines">
-    <path d="M8 10L12 10L16 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 14L10 14L12 14" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="multi-bubble">
-    <path d="M7.5 22C10.5376 22 13 19.5376 13 16.5C13 13.4624 10.5376 11 7.5 11C4.46243 11 2 13.4624 2 16.5C2 17.5018 2.26783 18.441 2.7358 19.25L2.275 21.725L4.75 21.2642C5.55898 21.7322 6.49821 22 7.5 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.2824 17.8978C16.2587 17.7405 17.1758 17.4065 18 16.9297L21.6 17.6L20.9297 14C21.6104 12.8233 22 11.4571 22 10C22 5.58172 18.4183 2 14 2C9.97262 2 6.64032 4.97598 6.08221 8.84884" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-download">
-    <path d="M19 2V8M19 8L22 5M19 8L16 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-upload">
-    <path d="M19 8V2M19 2L22 5M19 2L16 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="headset-help">
-    <path d="M20 11C20 6.58172 16.4183 3 12 3C7.58172 3 4 6.58172 4 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 15.4384V13.5616C2 12.6438 2.62459 11.8439 3.51493 11.6213L5.25448 11.1864C5.63317 11.0917 6 11.3781 6 11.7685V17.2315C6 17.6219 5.63317 17.9083 5.25448 17.8136L3.51493 17.3787C2.62459 17.1561 2 16.3562 2 15.4384Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M22 15.4384V13.5616C22 12.6438 21.3754 11.8439 20.4851 11.6213L18.7455 11.1864C18.3668 11.0917 18 11.3781 18 11.7685V17.2315C18 17.6219 18.3668 17.9083 18.7455 17.8136L20.4851 17.3787C21.3754 17.1561 22 16.3562 22 15.4384Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M20 18V18.5C20 19.6046 19.1046 20.5 18 20.5H14.5" stroke="black" stroke-width="1.5"></path>
-    <path d="M13.5 22H10.5C9.67157 22 9 21.3284 9 20.5C9 19.6716 9.67157 19 10.5 19H13.5C14.3284 19 15 19.6716 15 20.5C15 21.3284 14.3284 22 13.5 22Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble-warning">
-    <path d="M12 8L12 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16.01L12.01 15.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="mail-opened">
-    <path d="M7 12L12 15.5L17 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 20V9.13238C2 8.42985 2.3686 7.77884 2.97101 7.41739L10.971 2.61739C11.6044 2.23738 12.3956 2.23738 13.029 2.6174L21.029 7.4174C21.6314 7.77884 22 8.42985 22 9.13238V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-warning">
-    <path d="M18 2L18 5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 9.01L18.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble-check">
-    <path d="M8 12L11 15L16 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="message-text">
-    <path d="M7 12L17 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 8L13 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.2895V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V15C21 16.1046 20.1046 17 19 17H7.96125C7.35368 17 6.77906 17.2762 6.39951 17.7506L4.06852 20.6643C3.71421 21.1072 3 20.8567 3 20.2895Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="message">
-    <path d="M3 20.2895V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V15C21 16.1046 20.1046 17 19 17H7.96125C7.35368 17 6.77906 17.2762 6.39951 17.7506L4.06852 20.6643C3.71421 21.1072 3 20.8567 3 20.2895Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble-check-1">
-    <path d="M8 12L11 15L16 10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-error">
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17.1211 7.36398L19.2424 5.24266M19.2424 5.24266L21.3637 3.12134M19.2424 5.24266L17.1211 3.12134M19.2424 5.24266L21.3637 7.36398" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-star">
-    <path d="M17.3056 4.11325L18.2147 2.1856C18.3314 1.93813 18.6686 1.93813 18.7853 2.1856L19.6944 4.11325L21.7275 4.42427C21.9884 4.46418 22.0923 4.79977 21.9035 4.99229L20.4326 6.4917L20.7797 8.60999C20.8243 8.88202 20.5515 9.08946 20.3181 8.96099L18.5 7.96031L16.6819 8.96099C16.4485 9.08946 16.1757 8.88202 16.2203 8.60999L16.5674 6.4917L15.0965 4.99229C14.9077 4.79977 15.0116 4.46418 15.2725 4.42427L17.3056 4.11325Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="app-notification">
-    <path d="M19 8C20.6569 8 22 6.65685 22 5C22 3.34315 20.6569 2 19 2C17.3431 2 16 3.34315 16 5C16 6.65685 17.3431 8 19 8Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 12V15C21 18.3137 18.3137 21 15 21H9C5.68629 21 3 18.3137 3 15V9C3 5.68629 5.68629 3 9 3H12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bubble-income">
-    <path d="M22 5H16M16 5L19 2M16 5L19 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13 2.04938C12.6711 2.01672 12.3375 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22C17.5228 22 22 17.5228 22 12C22 11.6625 21.9833 11.3289 21.9506 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="bell-off">
-    <path d="M6.27049 6.5C6.09277 7.10971 6 7.74975 6 8.4C6 15.8667 3 18 3 18H18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7.75732 3.87452C8.88254 2.67428 10.4087 2 12 2C13.5913 2 15.1174 2.67428 16.2426 3.87452C17.3678 5.07475 18 6.70261 18 8.4C18 15.8667 21 18 21 18" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M13.73 21C13.5542 21.3031 13.3019 21.5547 12.9982 21.7295C12.6946 21.9044 12.3504 21.9965 12 21.9965C11.6496 21.9965 11.3054 21.9044 11.0018 21.7295C10.6982 21.5547 10.4458 21.3031 10.27 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 3L21 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-remove">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M9 12H12L15 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble-empty">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-bubble-question">
-    <path d="M9 9C9 5.49997 14.5 5.5 14.5 9C14.5 11.5 12 10.9999 12 13.9999" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 18.01L12.01 17.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="chat-add">
-    <path d="M9 12H12M15 12H12M12 12V9M12 12V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="percentage-square">
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M15.5 16C15.7761 16 16 15.7761 16 15.5C16 15.2239 15.7761 15 15.5 15C15.2239 15 15 15.2239 15 15.5C15 15.7761 15.2239 16 15.5 16Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.77614 9 9 8.77614 9 8.5C9 8.22386 8.77614 8 8.5 8C8.22386 8 8 8.22386 8 8.5C8 8.77614 8.22386 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 8L8 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="stats-report">
-    <path d="M10 9H6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 11C14.1193 11 13 9.88071 13 8.5C13 7.11929 14.1193 6 15.5 6C16.8807 6 18 7.11929 18 8.5C18 9.88071 16.8807 11 15.5 11Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 6H9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 18L13.5 15L11 17L6 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="reports">
-    <path d="M9 21H15M9 21V16M9 21H3.6C3.26863 21 3 20.7314 3 20.4V16.6C3 16.2686 3.26863 16 3.6 16H9M15 21V9M15 21H20.4C20.7314 21 21 20.7314 21 20.4V3.6C21 3.26863 20.7314 3 20.4 3H15.6C15.2686 3 15 3.26863 15 3.6V9M15 9H9.6C9.26863 9 9 9.26863 9 9.6V16" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="percentage">
-    <path d="M17 19C15.8954 19 15 18.1046 15 17C15 15.8954 15.8954 15 17 15C18.1046 15 19 15.8954 19 17C19 18.1046 18.1046 19 17 19Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 9C5.89543 9 5 8.10457 5 7C5 5.89543 5.89543 5 7 5C8.10457 5 9 5.89543 9 7C9 8.10457 8.10457 9 7 9Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M19 5L5 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="percentage-round">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15.5 16C15.7761 16 16 15.7761 16 15.5C16 15.2239 15.7761 15 15.5 15C15.2239 15 15 15.2239 15 15.5C15 15.7761 15.2239 16 15.5 16Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8.5 9C8.77614 9 9 8.77614 9 8.5C9 8.22386 8.77614 8 8.5 8C8.22386 8 8 8.22386 8 8.5C8 8.77614 8.22386 9 8.5 9Z" fill="black" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 8L8 16" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="report-columns">
-    <path d="M3 7.4V3.6C3 3.26863 3.26863 3 3.6 3H9.4C9.73137 3 10 3.26863 10 3.6V7.4C10 7.73137 9.73137 8 9.4 8H3.6C3.26863 8 3 7.73137 3 7.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 20.4V16.6C14 16.2686 14.2686 16 14.6 16H20.4C20.7314 16 21 16.2686 21 16.6V20.4C21 20.7314 20.7314 21 20.4 21H14.6C14.2686 21 14 20.7314 14 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M14 12.4V3.6C14 3.26863 14.2686 3 14.6 3H20.4C20.7314 3 21 3.26863 21 3.6V12.4C21 12.7314 20.7314 13 20.4 13H14.6C14.2686 13 14 12.7314 14 12.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 20.4V11.6C3 11.2686 3.26863 11 3.6 11H9.4C9.73137 11 10 11.2686 10 11.6V20.4C10 20.7314 9.73137 21 9.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="graph-down">
-    <path d="M20 20H4V4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 7L12 15L15 12L19.5 16.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="stat-up">
-    <path d="M16 20V12M16 12L19 15M16 12L13 15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 14L12 6L15 9L20 4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="stats-square-down">
-    <path d="M8 16L8 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16L12 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 16L16 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="graph-up">
-    <path d="M20 20H4V4" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M4 16.5L12 9L15 12L19.5 7.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="stat-down">
-    <path d="M4 10L12 18L15 15L20 20" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M16 4V12M16 12L19 9M16 12L13 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="stats-square-up">
-    <path d="M16 16L16 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16L12 11" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 16L8 13" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shop">
-    <path d="M3 9V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V9" stroke="black" stroke-width="1.5"></path>
-    <path d="M20.4849 3H16.4932L16.9932 8C16.9932 8 17.9932 9 19.4932 9C20.5702 9 21.3035 8.48445 21.6315 8.1937C21.7622 8.07782 21.81 7.90091 21.7813 7.72861L21.0767 3.50136C21.0285 3.21205 20.7782 3 20.4849 3Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16.4932 3L16.9932 8C16.9932 8 15.9932 9 14.4932 9C12.9932 9 11.9932 8 11.9932 8V3H16.4932Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M11.9932 3V8C11.9932 8 10.9932 9 9.49316 9C7.99316 9 6.99316 8 6.99316 8L7.49316 3H11.9932Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M7.49349 3H3.50177C3.20846 3 2.95815 3.21205 2.90993 3.50136L2.20539 7.72862C2.17667 7.90091 2.2245 8.07782 2.3552 8.1937C2.68312 8.48445 3.41644 9 4.49347 9C5.99347 9 6.99349 8 6.99349 8L7.49349 3Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="city">
-    <path d="M7 9.01L7.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 9.01L11.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 13.01L7.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 13.01L11.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 17.01L7.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M11 17.01L11.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M15 21H3.6C3.26863 21 3 20.7314 3 20.4V5.6C3 5.26863 3.26863 5 3.6 5H9V3.6C9 3.26863 9.26863 3 9.6 3H14.4C14.7314 3 15 3.26863 15 3.6V9M15 21H20.4C20.7314 21 21 20.7314 21 20.4V9.6C21 9.26863 20.7314 9 20.4 9H15M15 21V17M15 9V13M15 13H17M15 13V17M15 17H17" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="shop-alt">
-    <path d="M20.4849 3H16.4932L16.9932 8C16.9932 8 17.9932 9 19.4932 9C20.5702 9 21.3035 8.48445 21.6315 8.1937C21.7622 8.07782 21.81 7.90091 21.7813 7.72861L21.0767 3.50136C21.0285 3.21205 20.7782 3 20.4849 3Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M16.4932 3L16.9932 8C16.9932 8 15.9932 9 14.4932 9C12.9932 9 11.9932 8 11.9932 8V3H16.4932Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M11.9932 3V8C11.9932 8 10.9932 9 9.49316 9C7.99316 9 6.99316 8 6.99316 8L7.49316 3H11.9932Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M7.49349 3H3.50177C3.20846 3 2.95815 3.21205 2.90993 3.50136L2.20539 7.72862C2.17667 7.90091 2.2245 8.07782 2.3552 8.1937C2.68312 8.48445 3.41644 9 4.49347 9C5.99347 9 6.99349 8 6.99349 8L7.49349 3Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M3 9V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V9" stroke="black" stroke-width="1.5"></path>
-    <path d="M14.8335 21V15C14.8335 13.8954 13.9381 13 12.8335 13H10.8335C9.72893 13 8.8335 13.8954 8.8335 15V21" stroke="black" stroke-width="1.5" stroke-miterlimit="16"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="building">
-    <path d="M10 9.01L10.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 9.01L14.01 8.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 13.01L10.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 13.01L14.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M10 17.01L10.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 17.01L14.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 20.4V5.6C6 5.26863 6.26863 5 6.6 5H12V3.6C12 3.26863 12.2686 3 12.6 3H17.4C17.7314 3 18 3.26863 18 3.6V20.4C18 20.7314 17.7314 21 17.4 21H6.6C6.26863 21 6 20.7314 6 20.4Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="megaphone">
-    <path d="M14 14V6M14 14L20.1023 17.487C20.5023 17.7156 21 17.4268 21 16.9661V3.03391C21 2.57321 20.5023 2.28439 20.1023 2.51296L14 6M14 14H7C4.79086 14 3 12.2091 3 10V10C3 7.79086 4.79086 6 7 6H14" stroke="black" stroke-width="1.5"></path>
-    <path d="M7.75716 19.3001L7 14H11L11.6772 18.7401C11.8476 19.9329 10.922 21 9.71716 21C8.73186 21 7.8965 20.2755 7.75716 19.3001Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="printing-page">
-    <path d="M17.5714 18H20.4C20.7314 18 21 17.7314 21 17.4V11C21 8.79086 19.2091 7 17 7H7C4.79086 7 3 8.79086 3 11V17.4C3 17.7314 3.26863 18 3.6 18H6.42857" stroke="black" stroke-width="1.5"></path>
-    <path d="M8 7V3.6C8 3.26863 8.26863 3 8.6 3H15.4C15.7314 3 16 3.26863 16 3.6V7" stroke="black" stroke-width="1.5"></path>
-    <path d="M6.09794 20.3151L6.42868 18L6.92651 14.5151C6.96874 14.2196 7.22189 14 7.52048 14H16.4797C16.7783 14 17.0315 14.2196 17.0737 14.5151L17.5715 18L17.9023 20.3151C17.9539 20.6766 17.6734 21 17.3083 21H6.69191C6.32678 21 6.0463 20.6766 6.09794 20.3151Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M17 10.01L17.01 9.99889" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="wristwatch">
-    <path d="M16 16.4722V20C16 21.1045 15.1046 22 14 22H10C8.89543 22 8 21.1045 8 20V16.4722" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M8 7.52779V4C8 2.89543 8.89543 2 10 2H14C15.1046 2 16 2.89543 16 4V7.52779" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M18 12C18 8.68629 15.3137 6 12 6C8.68629 6 6 8.68629 6 12C6 15.3137 8.68629 18 12 18C15.3137 18 18 15.3137 18 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M14 12H12V10" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="tv">
-    <path d="M2 20V9C2 7.89543 2.89543 7 4 7H20C21.1046 7 22 7.89543 22 9V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M8.5 2.5L12 6L15.5 2.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="smartphone-device">
-    <path d="M12 16.01L12.01 15.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M7 19.4V4.6C7 4.26863 7.26863 4 7.6 4H16.4C16.7314 4 17 4.26863 17 4.6V19.4C17 19.7314 16.7314 20 16.4 20H7.6C7.26863 20 7 19.7314 7 19.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="hard-drive">
-    <path d="M10 17.01L10.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M6 17.01L6.01 16.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 13V20.4C2 20.7314 2.26863 21 2.6 21H21.4C21.7314 21 22 20.7314 22 20.4V13M2 13H22M2 13L4.87172 3.42759C4.94786 3.1738 5.18145 3 5.44642 3H18.5536C18.8185 3 19.0521 3.1738 19.1283 3.42759L22 13" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="printer">
-    <path d="M3 17H21M6 10V3.6C6 3.26863 6.26863 3 6.6 3H17.4C17.7314 3 18 3.26863 18 3.6V10M21 20.4V14C21 11.7909 19.2091 10 17 10H7C4.79086 10 3 11.7909 3 14V20.4C3 20.7314 3.26863 21 3.6 21H20.4C20.7314 21 21 20.7314 21 20.4Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M17 13.01L17.01 12.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="save-floppy-disk">
-    <path d="M3 19V5C3 3.89543 3.89543 3 5 3H16.1716C16.702 3 17.2107 3.21071 17.5858 3.58579L20.4142 6.41421C20.7893 6.78929 21 7.29799 21 7.82843V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M8.6 9H15.4C15.7314 9 16 8.73137 16 8.4V3.6C16 3.26863 15.7314 3 15.4 3H8.6C8.26863 3 8 3.26863 8 3.6V8.4C8 8.73137 8.26863 9 8.6 9Z" stroke="black" stroke-width="1.5"></path>
-    <path d="M6 13.6V21H18V13.6C18 13.2686 17.7314 13 17.4 13H6.6C6.26863 13 6 13.2686 6 13.6Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="computer">
-    <path d="M2 21L17 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M21 21L22 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 16.4V3.6C2 3.26863 2.26863 3 2.6 3H21.4C21.7314 3 22 3.26863 22 3.6V16.4C22 16.7314 21.7314 17 21.4 17H2.6C2.26863 17 2 16.7314 2 16.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="laptop">
-    <path d="M3.2 14.2222V4C3.2 2.89543 4.09543 2 5.2 2H18.8C19.9046 2 20.8 2.89543 20.8 4V14.2222M3.2 14.2222H20.8M3.2 14.2222L1.71969 19.4556C1.35863 20.7321 2.31762 22 3.64418 22H20.3558C21.6824 22 22.6414 20.7321 22.2803 19.4556L20.8 14.2222" stroke="black" stroke-width="1.5"></path>
-    <path d="M11 19L13 19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="modern-tv">
-    <path d="M7 21L17 21" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 16.4V3.6C2 3.26863 2.26863 3 2.6 3H21.4C21.7314 3 22 3.26863 22 3.6V16.4C22 16.7314 21.7314 17 21.4 17H2.6C2.26863 17 2 16.7314 2 16.4Z" stroke="black" stroke-width="1.5"></path>
-  </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="hesa-warning-outline">
-    <path d="M1.17272 12.3C1.06554 12.1144 1.06554 11.8856 1.17272 11.7L6.32631 2.77372C6.43349 2.58808 6.63156 2.47372 6.84592 2.47372H17.1531C17.3675 2.47372 17.5655 2.58808 17.6727 2.77372L22.8263 11.7C22.9335 11.8856 22.9335 12.1144 22.8263 12.3L17.6727 21.2263C17.5655 21.4119 17.3675 21.5263 17.1531 21.5263H6.84592C6.63156 21.5263 6.43349 21.4119 6.32631 21.2263L1.17272 12.3Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 8L12 12" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M12 16.01L12.01 15.9989" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="prohibition">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.141 5A9.97 9.97 0 0012 2C6.477 2 2 6.477 2 12a9.968 9.968 0 002.859 7M19.14 5A9.967 9.967 0 0122 12c0 5.523-4.477 10-10 10a9.97 9.97 0 01-7.141-3M19.14 5L4.86 19"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="lock">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 12h1.4a.6.6 0 01.6.6v6.8a.6.6 0 01-.6.6H6.6a.6.6 0 01-.6-.6v-6.8a.6.6 0 01.6-.6H8m8 0V8c0-1.333-.8-4-4-4S8 6.667 8 8v4m8 0H8"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="star-outline">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8.587 8.236l2.598-5.232a.911.911 0 011.63 0l2.598 5.232 5.808.844a.902.902 0 01.503 1.542l-4.202 4.07.992 5.75c.127.738-.653 1.3-1.32.952L12 18.678l-5.195 2.716c-.666.349-1.446-.214-1.319-.953l.992-5.75-4.202-4.07a.902.902 0 01.503-1.54l5.808-.845z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="link">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 11.998C14 9.506 11.683 7 8.857 7H7.143C4.303 7 2 9.238 2 11.998c0 2.378 1.71 4.368 4 4.873a5.3 5.3 0 001.143.124"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 11.998c0 2.491 2.317 4.997 5.143 4.997h1.714c2.84 0 5.143-2.237 5.143-4.997 0-2.379-1.71-4.37-4-4.874A5.304 5.304 0 0016.857 7"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="number">
+    <g>
+      <path fill="currentColor" d="M6.326 16.756l.351-.357-.35.357zm-.093-9.9l.254-.431-.754-.445v.876h.5zm.156.091l.272.42.677-.44-.695-.41-.254.43zM4.012 8.49l-.272-.42-.002.002.274.418zm-.419-.046l-.397.304.021.028.026.025.35-.357zm.078-.488l.236.44.018-.01.017-.01-.271-.42zm2.718-1.757l-.255-.431-.008.005-.009.006.272.42zm.14-.046v.5h.06l.059-.015-.12-.485zm.124 0l-.12.485.025.006.025.004.07-.495zm.17.107l-.414.28.013.018.013.017.388-.315zm-.03 10.496l.35.356-.35-.356zm3.39-.046l.393-.31-.392.31zm0-1.024l.374.332.01-.01.009-.012-.392-.31zm.684 0l-.414.28.019.028.021.024.374-.332zm0 1.024l-.392-.31-.012.014-.01.015.414.28zm3.965-.443l-.34.366.003.004.337-.37zm-1.212-2.002l-.477.148.001.006.476-.154zm0-5.53l-.476-.154v.004l.476.15zm1.212-1.986l.336.37.004-.004-.34-.366zm4.068 0l-.343.363.007.007.336-.37zm1.196 1.986l-.477.148.002.007.475-.155zm0 5.53l-.476-.153-.001.005.477.148zM18.9 16.267l.34.367-.34-.367zm-.388-.535l-.342-.365-.004.004.346.36zm.994-1.726l-.477-.149-.002.006.48.143zm0-5.027l-.48.142.003.006.477-.148zm-.994-1.71l-.346.36.009.008.337-.369zm-3.308 0l.342.364-.342-.365zm-.994 1.71l-.477-.148-.002.006.48.142zm0 5.027l-.479.142.002.006.477-.148zm.994 1.726l-.346.36.004.005.342-.365zm-8.645.615a.19.19 0 01.118.052l-.701.713c.162.16.37.235.583.235v-1zm.118.052a.216.216 0 01.056.143h-1a.79.79 0 00.243.57l.701-.713zm.056.143V6.856h-1v9.686h1zM5.98 7.286l.155.092.509-.861-.156-.092-.508.861zm.137-.758L3.74 8.07l.545.839L6.66 7.367l-.545-.84zM3.738 8.072c-.005.004 0 0 .017-.007a.26.26 0 01.087-.014v1a.813.813 0 00.445-.143l-.549-.836zm.104-.02a.17.17 0 01.102.036l-.701.713c.156.154.362.25.599.25v-1zm.149.09c-.01-.014-.01-.016-.005-.004A.21.21 0 014 8.215H3c0 .22.095.4.196.533l.795-.607zM4 8.214c0 .034-.01.081-.04.126-.027.041-.054.056-.053.055l-.473-.881a.782.782 0 00-.434.7h1zm-.058.16L6.66 6.62l-.543-.84L3.4 7.536l.543.84zm2.7-1.746a.29.29 0 01-.114.024v-1a.777.777 0 00-.394.115l.509.861zm.006.01a.244.244 0 01-.115 0l.239-.972a.756.756 0 00-.363 0l.239.971zm-.065.009a.256.256 0 01-.174-.108l.828-.56a.738.738 0 00-.515-.322l-.139.99zm-.148-.073a.239.239 0 01-.042-.078.14.14 0 01-.007-.039h1a.803.803 0 00-.175-.514l-.776.631zm-.05-.117v10.084h1V6.458h-1zm0 10.084a.216.216 0 01.057-.143l.701.713a.79.79 0 00.243-.57h-1zm.057-.143a.19.19 0 01.117-.052v1a.818.818 0 00.584-.235l-.701-.713zm4.052-.052c-.01 0 .001-.002.024.009a.156.156 0 01.058.044l-.785.62c.183.23.442.327.703.327v-1zm.082.053l.001.002v.001s-.002-.009-.002-.03h-1c0 .23.065.455.216.647l.785-.62zm-.001-.026v-.352h-1v.352h1zm0-.352c0-.03.004-.04.003-.037a.116.116 0 01-.02.033l-.748-.664a.984.984 0 00-.235.668h1zm0-.026a.156.156 0 01-.057.044c-.023.01-.034.009-.024.009v-1a.872.872 0 00-.703.327l.785.62zm-.08.053h.061v-1h-.062v1zm.061 0c.022 0 .012.003-.016-.009a.204.204 0 01-.087-.073l.828-.561c-.183-.27-.47-.357-.725-.357v1zm-.063-.03a.115.115 0 01-.014-.021l-.006-.013c-.001-.003.003.008.003.037h1a.984.984 0 00-.236-.668l-.747.664zm-.017.003v.352h1v-.352h-1zm0 .352c0 .02-.003.029-.003.03v-.002l.002-.002.784.62c.152-.192.217-.417.217-.646h-1zm-.023.055a.215.215 0 01.087-.073c.027-.012.038-.009.016-.009v1c.254 0 .542-.087.725-.357l-.828-.56zm.103-.082h-.062v1h.062v-1zm6.31.153c-.71 0-1.264-.209-1.698-.604l-.673.74c.643.584 1.446.864 2.371.864v-1zm-1.694-.6c-.465-.43-.828-1.019-1.076-1.788l-.952.307c.29.9.735 1.647 1.348 2.214l.68-.733zm-1.074-1.783c-.242-.78-.366-1.651-.366-2.617h-1c0 1.051.135 2.024.41 2.913l.956-.296zm-.366-2.617c0-.976.124-1.847.365-2.616l-.954-.299c-.276.881-.411 1.854-.411 2.915h1zm.364-2.612c.248-.769.61-1.35 1.072-1.77l-.673-.74c-.615.56-1.06 1.302-1.35 2.203l.951.307zm1.075-1.773c.436-.403.988-.615 1.695-.615v-1c-.928 0-1.733.287-2.374.882l.68.733zm1.695-.615c.72 0 1.269.213 1.691.612l.687-.727c-.634-.599-1.441-.885-2.378-.885v1zm1.698.619c.46.417.817.997 1.055 1.764l.955-.296c-.28-.904-.72-1.648-1.338-2.209l-.672.74zm1.057 1.77c.25.768.379 1.636.379 2.611h1c0-1.062-.14-2.037-.428-2.92l-.951.31zM20 11.5c0 .964-.129 1.833-.38 2.612l.952.307c.288-.892.428-1.866.428-2.919h-1zm-.381 2.617c-.238.768-.596 1.354-1.058 1.783l.68.733c.613-.569 1.053-1.317 1.333-2.22l-.955-.296zM18.56 15.9c-.422.39-.972.6-1.695.6v1c.934 0 1.74-.28 2.374-.866l-.68-.734zm-1.695.958c.778 0 1.455-.25 1.992-.765l-.692-.722c-.332.32-.753.487-1.3.487v1zm1.988-.761c.525-.492.895-1.152 1.131-1.95l-.958-.284c-.199.67-.49 1.16-.857 1.504l.684.73zm1.13-1.943c.245-.79.364-1.677.364-2.654h-1c0 .897-.11 1.681-.32 2.357l.956.297zm.364-2.654c0-.986-.119-1.878-.364-2.67l-.955.297c.21.676.319 1.465.319 2.373h1zm-.363-2.663c-.236-.797-.607-1.455-1.135-1.938l-.675.738c.362.332.653.815.852 1.484l.958-.284zm-1.127-1.93c-.537-.516-1.214-.765-1.992-.765v1c.547 0 .968.168 1.3.487l.692-.722zm-1.992-.765c-.778 0-1.458.249-2.004.761l.684.73c.345-.323.773-.491 1.32-.491v-1zm-2.004.761c-.513.482-.883 1.135-1.13 1.928l.956.296c.21-.673.502-1.16.858-1.494l-.684-.73zm-1.131 1.934c-.234.789-.347 1.679-.347 2.663h1c0-.91.105-1.701.306-2.379l-.959-.284zm-.347 2.663c0 .975.113 1.86.347 2.648l.959-.285c-.201-.678-.306-1.464-.306-2.363h-1zm.349 2.654c.246.792.615 1.448 1.125 1.939l.693-.722c-.36-.345-.654-.84-.863-1.514l-.955.297zm1.13 1.943c.545.512 1.225.761 2.003.761v-1c-.547 0-.975-.168-1.32-.49l-.684.729z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="settings">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 15a3 3 0 100-6 3 3 0 000 6z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.622 10.395l-1.097-2.65L20 6l-2-2-1.735 1.483-2.707-1.113L12.935 2h-1.954l-.632 2.401-2.645 1.115L6 4 4 6l1.453 1.789-1.08 2.657L2 11v2l2.401.655L5.516 16.3 4 18l2 2 1.791-1.46 2.606 1.072L11 22h2l.604-2.387 2.651-1.098C16.697 18.831 18 20 18 20l2-2-1.484-1.75 1.098-2.652 2.386-.62V11l-2.378-.605z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="download">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 20h12"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4v12m0 0l3.5-3.5M12 16l-3.5-3.5"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="magic-wand">
+    <g>
+      <g>
+        <path fill="currentColor" d="M17.541 9.082l-2.623-2.623a.634.634 0 00-.918 0L2.197 18.262a.634.634 0 000 .918l2.623 2.623a.648.648 0 00.459.197.648.648 0 00.459-.197L17.54 10a.634.634 0 000-.918zM5.279 20.426l-1.705-1.705 8.59-8.59 1.705 1.705-8.59 8.59zm9.508-9.508l-1.705-1.705 1.377-1.377 1.705 1.705-1.377 1.377z"></path>
+        <path fill="currentColor" d="M18.525 12.36a.634.634 0 00-.918 0 .634.634 0 000 .919l1.311 1.311a.647.647 0 00.46.197.647.647 0 00.458-.197.634.634 0 000-.918l-1.311-1.311z"></path>
+        <path fill="currentColor" d="M21.213 8.557h-1.64a.658.658 0 00-.655.656c0 .36.295.656.656.656h1.64c.36 0 .655-.295.655-.656a.658.658 0 00-.656-.656z"></path>
+        <path fill="currentColor" d="M18.066 6.59a.647.647 0 00.459-.197l1.279-1.278a.634.634 0 000-.918.634.634 0 00-.919 0l-1.278 1.278a.634.634 0 000 .918.648.648 0 00.459.197z"></path>
+        <path fill="currentColor" d="M14.656 4.95c.36 0 .655-.294.655-.655v-1.64A.658.658 0 0014.656 2a.658.658 0 00-.656.656v1.639c0 .36.295.656.656.656z"></path>
+        <path fill="currentColor" d="M10.721 6.394a.647.647 0 00.46.196.647.647 0 00.458-.196.634.634 0 000-.918l-1.278-1.312a.634.634 0 00-.919 0 .634.634 0 000 .918l1.28 1.312z"></path>
+      </g>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="server">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 18.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 6.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M2 9.4V2.6a.6.6 0 01.6-.6h18.8a.6.6 0 01.6.6v6.8a.6.6 0 01-.6.6H2.6a.6.6 0 01-.6-.6z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M2 21.4v-6.8a.6.6 0 01.6-.6h18.8a.6.6 0 01.6.6v6.8a.6.6 0 01-.6.6H2.6a.6.6 0 01-.6-.6z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="smartphone-device">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 16.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M7 19.4V4.6a.6.6 0 01.6-.6h8.8a.6.6 0 01.6.6v14.8a.6.6 0 01-.6.6H7.6a.6.6 0 01-.6-.6z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="bell">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 8.4c0-1.697-.632-3.325-1.757-4.525C15.117 2.675 13.59 2 12 2c-1.591 0-3.117.674-4.243 1.875C6.632 5.075 6 6.703 6 8.4 6 15.867 3 18 3 18h18s-3-2.133-3-9.6z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.73 21a1.999 1.999 0 01-3.46 0"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="integer">
+    <g>
+      <path fill="currentColor" d="M4.195 16.756l.359-.348-.36.348zm-.089-9.9l.263-.426-.763-.472v.898h.5zm.148.091l.282.413.636-.433-.655-.405-.263.425zM1.989 8.49l-.282-.413-.002.001.284.412zm-.4-.046l-.405.294.021.029.025.025.359-.348zm.074-.488l.245.435.018-.01.017-.012-.28-.413zm2.591-1.757l-.263-.426-.009.006-.009.006.281.414zm.133-.046v.5h.064l.061-.016-.125-.484zm.119 0l-.125.484.026.007.026.003.073-.494zm.163.107l-.42.271.011.018.013.017.396-.306zm-.03 10.496l.359.348-.359-.348zm9.689-.428l.359-.348-.359.348zm0 .443l.326.379.017-.015.016-.016-.359-.348zm-6.174.015l-.271.42.02.013.021.011.23-.444zm-.045-.458L7.732 16l-.018.02-.016.023.411.285zm3.48-4.003l-.373-.334-.005.006.378.328zm1.347-1.833l-.44-.237-.002.002.442.235zM9.96 6.825l.196.46-.196-.46zm-.888.565l-.337-.37-.008.008.345.362zm-.548.78l.46.197.002-.006-.462-.192zm-.133.198l.306.395.006-.004.006-.005-.318-.386zm-.385-.015l-.326.379.02.017.022.016.284-.412zm-.074-.29l.475.153.006-.018.004-.018-.485-.117zm.059-.169l-.453-.212-.005.01-.004.01.462.192zm.71-.931l-.329-.377-.006.005.335.372zm1.096-.688l.197.46.005-.003-.202-.457zm2.813.092l-.24.438.003.002.237-.44zm1.052 1.023l-.436.246.436-.246zm-1.585 5.302l-.373-.333-.007.008.38.325zm-3.183 3.727l-.404.294.372.513.412-.482-.38-.325zm-.133-.183v-.5h-.982l.577.794.405-.294zm8.23-.733l-.228.444.05.026.054.014.125-.484zm.149.122l-.385.32.006.006.005.006.374-.332zm.785.55l.185-.464-.185.464zm2.502-.183l-.241-.438-.004.002.245.436zm1.051-1.024l-.427-.26-.004.007.431.253zm-.03-3.07l-.408.287.003.005.406-.293zm-1.08-.887l-.204.457.01.004.194-.46zm-1.57-.275v.5h.029l.028-.003-.057-.497zm-.251.015l-.064-.496-.01.002.074.494zm-.34-.076l-.39.314.014.018.016.016.36-.348zm-.045-.367l-.45-.218.45.218zm.088-.137l-.374-.332-.01.013-.01.012.394.307zm3.14-3.545l.461-.191-.306-.738-.53.598.375.331zm.088.214v.5h.75l-.288-.692-.462.192zm-4.975-.091l-.359.348.36-.348zm0-.428l.326.379.017-.015.016-.016-.359-.348zm5.582.046l-.459.197.005.01.005.01.45-.217zm.03.305l-.45-.218-.015.031-.01.034.475.153zm-.074.107l-.36-.348-.007.009-.008.009.375.33zm-3.124 3.545l-.148.477.309.096.214-.243-.375-.33zm-.296-.092h-.5v.369l.352.109.148-.478zm.237-.092l-.09-.492-.005.001.095.491zm1.924.321l-.221.448.003.002.218-.45zm1.23 1.115l-.423.268.004.006.418-.274zm0 3.743l.425.262-.426-.262zm-1.304 1.238l-.239-.44-.003.003.242.437zm-2.99.214l-.187.464.01.004.177-.468zm-1.067-.749l.37-.336-.005-.006-.006-.006-.359.348zm-.074-.091l-.486.117.02.083.046.07.42-.27zm.074-.352l-.384-.32.384.32zm-12.234.768a.206.206 0 01.137.06l-.718.697a.796.796 0 00.58.243v-1zm.137.06a.205.205 0 01.052.134h-1c0 .218.085.413.23.563l.718-.696zm.052.135V6.856h-1v9.686h1zM3.843 7.28l.148.091.526-.85-.148-.092-.526.85zm.13-.747L1.707 8.077l.563.827L4.536 7.36l-.563-.826zM1.705 8.078c-.012.009.032-.027.12-.027v1a.79.79 0 00.447-.149l-.567-.824zm.12-.027c.025 0 .054.006.08.018.026.012.04.024.043.027l-.718.696a.82.82 0 00.596.26v-1zm.168.1c-.01-.014-.008-.016-.005-.006.005.011.012.036.012.07H1c0 .213.088.39.184.523l.81-.588zM2 8.214a.227.227 0 01-.092.176l-.49-.871A.784.784 0 001 8.215h1zm-.057.154l2.592-1.757-.562-.827-2.59 1.757.56.827zm2.574-1.745l-.007.004a.308.308 0 01-.122.025v-1a.755.755 0 00-.397.12l.526.85zm-.005.013a.267.267 0 01-.131 0l.25-.968a.733.733 0 00-.369 0l.25.968zm-.08.01a.274.274 0 01-.183-.116l.84-.543a.726.726 0 00-.51-.33l-.146.99zm-.159-.08a.235.235 0 01-.04-.077c-.005-.02-.005-.032-.005-.032h1a.813.813 0 00-.164-.505l-.79.613zm-.045-.109v10.084h1V6.458h-1zm0 10.084a.204.204 0 01.052-.134l.718.695a.797.797 0 00.23-.561h-1zm.052-.134a.206.206 0 01.137-.06v1c.217 0 .423-.081.581-.244l-.718-.696zm9.84.328a.229.229 0 01-.151-.06l.718-.696a.78.78 0 00-.566-.244v1zm-.151-.06a.204.204 0 01-.052-.134h1a.797.797 0 00-.23-.562l-.718.696zm-.052-.134c0-.009.001-.03.011-.055a.195.195 0 01.04-.064l.719.696a.815.815 0 00.23-.577h-1zm.085-.15a.187.187 0 01.119-.045v1a.808.808 0 00.533-.197l-.652-.758zm.119-.045H8.405v1h5.716v-1zm-5.716 0a.043.043 0 01-.022-.005l-.459.889c.15.077.313.116.481.116v-1zm.02.019a.263.263 0 01.095.11c.017.037.015.06.015.05h-1c0 .235.084.51.348.68l.542-.84zm.11.16a.229.229 0 01-.013.08c-.005.013-.008.015-.002.006l-.822-.569a.85.85 0 00-.163.483h1zm-.048.13l3.48-4.003-.756-.656L7.731 16l.756.656zm3.474-3.997c.627-.7 1.105-1.344 1.417-1.933l-.884-.469c-.26.491-.68 1.069-1.277 1.734l.744.668zm1.415-1.93c.32-.594.504-1.17.504-1.72h-1c0 .328-.112.74-.384 1.246l.88.474zm.504-1.72c0-.83-.253-1.545-.796-2.093l-.71.704c.325.328.506.774.506 1.39h1zm-.796-2.093c-.545-.55-1.265-.805-2.102-.805v1c.623 0 1.069.183 1.392.51l.71-.705zm-2.102-.805a3.09 3.09 0 00-1.217.254l.39.92c.278-.118.552-.174.827-.174v-1zm-1.217.254c-.385.163-.73.382-1.03.656l.674.739c.213-.195.46-.353.747-.475l-.391-.92zm-1.038.663a2.775 2.775 0 00-.665.95l.924.383c.089-.214.229-.417.43-.608l-.689-.725zm-.662.944a.37.37 0 01-.02.037l.006-.006a.187.187 0 01.021-.02l.637.77c.135-.111.219-.258.274-.386l-.918-.395zm.02 0a.301.301 0 01.107-.054c.02-.005.03-.004.02-.004v1a.78.78 0 00.485-.15l-.612-.791zm.128-.058c.004 0 .015 0 .03.005a.163.163 0 01.046.022l-.567.824c.151.103.321.149.49.149v-1zm.119.06a.276.276 0 01.085.196h-1c0 .231.105.426.263.562l.652-.758zm.085.195c0-.001 0 .017-.01.047l-.951-.307a.846.846 0 00-.04.26h1zm0 .011l.008-.024.028-.07-.924-.383a1.696 1.696 0 00-.083.242l.971.235zm.026-.073c.126-.268.32-.526.594-.773l-.67-.743a3.45 3.45 0 00-.829 1.09l.905.426zm.588-.768a3.6 3.6 0 01.963-.604l-.393-.92a4.6 4.6 0 00-1.229.771l.659.753zm.968-.607c.359-.158.7-.232 1.027-.232v-1c-.482 0-.96.11-1.431.318l.404.914zm1.027-.232c.545 0 .987.109 1.343.305l.482-.876c-.531-.293-1.146-.429-1.825-.429v1zm1.347.307c.373.2.654.475.853.829l.871-.491a3.087 3.087 0 00-1.25-1.219l-.474.88zm.853.829c.197.35.306.78.306 1.313h1c0-.67-.138-1.278-.435-1.804l-.87.49zm.306 1.313c0 .418-.127.904-.418 1.466l.888.459c.341-.66.53-1.304.53-1.925h-1zm-.418 1.466c-.29.56-.755 1.209-1.41 1.944l.747.665c.687-.772 1.21-1.489 1.551-2.15l-.888-.46zm-1.417 1.952l-3.183 3.728.76.65 3.184-3.729-.76-.649zm-2.399 3.758l-.133-.183-.809.588.134.183.808-.588zm-.537.611h5.36v-1H8.76v1zm8.113-.764a.245.245 0 01-.111-.025l.458-.889a.756.756 0 00-.348-.086v1zm-.007.015a.371.371 0 01-.127-.06c-.007-.007-.002-.004.015.018l.77-.64a1.132 1.132 0 00-.148-.15.678.678 0 00-.26-.136l-.25.968zm-.1-.03c.268.303.595.531.972.682l.371-.928a1.554 1.554 0 01-.596-.418l-.748.664zm.972.682c.374.15.784.22 1.222.22v-1c-.332 0-.613-.053-.85-.148l-.372.928zm1.222.22c.621 0 1.196-.141 1.711-.432l-.49-.871a2.437 2.437 0 01-1.22.302v1zm1.707-.43c.523-.287.94-.692 1.242-1.208l-.863-.506c-.211.36-.496.638-.861.839l.482.876zm1.238-1.201a3.322 3.322 0 00.472-1.757h-1c0 .477-.112.885-.327 1.237l.855.52zm.472-1.757c0-.723-.159-1.36-.524-1.866l-.81.585c.207.287.334.7.334 1.28h1zm-.52-1.861a2.986 2.986 0 00-1.296-1.06l-.389.922c.343.145.631.378.867.713l.818-.575zm-1.287-1.056a3.743 3.743 0 00-1.536-.333v1c.38 0 .756.08 1.13.247l.406-.914zm-1.536-.333c-.093 0-.191.007-.294.018l.114.994c.075-.009.135-.012.18-.012v-1zm-.237.015a2.47 2.47 0 00-.315.02l.128.991c.055-.007.117-.01.187-.01v-1zm-.324.02a3.935 3.935 0 01-.073.011l-.008.001h-.003.007a.25.25 0 01.031-.001v1c.045 0 .093-.007.101-.008a4.76 4.76 0 00.09-.013l-.145-.99zm-.046.01c.014 0 .039.003.069.016.03.012.053.03.068.045l-.718.696a.797.797 0 00.581.244v-1zm.167.095c.02.023.03.046.034.062.005.014.003.019.003.008h-1c0 .181.045.385.185.558l.778-.628zm.037.07c0 .042-.01.076-.02.095l-.9-.436a.777.777 0 00-.08.34h1zm-.02.095c-.001.002 0-.002.007-.011a.572.572 0 01.027-.038l-.79-.613a1.292 1.292 0 00-.144.226l.9.436zm.013-.024l3.139-3.544-.749-.663-3.139 3.544.749.663zm2.303-3.684l.089.214.923-.384-.089-.213-.923.383zm.55-.478h-4.767v1h4.767v-1zm-4.767 0a.229.229 0 01.151.06l-.718.697a.78.78 0 00.567.243v-1zm.151.06c.01.01.025.03.036.058a.204.204 0 01.017.077h-1c0 .217.084.412.23.562l.717-.696zm.053.135a.19.19 0 01-.017.07.258.258 0 01-.069.095l-.652-.758a.766.766 0 00-.262.593h1zm-.053.134a.229.229 0 01-.152.06v-1a.78.78 0 00-.566.244l.718.696zm-.151.06h5.123v-1H16.71v1zm5.123 0c.008 0-.028.002-.08-.027a.294.294 0 01-.128-.138l.919-.395a.707.707 0 00-.312-.344.826.826 0 00-.4-.096v1zm-.198-.144l.014.03.003.01.001.002-.001-.004a.315.315 0 01-.008-.073h1a.949.949 0 00-.11-.401l-.9.436zm.009-.035c0-.043.01-.076.02-.096l.9.436a.777.777 0 00.08-.34h-1zm-.006-.031a.316.316 0 01.039-.082c.007-.01.01-.012.004-.006l.718.696a.79.79 0 00.19-.301l-.95-.307zm.027-.07l-3.124 3.544.75.661 3.124-3.544-.75-.661zm-2.601 3.397l-.297-.092-.295.956.296.091.296-.955zm.056.386a.471.471 0 01-.238.41.235.235 0 01-.023.01c-.002.002.022-.007.093-.02l-.19-.983a1.581 1.581 0 00-.264.07.673.673 0 00-.17.095.53.53 0 00-.208.418h1zm-.174.4c.156-.028.256-.038.31-.038v-1c-.142 0-.31.022-.489.054l.18.984zm.31-.038c.442 0 .875.103 1.303.315l.444-.896a3.897 3.897 0 00-1.747-.419v1zm1.307.317c.415.201.756.508 1.025.933l.845-.535A3.477 3.477 0 0021 10.011l-.437.9zm1.029.939c.26.397.407.927.407 1.62h1c0-.833-.178-1.567-.57-2.167l-.837.547zM22 13.47c0 .623-.143 1.146-.415 1.587l.852.524c.38-.618.563-1.327.563-2.11h-1zm-.415 1.587a2.93 2.93 0 01-1.116 1.06l.478.88a3.93 3.93 0 001.49-1.416l-.852-.524zm-1.119 1.063c-.456.252-.955.38-1.505.38v1c.713 0 1.38-.168 1.99-.506l-.485-.874zm-1.505.38c-.363 0-.718-.065-1.067-.197l-.353.936c.46.173.934.261 1.42.261v-1zm-1.057-.193a2.388 2.388 0 01-.883-.621l-.74.673c.355.39.772.683 1.25.876l.373-.928zm-.894-.633c-.01-.01-.013-.016-.013-.015l-.84.543c.04.062.087.118.135.168l.718-.696zm.053.139v-.004h-1c0 .08.01.161.028.24l.972-.236zm0-.005a.176.176 0 01-.012.063c-.007.018-.015.027-.015.028l-.77-.64a.851.851 0 00-.203.55h1zm-.027.09a.224.224 0 01-.163.074v-1a.777.777 0 00-.606.288l.769.639z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="right-circle">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 8.5l3.5 3.5-3.5 3.5"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="report-columns">
+    <g>
+      <path stroke="currentColor" stroke-width="1.5" d="M3 7.4V3.6a.6.6 0 01.6-.6h5.8a.6.6 0 01.6.6v3.8a.6.6 0 01-.6.6H3.6a.6.6 0 01-.6-.6z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M14 20.4v-3.8a.6.6 0 01.6-.6h5.8a.6.6 0 01.6.6v3.8a.6.6 0 01-.6.6h-5.8a.6.6 0 01-.6-.6z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M14 12.4V3.6a.6.6 0 01.6-.6h5.8a.6.6 0 01.6.6v8.8a.6.6 0 01-.6.6h-5.8a.6.6 0 01-.6-.6z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M3 20.4v-8.8a.6.6 0 01.6-.6h5.8a.6.6 0 01.6.6v8.8a.6.6 0 01-.6.6H3.6a.6.6 0 01-.6-.6z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="plus">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 12h6m6 0h-6m0 0V6m0 6v6"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="check">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 13l4 4L19 7"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="nav-arrow-right">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 6l6 6-6 6"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="more-vert">
+    <g>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 12.5a.5.5 0 100-1 .5.5 0 000 1z"></path>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18.5a.5.5 0 100-1 .5.5 0 000 1z"></path>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6.5a.5.5 0 100-1 .5.5 0 000 1z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="code-brackets">
+    <g>
+      <g>
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 21H8c-1.105 0-2-.894-2-1.999V14c0-1-1.5-2-1.5-2S6 11 6 10V5a2 2 0 012-2h1"></path>
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 21h1c1.105 0 2-.894 2-1.999V14c0-1 1.5-2 1.5-2S18 11 18 10V5a2 2 0 00-2-2h-1"></path>
+      </g>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="warning-circled-outline">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 7v6"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 17.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="4x4-cell">
+    <g>
+      <path stroke="currentColor" stroke-width="1.5" d="M21 3.6V12h-9V3h8.4a.6.6 0 01.6.6z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M21 20.4V12h-9v9h8.4a.6.6 0 00.6-.6z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M3 12V3.6a.6.6 0 01.6-.6H12v9H3z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M3 12v8.4a.6.6 0 00.6.6H12v-9H3z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="edit-pencil">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.02 5.828L15.85 3l4.949 4.95-2.828 2.828m-4.95-4.95l-9.607 9.607a1 1 0 00-.293.707v4.536h4.536a1 1 0 00.707-.293l9.607-9.607m-4.95-4.95l4.95 4.95"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="trash">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11v9.4a.6.6 0 01-.6.6H5.6a.6.6 0 01-.6-.6V11"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 17v-6"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 17v-6"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 7h-5M3 7h5m0 0V3.6a.6.6 0 01.6-.6h6.8a.6.6 0 01.6.6V7M8 7h8"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="text">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 7V5H5v2"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 5v14m0 0h-2m2 0h2"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="info-empty">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 11.5v5"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 7.51l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="page">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 21.4V2.6a.6.6 0 01.6-.6h11.652a.6.6 0 01.424.176l3.148 3.148A.6.6 0 0120 5.75V21.4a.6.6 0 01-.6.6H4.6a.6.6 0 01-.6-.6z"></path>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 5.4V2.354a.354.354 0 01.604-.25l3.292 3.292a.353.353 0 01-.25.604H16.6a.6.6 0 01-.6-.6z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 10h8"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 18h8"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 14h4"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="check-circled-outline">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 12.5l3 3 7-7"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="circle-filled">
+    <g>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="language">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2 12c0 5.523 4.477 10 10 10s10-4.477 10-10S17.523 2 12 2 2 6.477 2 12z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 2.05S16 6 16 12c0 6-3 9.95-3 9.95"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 21.95S8 18 8 12c0-6 3-9.95 3-9.95"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.63 15.5h18.74"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.63 8.5h18.74"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="warning-triangle-outline">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-width="1.5" d="M20.043 21H3.957c-1.538 0-2.5-1.664-1.734-2.997l8.043-13.988c.77-1.337 2.699-1.337 3.468 0l8.043 13.988C22.543 19.336 21.58 21 20.043 21z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-width="1.5" d="M12 9v4"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 17.01l.01-.011"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="eye-empty">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14a2 2 0 100-4 2 2 0 000 4z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 12c-1.889 2.991-5.282 6-9 6s-7.111-3.009-9-6c2.299-2.842 4.992-6 9-6s6.701 3.158 9 6z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="filter">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 3h16a1 1 0 011 1v1.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707v6.305a1 1 0 01-1.243.97l-2-.5a1 1 0 01-.757-.97v-5.805a1 1 0 00-.293-.707L3.293 6.293A1 1 0 013 5.586V4a1 1 0 011-1z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="question-mark-circle">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 9c0-3.5 5.5-3.5 5.5 0 0 2.5-2.5 2-2.5 5"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18.01l.01-.011"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="data-transfer-both">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20V4m0 0l3 3m-3-3l-3 3"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 4v16m0 0l3-3m-3 3l-3-3"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="calendar">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 4V2m0 2v2m0-2h-4.5M3 10v9a2 2 0 002 2h14a2 2 0 002-2v-9H3z"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 10V6a2 2 0 012-2h2"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 2v4"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 10V6a2 2 0 00-2-2h-.5"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="nav-arrow-down">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 9l6 6 6-6"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="table-rows">
+    <g>
+      <path stroke="currentColor" stroke-width="1.5" d="M3 12h18M3 12v4.5M3 12V7.5M21 12v4.5m0-4.5V7.5m-18 9v3.9a.6.6 0 00.6.6h16.8a.6.6 0 00.6-.6v-3.9m-18 0h18m0-9V3.6a.6.6 0 00-.6-.6H3.6a.6.6 0 00-.6.6v3.9m18 0H3"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="upload">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 20h12"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 16V4m0 0l3.5 3.5M12 4L8.5 7.5"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="switch-on-outline">
+    <g>
+      <path fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 13a1 1 0 100-2 1 1 0 000 2z"></path>
+      <path stroke="currentColor" stroke-width="1.5" d="M17 17H7A5 5 0 017 7h10a5 5 0 010 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="clock-outline">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6h6"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="building">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 9.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 9.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 13.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 13.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 17.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 17.01l.01-.011"></path>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 20.4V5.6a.6.6 0 01.6-.6H12V3.6a.6.6 0 01.6-.6h4.8a.6.6 0 01.6.6v16.8a.6.6 0 01-.6.6H6.6a.6.6 0 01-.6-.6z"></path>
+    </g>
+  </symbol>
+  <symbol fill="none" viewBox="0 0 24 24" id="minus">
+    <g>
+      <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 12h12"></path>
+    </g>
   </symbol>
 </svg>


### PR DESCRIPTION
**Issue**

NA

**Description**

- I removed unused icons from the sprite
- I added `currentColor` property to each path and group inside SVG to allow the color customization

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hevltahxqr.chromatic.com)
<!-- Storybook placeholder end -->
