### PR TITLE
fix: add form-tags-input to public api

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
@@ -21,6 +21,10 @@ export * from './gio-save-bar/gio-save-bar.component';
 export * from './gio-save-bar/gio-save-bar.module';
 export * from './gio-save-bar/gio-save-bar.harness';
 
+export * from './gio-form-tags-input/gio-form-tags-input.component';
+export * from './gio-form-tags-input/gio-form-tags-input.module';
+export * from './gio-form-tags-input/gio-form-tags-input.harness';
+
 export * from './gio-banner/gio-banner.component';
 export * from './gio-banner/gio-banner.module';
 


### PR DESCRIPTION
**Description**

Add the new component `form-tags-input` to ui-particles public api
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-shlaqiafwy.chromatic.com)
<!-- Storybook placeholder end -->
