### PR TITLE
feat: add form-tags-input component

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.stories.mdx
@@ -1,0 +1,37 @@
+import { Meta, Story } from '@storybook/addon-docs';
+
+<Meta title="Components / Form Tags Input / README" />
+
+# Form Tags Input
+
+Documentation and examples for Form Tags Input, a component to specify a list of values based on material chip-list
+
+## Demo
+
+<Story id="components-form-tags-input--with-initial-value"/>
+
+## Usage
+
+**Inputs**
+ - `ariaLabel`: `string` - Aria label for the input.
+ - `addOnBlur`: `boolean` - Whether or not the chipEnd event will be emitted when the input is blurred.
+ - `tagValidationHook`: `function(tag, validationCallback())` - Function called each time a tag is added. Useful to hook inside the addition process to, for instance, have custom validation in the components using `gio-form-tags-input`.
+ - `placeholder`: `string` - The input's placeholder text.
+ - `required`: `boolean` - Whether the input requires to have at least one value.
+ - `disabled`: `boolean` - Whether the input is disabled.
+
+Example:
+
+```html
+
+what about this one :
+
+<mat-form-field appearance="fill">
+  <mat-label>Tags</mat-label>
+  <gio-form-tags-input
+    [required]="required"
+    [placeholder]="Add a tag"
+    [formControl]="tagsControl"
+  ></gio-form-tags-input>
+</mat-form-field>
+```

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-chip-list #tagChipList [attr.aria-label]="ariaLabel" multiple [disabled]="disabled">
+  <mat-chip *ngFor="let tag of value" [selectable]="false" [removable]="!disabled" (removed)="removeChipToFormControl(tag)">
+    {{ tag }}
+    <mat-icon matChipRemove>cancel</mat-icon>
+  </mat-chip>
+  <input
+    *ngIf="!disabled"
+    #tagInput
+    [placeholder]="placeholder"
+    [matChipInputFor]="tagChipList"
+    [matChipInputAddOnBlur]="addOnBlur"
+    (matChipInputTokenEnd)="addChipToFormControl($event)"
+  />
+</mat-chip-list>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.scss
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { Component, DoCheck, ElementRef, HostBinding, Input, OnDestroy, Optional, Self, ViewChild } from '@angular/core';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { MatFormFieldControl } from '@angular/material/form-field';
+import { isEmpty } from 'lodash';
+import { Subject } from 'rxjs';
+
+export type Tags = Array<string>;
+
+@Component({
+  selector: 'gio-form-tags-input',
+  templateUrl: './gio-form-tags-input.component.html',
+  styleUrls: ['./gio-form-tags-input.component.scss'],
+  providers: [
+    {
+      provide: MatFormFieldControl,
+      useExisting: GioFormTagsInputComponent,
+    },
+  ],
+})
+export class GioFormTagsInputComponent implements MatFormFieldControl<Tags>, ControlValueAccessor, DoCheck, OnDestroy {
+  private static nextId = 0;
+
+  public _onChange: (_tags: Tags | null) => void = () => ({});
+
+  public _onTouched: () => void = () => ({});
+  private touched = false;
+
+  @Input('aria-label')
+  public ariaLabel = '';
+
+  @Input()
+  public addOnBlur = true;
+
+  /**
+   * Function called each time a tag is added, it can be used to hook inside the
+   * addition process to, for instance, have custom validation in the components
+   * using `gio-form-tags-input`.
+   *
+   * Parameters are:
+   * - `tag`: The value of the tag to add
+   * - `validationCb`: The callback function to call when validation is done. If
+   * called with `true` it will add the tag, otherwise it will just ignore it
+   */
+  @Input()
+  public tagValidationHook: ((tag: string, validationCb: (shouldAddTag: boolean) => void) => void) | undefined = undefined;
+
+  @ViewChild('tagInput')
+  public tagInput: ElementRef<HTMLInputElement> | null = null;
+
+  // From ControlValueAccessor interface
+  public get value(): Tags | null {
+    return this._value;
+  }
+
+  public set value(_tags: Tags | null) {
+    this._value = _tags;
+    this._onChange(_tags);
+    this.stateChanges.next();
+  }
+
+  private _value: Tags | null = null;
+
+  // From ControlValueAccessor interface
+  public stateChanges = new Subject<void>();
+
+  // From ControlValueAccessor interface
+  @HostBinding('id')
+  public id = `gio-form-tags-input-${GioFormTagsInputComponent.nextId++}`;
+
+  // From ControlValueAccessor interface
+  @Input()
+  public get placeholder(): string {
+    return this._placeholder;
+  }
+
+  public set placeholder(plh: string) {
+    this._placeholder = plh;
+    this.stateChanges.next();
+  }
+
+  private _placeholder = '';
+
+  // From ControlValueAccessor interface
+  public focused = false;
+
+  // From ControlValueAccessor interface
+  public get empty(): boolean {
+    return isEmpty(this.value) && isEmpty(this.tagInput?.nativeElement?.value);
+  }
+
+  // From ControlValueAccessor interface
+  @HostBinding('class.floating')
+  public get shouldLabelFloat(): boolean {
+    return this.focused || !this.empty;
+  }
+
+  // From ControlValueAccessor interface
+  @Input()
+  public get required(): boolean {
+    return this._required;
+  }
+
+  public set required(req: boolean) {
+    this._required = coerceBooleanProperty(req);
+    this.stateChanges.next();
+  }
+
+  private _required = false;
+
+  // From ControlValueAccessor interface
+  @Input()
+  public get disabled(): boolean {
+    return this._disabled || (this.ngControl && this.ngControl.disabled === true);
+  }
+
+  public set disabled(dis: boolean) {
+    this._disabled = coerceBooleanProperty(dis);
+    this.stateChanges.next();
+  }
+
+  private _disabled = false;
+
+  // From ControlValueAccessor interface
+  public get errorState(): boolean {
+    return (
+      this.touched &&
+      // if required check if is empty
+      ((this.required && this.empty) ||
+        // if there is a touched control check if there is an error
+        (this.ngControl && this.ngControl.touched === true && !!this.ngControl.errors))
+    );
+  }
+
+  // From ControlValueAccessor interface
+  public controlType?: string;
+
+  // From ControlValueAccessor interface
+  public autofilled?: boolean;
+
+  // From ControlValueAccessor interface
+  public userAriaDescribedBy?: string;
+
+  constructor(
+    // From ControlValueAccessor interface
+    @Optional() @Self() public readonly ngControl: NgControl,
+    private readonly elRef: ElementRef,
+    private readonly fm: FocusMonitor,
+  ) {
+    // Replace the provider from above with this.
+    if (this.ngControl != null) {
+      // Setting the value accessor directly (instead of using
+      // the providers) to avoid running into a circular import.
+      this.ngControl.valueAccessor = this;
+    }
+
+    fm.monitor(elRef.nativeElement, true).subscribe(origin => {
+      this.focused = !!origin;
+      this._onTouched();
+      this.touched = true;
+      this.stateChanges.next();
+    });
+  }
+
+  public ngDoCheck(): void {
+    // sync control touched with local touched
+    if (this.ngControl != null && this.touched !== this.ngControl.touched) {
+      this.touched = this.ngControl.touched === true;
+      this.stateChanges.next();
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.stateChanges.complete();
+    this.fm.stopMonitoring(this.elRef.nativeElement);
+  }
+
+  // From ControlValueAccessor interface
+  public writeValue(value: string[]): void {
+    this._value = value;
+  }
+
+  // From ControlValueAccessor interface
+  public registerOnChange(fn: (tags: Tags | null) => void): void {
+    this._onChange = fn;
+  }
+
+  // From ControlValueAccessor interface
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  // From ControlValueAccessor interface
+  @HostBinding('attr.aria-describedby')
+  public describedBy = '';
+
+  public setDescribedByIds(ids: string[]): void {
+    this.describedBy = ids.join(' ');
+  }
+
+  // From ControlValueAccessor interface
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  public onContainerClick(_event: MouseEvent): void {}
+
+  public addChipToFormControl(event: MatChipInputEvent): void {
+    const input = event.chipInput?.inputElement;
+    const tagToAdd = (event.value ?? '').trim();
+
+    if (isEmpty(tagToAdd)) {
+      return;
+    }
+
+    // Add the tag only if shouldAddTag in validationCb return true
+    // Set default callback if not defined
+    const tagValidationHook = this.tagValidationHook ?? ((_, validationCb) => validationCb(true));
+
+    const validationCb = (shouldAddTag: boolean) => {
+      // Add new Tag in form control
+      if (shouldAddTag) {
+        // Delete Tag if already existing
+        const formControlValue = [...(this.value ?? [])].filter(v => v !== tagToAdd);
+
+        this.value = [...formControlValue, tagToAdd];
+      }
+    };
+
+    // Reset the input value
+    if (input) {
+      input.value = '';
+    }
+
+    tagValidationHook(tagToAdd, validationCb);
+  }
+
+  public removeChipToFormControl(tag: string): void {
+    this.value = [...(this.value ?? [])].filter(v => v !== tag);
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.harness.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.harness.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BaseHarnessFilters, ComponentHarness, parallel, TestKey } from '@angular/cdk/testing';
+import { MatChipListHarness } from '@angular/material/chips/testing';
+
+export type GioFormTagsInputHarnessFilters = BaseHarnessFilters;
+
+export class GioFormTagsInputHarness extends ComponentHarness {
+  public static hostSelector = 'gio-form-tags-input';
+
+  protected getMatChipListHarness = this.locatorFor(MatChipListHarness);
+
+  public async getTags(): Promise<string[]> {
+    const matChipList = await this.getMatChipListHarness();
+
+    const chips = await matChipList.getChips();
+
+    return parallel(() => chips.map(async chip => await chip.getText()));
+  }
+
+  public async addTag(tag: string, separatorKey: TestKey | 'blur' = TestKey.ENTER): Promise<void> {
+    const matChipList = await this.getMatChipListHarness();
+
+    const chipInput = await matChipList.getInput();
+    await chipInput.setValue(tag);
+    if (separatorKey === 'blur') {
+      await chipInput.blur();
+    } else {
+      await chipInput.sendSeparatorKey(separatorKey);
+    }
+  }
+
+  public async removeTag(tag: string): Promise<void> {
+    const matChipList = await this.getMatChipListHarness();
+
+    const chips = await matChipList.getChips({ text: tag });
+    if (chips[0]) {
+      await chips[0].remove();
+    }
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { GioFormTagsInputHarness } from './gio-form-tags-input.harness';
+import { GioFormTagsInputModule } from './gio-form-tags-input.module';
+
+@Component({
+  template: `
+    <mat-form-field appearance="fill">
+      <mat-label>My tags</mat-label>
+      <gio-form-tags-input
+        [required]="required"
+        [placeholder]="placeholder"
+        [formControl]="tagsControl"
+        [tagValidationHook]="tagValidationHook"
+      ></gio-form-tags-input>
+      <mat-error>Error</mat-error>
+    </mat-form-field>
+  `,
+})
+class TestComponent {
+  public required = false;
+  public placeholder = 'Add a tag';
+  public tagValidationHook: ((tag: string, validationCb: (shouldAddTag: boolean) => void) => void) | undefined = undefined;
+
+  public tagsControl = new FormControl(null, Validators.required);
+}
+
+describe('GioFormTagsInputModule', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [NoopAnimationsModule, GioFormTagsInputModule, MatFormFieldModule, ReactiveFormsModule],
+    });
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should display tags from formControl', async () => {
+    fixture.detectChanges();
+
+    const formTagsInputHarness = await loader.getHarness(GioFormTagsInputHarness);
+    expect(await formTagsInputHarness.getTags()).toEqual([]);
+
+    component.tagsControl.setValue(['tag1', 'tag2']);
+
+    expect(await formTagsInputHarness.getTags()).toEqual(['tag1', 'tag2']);
+  });
+
+  it('should add / remove tags to formControl', async () => {
+    fixture.detectChanges();
+
+    const formTagsInputHarness = await loader.getHarness(GioFormTagsInputHarness);
+
+    await formTagsInputHarness.addTag('tag1');
+    await formTagsInputHarness.addTag('tag2', 'blur');
+
+    expect(await formTagsInputHarness.getTags()).toEqual(['tag1', 'tag2']);
+    expect(component.tagsControl.value).toEqual(['tag1', 'tag2']);
+
+    await formTagsInputHarness.removeTag('tag1');
+
+    expect(await formTagsInputHarness.getTags()).toEqual(['tag2']);
+    expect(component.tagsControl.value).toEqual(['tag2']);
+  });
+
+  it('should add tag with confirm function before added', async () => {
+    component.tagValidationHook = (tag: string, validationCb: (shouldAddTag: boolean) => void) => {
+      validationCb(tag.startsWith('*'));
+    };
+    fixture.detectChanges();
+
+    const formTagsInputHarness = await loader.getHarness(GioFormTagsInputHarness);
+
+    await formTagsInputHarness.addTag('*');
+    await formTagsInputHarness.addTag('tag2');
+
+    expect(await formTagsInputHarness.getTags()).toEqual(['*']);
+    expect(component.tagsControl.value).toEqual(['*']);
+  });
+
+  it('should handle error state with control', async () => {
+    component.tagsControl.addValidators(Validators.required);
+    fixture.detectChanges();
+
+    const formTagsInputHarness = await loader.getHarness(GioFormTagsInputHarness);
+
+    await formTagsInputHarness.addTag('A');
+    await formTagsInputHarness.removeTag('A');
+
+    const matFormFieldHarness = await loader.getHarness(MatFormFieldHarness);
+
+    expect(await matFormFieldHarness.hasErrors()).toBe(true);
+    expect(component.tagsControl.valid).toEqual(false);
+  });
+
+  it('should handle disabled state with control', async () => {
+    component.tagsControl.disable();
+    fixture.detectChanges();
+
+    const matFormFieldHarness = await loader.getHarness(MatFormFieldHarness);
+
+    expect(await matFormFieldHarness.isDisabled()).toBe(true);
+  });
+
+  it('should update error state when control is touched', async () => {
+    component.tagsControl.addValidators(Validators.required);
+    fixture.detectChanges();
+    const matFormFieldHarness = await loader.getHarness(MatFormFieldHarness);
+
+    expect(await matFormFieldHarness.hasErrors()).toBe(false);
+
+    component.tagsControl.markAsTouched();
+
+    expect(await matFormFieldHarness.hasErrors()).toBe(true);
+  });
+});

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { A11yModule } from '@angular/cdk/a11y';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+
+import { GioFormTagsInputComponent } from './gio-form-tags-input.component';
+
+@NgModule({
+  imports: [CommonModule, A11yModule, MatChipsModule, MatInputModule, FormsModule, MatIconModule],
+  declarations: [GioFormTagsInputComponent],
+  exports: [GioFormTagsInputComponent],
+  entryComponents: [GioFormTagsInputComponent],
+})
+export class GioFormTagsInputModule {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/dist/ts3.9/client/preview/types-7-0';
+import { action } from '@storybook/addon-actions';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { GioFormTagsInputComponent, Tags } from './gio-form-tags-input.component';
+import { GioFormTagsInputModule } from './gio-form-tags-input.module';
+
+export default {
+  title: 'Components / Form Tags Input',
+  component: GioFormTagsInputComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [BrowserAnimationsModule, GioFormTagsInputModule, FormsModule, ReactiveFormsModule, MatFormFieldModule],
+    }),
+  ],
+  render: () => ({}),
+  argTypes: {
+    tags: {
+      control: { type: 'array' },
+      description: '',
+      table: { type: { summary: 'string[]' }, defaultValue: [] },
+    },
+    placeholder: {
+      control: { type: 'string' },
+    },
+    required: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    disabled: {
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+  },
+} as Meta;
+
+export const WithoutFormField: Story = {
+  render: ({ tags = ['A', 'B'], placeholder, required, disabled }) => ({
+    template: `
+      <gio-form-tags-input [disabled]="disabled" [required]="required" [placeholder]="placeholder" [ngModel]="tags" (ngModelChange)="onTagsChange($event)">
+      </gio-form-tags-input>
+    `,
+    props: {
+      tags,
+      placeholder,
+      required,
+      disabled,
+      onTagsChange: (e: Tags[]) => action('Tags')(e),
+    },
+  }),
+  args: {},
+};
+
+export const EmptyModel: Story = {
+  render: ({ tags, placeholder, required, disabled }) => ({
+    template: `
+    <mat-form-field appearance="fill" style="width:100%">
+      <mat-label>Tags</mat-label>
+      <gio-form-tags-input 
+        [disabled]="disabled" 
+        [required]="required" 
+        [placeholder]="placeholder" 
+        [ngModel]="tags" 
+        (ngModelChange)="onTagsChange($event)"
+      >
+      </gio-form-tags-input>
+    </mat-form-field>
+    `,
+    props: {
+      tags,
+      placeholder,
+      required,
+      disabled,
+      onTagsChange: (e: Tags[]) => action('Tags')(e),
+    },
+  }),
+  args: {},
+};
+
+export const WithInitialValue: Story = {
+  render: EmptyModel.render,
+  args: {
+    tags: ['A', 'B'],
+    required: false,
+    placeholder: 'Add a tag',
+  },
+};
+
+export const Required: Story = {
+  render: EmptyModel.render,
+  args: {
+    tags: ['A', 'B'],
+    required: true,
+    placeholder: 'Add a tag',
+  },
+};
+
+export const Disabled: Story = {
+  render: EmptyModel.render,
+  args: {
+    tags: ['A', 'B'],
+    required: false,
+    disabled: true,
+    placeholder: 'Add a tag',
+  },
+};
+
+export const FormControlEmpty: Story = {
+  render: ({ tags, placeholder, required, disabled, tagValidationHook }) => {
+    const tagsControl = new FormControl({ value: tags, disabled });
+
+    tagsControl.valueChanges.subscribe(value => {
+      action('Tags')(value);
+    });
+
+    return {
+      template: `
+      <mat-form-field appearance="fill" style="width:100%">
+        <mat-label>Labels</mat-label>
+        <gio-form-tags-input
+          [required]="required" 
+          [placeholder]="placeholder" 
+          [formControl]="tagsControl"
+          [tagValidationHook]="tagValidationHook"
+        >
+        </gio-form-tags-input>
+      </mat-form-field>
+      `,
+      props: {
+        tags,
+        placeholder,
+        required,
+        disabled,
+        tagsControl,
+        tagValidationHook,
+      },
+    };
+  },
+  args: {},
+};
+
+export const WithTagValidationHook: Story = {
+  render: FormControlEmpty.render,
+  args: {
+    tags: ['A'],
+    disabled: false,
+    placeholder: 'Add a tag',
+    tagValidationHook: (tag: string, validationCb: (shouldAddTag: boolean) => void) => {
+      validationCb(confirm(`Add "${tag}" tag ?`));
+    },
+  },
+  argTypes: {
+    tagValidationHook: {
+      control: { type: 'function' },
+    },
+  },
+};


### PR DESCRIPTION
**Description**

Component `form-tags-input` (already present in [gravitee-api-management](https://github.com/gravitee-io/gravitee-api-management/tree/master/gravitee-apim-console-webui/src/shared/components/gio-form-tags-input)) is common to multiple Gravitee products.

This PR relocates it, without modifying the actual behaviour.

**Additional context**
[API-Management Storybook](https://612657caa8e859003a8a6430-cacbubogdv.chromatic.com/?path=/story/shared-form-tags-input--without-form-field)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-ospqcoobma.chromatic.com)
<!-- Storybook placeholder end -->
