### PR TITLE
fix: adjust h5 default bottom margin

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.harness.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.harness.ts
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-import { BaseHarnessFilters, ComponentHarness, parallel, TestKey } from '@angular/cdk/testing';
+import { BaseHarnessFilters, ComponentHarness, HarnessPredicate, parallel, TestKey } from '@angular/cdk/testing';
 import { MatChipListHarness } from '@angular/material/chips/testing';
 
 export type GioFormTagsInputHarnessFilters = BaseHarnessFilters;
 
 export class GioFormTagsInputHarness extends ComponentHarness {
   public static hostSelector = 'gio-form-tags-input';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `GioFormColorInputHarness` that meets
+   * certain criteria.
+   *
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  public static with(options: GioFormTagsInputHarnessFilters = {}): HarnessPredicate<GioFormTagsInputHarness> {
+    return new HarnessPredicate(GioFormTagsInputHarness, options);
+  }
 
   protected getMatChipListHarness = this.locatorFor(MatChipListHarness);
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-h5.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-h5.scss
@@ -21,5 +21,7 @@
   .mat-typography h5,
   .mat-typography .mat-h5 {
     @include typo.subtitle-typography;
+
+    margin-bottom: 4px;
   }
 }


### PR DESCRIPTION
**Description**

According to the mock-ups ([here](https://www.figma.com/file/XvLO9G5fPRIrfyhLjPg6a2/Gravitee_Lib_elemZ?node-id=516%3A1844)), `<h5>` bottom margin should be 4px

Bonus in this PR: adds the `with` method to form-tags-input`s harness to allow filtering.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-zjzalxsnux.chromatic.com)
<!-- Storybook placeholder end -->
