### PR TITLE
feat: add gio-confirm-dialog component

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/README.stories.mdx
@@ -1,0 +1,43 @@
+import { Meta, Story } from '@storybook/addon-docs';
+
+<Meta title="Components / Confirm dialog / README" />
+
+# Confirm dialog
+
+Documentation and examples for Confirm dialog, a component to asking for confirmation.
+
+## Demo
+
+<Story id="components-confirm-dialog--custom"/>
+
+## Usage
+
+**Inputs**
+ - `title`: `string` - The dialog title.
+ - `content`: `string` - The dialog content override.
+ - `confirmButton`: `string` - The dialog confirmation button override.
+ - `confirmCancel`: `string` - The dialog cancel button override.
+
+Example:
+
+```typescript
+
+this.matDialog
+  .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+    data: {
+      title: 'title override',
+      content: 'content override',
+      confirmButton: 'confirmButton override',
+      cancelButton: 'cancelButton override',
+    },
+    role: 'alertdialog',
+    id: 'confirmDialog',
+  })
+  .afterClosed()
+  .pipe(
+    tap(confirmed => {
+      action('confirmed?')(confirmed);
+    }),
+  )
+  .subscribe((confirmed => {});
+```

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.html
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title class="confirm-dialog__title">{{ title }}</h2>
+
+<mat-dialog-content *ngIf="content" class="confirm-dialog__content">
+  <p [innerHTML]="content"></p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="confirm-dialog__actions">
+  <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">
+    {{ cancelButton }}
+  </button>
+  <button class="confirm-dialog__confirm-button" color="warn" mat-raised-button [mat-dialog-close]="true" cdkFocusInitial>
+    {{ confirmButton }}
+  </button>
+</mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@use '../../scss' as gio;
+
+.confirm-dialog {
+  &__content {
+    color: mat.get-color-from-palette(gio.$mat-content-palette);
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+import { GioConfirmDialogComponent, GioConfirmDialogData } from './gio-confirm-dialog.component';
+import { GioConfirmDialogModule } from './gio-confirm-dialog.module';
+import { GioConfirmDialogHarness } from './gio-confirm-dialog.harness';
+
+@Component({
+  selector: 'gio-confirm-dialog-test',
+  template: `<button mat-button id="open-confirm-dialog" (click)="openConfirmDialog()">Open confirm dialog</button>`,
+})
+class TestComponent {
+  public confirmed?: boolean;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openConfirmDialog() {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        data: {},
+        role: 'alertdialog',
+        id: 'confirmDialog',
+      })
+      .afterClosed()
+      .subscribe(confirmed => (this.confirmed = confirmed));
+  }
+}
+
+describe('GioConfirmDialogComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [GioConfirmDialogModule, NoopAnimationsModule],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  });
+
+  it('should return true with the user confirms', async () => {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+
+    const confirmDialogHarness = await loader.getHarness(GioConfirmDialogHarness);
+    await confirmDialogHarness.confirm();
+
+    expect(component.confirmed).toBe(true);
+  });
+
+  it('should return false with the user cancels', async () => {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+
+    const confirmDialogHarness = await loader.getHarness(GioConfirmDialogHarness);
+    await confirmDialogHarness.cancel();
+
+    expect(component.confirmed).toBe(false);
+  });
+});

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+export type GioConfirmDialogData = {
+  title?: string;
+  content?: string;
+  confirmButton?: string;
+  cancelButton?: string;
+};
+
+@Component({
+  selector: 'gio-confirm-dialog',
+  templateUrl: './gio-confirm-dialog.component.html',
+  styleUrls: ['./gio-confirm-dialog.component.scss'],
+})
+export class GioConfirmDialogComponent {
+  public title: string;
+  public content?: string;
+  public confirmButton: string;
+  public cancelButton: string;
+
+  constructor(public dialogRef: MatDialogRef<GioConfirmDialogComponent>, @Inject(MAT_DIALOG_DATA) confirmDialogData: GioConfirmDialogData) {
+    this.title = confirmDialogData?.title ?? 'Are you sure?';
+    this.content = confirmDialogData?.content;
+    this.confirmButton = confirmDialogData?.confirmButton ?? 'Confirm';
+    this.cancelButton = confirmDialogData?.cancelButton ?? 'Cancel';
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.harness.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class GioConfirmDialogHarness extends ComponentHarness {
+  public static hostSelector = 'gio-confirm-dialog';
+
+  private getConfirmBtn = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__confirm-button' }));
+  private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__cancel-button' }));
+
+  public async confirm(): Promise<void> {
+    const button = await this.getConfirmBtn();
+    await button.click();
+  }
+
+  public async cancel(): Promise<void> {
+    const button = await this.getCancelBtn();
+    await button.click();
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.module.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { A11yModule } from '@angular/cdk/a11y';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { GioConfirmDialogComponent } from './gio-confirm-dialog.component';
+
+@NgModule({
+  imports: [CommonModule, MatButtonModule, MatDialogModule, A11yModule],
+  declarations: [GioConfirmDialogComponent],
+  exports: [GioConfirmDialogComponent],
+  entryComponents: [GioConfirmDialogComponent],
+})
+export class GioConfirmDialogModule {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.stories.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Component, Input } from '@angular/core';
+import { tap } from 'rxjs/operators';
+import { action } from '@storybook/addon-actions';
+
+import { GioConfirmDialogComponent, GioConfirmDialogData } from './gio-confirm-dialog.component';
+import { GioConfirmDialogModule } from './gio-confirm-dialog.module';
+
+@Component({
+  selector: 'gio-confirm-dialog-story',
+  template: `<button id="open-confirm-dialog" (click)="openConfirmDialog()">Open confirm dialog</button>`,
+})
+class ConfirmDialogStoryComponent {
+  @Input() public title?: string;
+  @Input() public content?: string;
+  @Input() public confirmButton?: string;
+  @Input() public cancelButton?: string;
+
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openConfirmDialog() {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        data: {
+          title: this.title,
+          content: this.content,
+          confirmButton: this.confirmButton,
+          cancelButton: this.cancelButton,
+        },
+        role: 'alertdialog',
+        id: 'confirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        tap(confirmed => {
+          action('confirmed?')(confirmed);
+        }),
+      )
+      .subscribe();
+  }
+}
+
+export default {
+  title: 'Components / Confirm dialog',
+  component: GioConfirmDialogComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [ConfirmDialogStoryComponent],
+      imports: [GioConfirmDialogModule, MatDialogModule, NoopAnimationsModule],
+    }),
+  ],
+  argTypes: {
+    title: {
+      type: { name: 'string', required: false },
+    },
+    content: {
+      type: { name: 'string', required: false },
+    },
+    confirmButton: {
+      type: { name: 'string', required: false },
+    },
+    cancelButton: {
+      type: { name: 'string', required: false },
+    },
+  },
+  render: args => ({
+    component: ConfirmDialogStoryComponent,
+    props: { ...args },
+  }),
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
+} as Meta;
+
+export const Default: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-confirm-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+
+export const Custom: StoryObj<GioConfirmDialogData> = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-confirm-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+Custom.args = {
+  title: 'Are you sure you want to remove all cats ?',
+  content: '🙀😿 Are you sure? You can’t undo this action afterwards.',
+  confirmButton: 'Yes, I want',
+  cancelButton: 'Nope',
+};

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
@@ -28,6 +28,10 @@ export * from './gio-form-tags-input/gio-form-tags-input.harness';
 export * from './gio-banner/gio-banner.component';
 export * from './gio-banner/gio-banner.module';
 
+export * from './gio-confirm-dialog/gio-confirm-dialog.component';
+export * from './gio-confirm-dialog/gio-confirm-dialog.module';
+export * from './gio-confirm-dialog/gio-confirm-dialog.harness';
+
 export * from './gio-icons/gio-icons.module';
 
 export * from './gio-form-headers/gio-form-headers.component';


### PR DESCRIPTION
**Description**

Add a ConfirmDialog component that could be embedded in a model to ask for confirmation from the user.

Once the dialog is closed, we received a boolean that allows us to know if the user has confirmed or canceled.

**Screenshots**

<img width="618" alt="image" src="https://user-images.githubusercontent.com/4171593/158823149-4cfc18aa-5df5-4315-a49d-ba52d5ba669e.png">

**Additional informations**

The component comes from [APIM](https://github.com/gravitee-io/gravitee-api-management/tree/master/gravitee-apim-console-webui/src/shared/components/gio-confirm-dialog)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-adnmhndehw.chromatic.com)
<!-- Storybook placeholder end -->
