### PR TITLE
fix: use default color and not the contrast color for content palette

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
@@ -53,12 +53,12 @@ $mat-accent-palette: mat.define-palette(
 $mat-content-palette: mat.define-palette(
   (
     darker: #100c27,
-    default: #fff,
+    default: #9698a2,
     disabled: #e0e0e0,
     lighter: #fff,
     contrast: (
       darker: #eee,
-      default: #9698a2,
+      default: #fff,
       disabled: #a6a6a6,
       lighter: #100c27,
     ),


### PR DESCRIPTION
**Issue**

na

**Description**

use default color and not the contrast color for content palette because there is no contrast for this color

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-miubqabgur.chromatic.com)
<!-- Storybook placeholder end -->
