### PR TITLE
Update design of the save bar to match new mockup

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
@@ -18,10 +18,10 @@
 
 <div *ngIf="isOpen()" [@slideUpDown] [@.disabled]="creationMode">
   <mat-card class="save-bar__content" [class.mat-elevation-z3]="creationMode" [class.mat-elevation-z6]="!creationMode">
-    <div class="save-bar__content__label">{{ creationMode ? '' : 'Please note you have unsaved modifications.' }}</div>
+    <div class="save-bar__content__label">{{ creationMode ? '' : 'You have unsaved changes' }}</div>
     <div>
-      <button *ngIf="!creationMode" class="save-bar__content__reset-button" mat-stroked-button type="button" (click)="onResetClicked()">
-        Reset
+      <button *ngIf="!creationMode" class="save-bar__content__reset-button" mat-button type="button" (click)="onResetClicked()">
+        Discard
       </button>
       <button
         class="save-bar__content__submit-button"
@@ -31,7 +31,7 @@
         [type]="form ? 'submit' : 'button'"
         (click)="onSubmitClicked()"
       >
-        {{ creationMode ? 'Create' : 'Save Changes' }}
+        {{ creationMode ? 'Create' : 'Save' }}
       </button>
     </div>
   </mat-card>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.scss
@@ -22,7 +22,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
 :host {
   display: block;
-  height: 50px;
+  height: 68px;
   margin-top: 32px;
   z-index: 1000;
 }
@@ -38,11 +38,11 @@ $typography: map.get(gio.$mat-theme, typography);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 32px;
+  padding: 16px 24px;
   height: 100%;
 
   &__label {
-    @include mat.typography-level($typography, body-2);
+    @include mat.typography-level($typography, body-1);
   }
 
   &__reset-button {
@@ -50,21 +50,13 @@ $typography: map.get(gio.$mat-theme, typography);
   }
 
   &__submit-button {
-    background-color: mat.get-color-from-palette(gio.$mat-success-palette, 'default');
-    color: mat.get-color-from-palette(gio.$mat-success-palette, 'default-contrast');
-
-    &:hover:enabled {
-      background-color: mat.get-color-from-palette(gio.$mat-success-palette, 'darker');
-      color: mat.get-color-from-palette(gio.$mat-success-palette, 'darker-contrast');
-    }
-
     &.invalid {
-      background-color: mat.get-color-from-palette(gio.$mat-success-palette, 'lighter');
-      color: mat.get-color-from-palette(gio.$mat-success-palette, 'lighter-contrast');
+      background-color: mat.get-color-from-palette(gio.$mat-primary-palette, 'lighter');
+      color: mat.get-color-from-palette(gio.$mat-primary-palette, 'lighter-contrast');
 
       &:hover:enabled {
-        background-color: mat.get-color-from-palette(gio.$mat-success-palette, 'default');
-        color: mat.get-color-from-palette(gio.$mat-success-palette, 'default-contrast');
+        background-color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default');
+        color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default-contrast');
       }
     }
   }


### PR DESCRIPTION
**Issue**

NA

**Description**

Update design of the save bar to match new mockup available on [Figma](https://www.figma.com/file/XvLO9G5fPRIrfyhLjPg6a2/Gravitee_Lib_elemZ?node-id=1221%3A2315).

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/4112568/154240135-3124766b-fc2e-4dea-b507-f7db1f0a58c3.png">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-klgnhltchv.chromatic.com)
<!-- Storybook placeholder end -->
