### PR TITLE
feat: override mat-button style

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/index.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/index.scss
@@ -20,3 +20,4 @@
 @forward 'mat-h5';
 @forward 'mat-tabs';
 @forward 'mat-option';
+@forward 'mat-button';

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.scss
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use '@angular/material' as mat;
+@mixin mat-button() {
+  .mat-button.mat-button-base,
+  .mat-stroked-button.mat-button-base,
+  .mat-raised-button.mat-button-base,
+  .mat-flat-button.mat-button-base {
+    border-radius: 8px;
 
-@use './gio-mat-theme-variable' as theme-variable;
+    &:hover {
+      filter: brightness(115%);
+      transition: all 0.3s linear;
+    }
+  }
 
-@use './mat-override' as override;
-
-// Config material theme with gio theme
-@mixin mat-theme() {
-  @include mat.core(theme-variable.$mat-typography);
-  @include mat.all-component-themes(theme-variable.$mat-theme);
-
-  // Gio overrides
-  @include override.mat-h5;
-  @include override.mat-form-field;
-  @include override.mat-table;
-  @include override.mat-card;
-  @include override.mat-list;
-  @include override.mat-tabs;
-  @include override.mat-option;
-  @include override.mat-button;
+  .mat-icon-button.mat-button-base:hover {
+    filter: brightness(115%);
+    transition: all 0.3s linear;
+  }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/types-7-0';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+export default {
+  title: 'Material Override',
+  decorators: [
+    moduleMetadata({
+      imports: [MatButtonModule, MatIconModule],
+    }),
+  ],
+  render: () => ({}),
+} as Meta;
+
+export const MatButton: Story = {
+  render: () => ({
+    template: `
+          <h3>Buttons</h3>
+          <div>
+              <div>
+                  <h4>Default</h4>
+                  <div class="button-container">
+                      <button mat-button>Basic</button>
+                      <button mat-button color="primary">Primary</button>
+                      <button mat-button color="accent">Accent</button>
+                      <button mat-button color="warn">Warn</button>
+                      <button mat-button disabled>Disabled</button>
+                  </div>
+              </div>
+              
+              <div>
+                  <h4>Raised</h4>
+                  <div class="button-container">
+                      <button mat-raised-button>Basic</button>
+                      <button mat-raised-button color="primary">Primary</button>
+                      <button mat-raised-button color="accent">Accent</button>
+                      <button mat-raised-button color="warn">Warn</button>
+                      <button mat-raised-button disabled>Disabled</button>
+                  </div>
+              </div>
+              
+              <div>
+                  <h4>Flat</h4>
+                  <div class="button-container">
+                      <button mat-flat-button>Basic</button>
+                      <button mat-flat-button color="primary">Primary</button>
+                      <button mat-flat-button color="accent">Accent</button>
+                      <button mat-flat-button color="warn">Warn</button>
+                      <button mat-flat-button disabled>Disabled</button>
+                  </div>
+              </div>
+              
+              <div>
+                  <h4>Flat</h4>
+                  <div class="button-container">
+                      <button mat-stroked-button>Basic</button>
+                      <button mat-stroked-button color="primary">Primary</button>
+                      <button mat-stroked-button color="accent">Accent</button>
+                      <button mat-stroked-button color="warn">Warn</button>
+                      <button mat-stroked-button disabled>Disabled</button>
+                  </div>
+              </div>
+              
+              <div>
+                  <h4>Icon</h4>
+                  <div class="button-container">
+                      <button mat-icon-button aria-label="Example icon button with a vertical three dot icon">
+                          <mat-icon>more_vert</mat-icon>
+                      </button>
+                      <button mat-icon-button color="primary" aria-label="Example icon button with a vertical three dot icon">
+                          <mat-icon>more_vert</mat-icon>
+                      </button>
+                      <button mat-icon-button color="accent" aria-label="Example icon button with a vertical three dot icon">
+                          <mat-icon>more_vert</mat-icon>
+                      </button>
+                      <button mat-icon-button color="warn" aria-label="Example icon button with a vertical three dot icon">
+                          <mat-icon>more_vert</mat-icon>
+                      </button>
+                      <button mat-icon-button disabled aria-label="Example icon button with a vertical three dot icon">
+                          <mat-icon>more_vert</mat-icon>
+                      </button>
+                  </div>
+              </div>
+          </div>
+        `,
+    styles: [
+      `
+            .button-container {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-around;
+                width: 500px;
+                margin-bottom: 16px;
+            }
+       `,
+    ],
+  }),
+};


### PR DESCRIPTION
**Description**

Here are some small changes made on cockpit mat-buttons we will certainly find everywhere in a near future.
In this pull request I override the default radius and brightness of the mat buttons

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-lalwftrwky.chromatic.com)
<!-- Storybook placeholder end -->
