### PR TITLE
fix(banner): change text color to darker for accessibility

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.scss
@@ -46,7 +46,7 @@ $types: (
     &.#{$typeName} {
       border: 1px solid mat.get-color-from-palette($typePalette, default);
       background-color: mat.get-color-from-palette($typePalette, lighter);
-      color: mat.get-color-from-palette($typePalette, default);
+      color: mat.get-color-from-palette($typePalette, darker);
     }
   }
 


### PR DESCRIPTION
**Issue**

N.A.

**Description**

For better accessibility, there need to be more contrast between background and text color in banners.

**Screenshot**

BEFORE

![screenshot-particles gravitee io-2022 09 06-15_07_25](https://user-images.githubusercontent.com/1655950/188650699-030f8502-5398-4436-a711-e600cb837d50.png)


AFTER 
![screenshot-localhost_9008-2022 09 06-15_06_15](https://user-images.githubusercontent.com/1655950/188650738-9d9e0bba-f868-4c1b-97ce-74d72cae1c0f.png)



<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hbqgfwbplh.chromatic.com)
<!-- Storybook placeholder end -->
