### PR TITLE
fix(gio-badge): remove text-transform

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
@@ -37,7 +37,6 @@
     font-weight: mat.font-weight(theme.$mat-typography, caption);
     line-height: 16px;
     text-align: center;
-    text-transform: capitalize;
     vertical-align: middle;
     white-space: nowrap;
 


### PR DESCRIPTION
**Issue**

N.A. 

**Description**

In `gio-badge`, the text is transformed with capitalize. But this component is often used as a readonly viewer for `gio-form-tags-input` where no text transformation is applied. 
To be more consistent, we remove the text transformation on `gio-badge`

