### PR TITLE
feat: add confirm and validate dialog component

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/README.stories.mdx
@@ -1,0 +1,50 @@
+import { Meta, Story } from '@storybook/addon-docs';
+
+<Meta title="Components / Confirm and validate dialog / README" />
+
+# Confirm and validate dialog
+
+Documentation and examples for Confirm and Validate dialog, a component to asking for confirmation.
+
+## Demo
+
+<Story id="components-confirm-and-validate-dialog--custom" />
+
+## Usage
+
+**Inputs**
+
+- `title`: `string` - The dialog title.
+- `warning`: `string` - Add this string into warning banner
+- `content`: `string` - The dialog content override.
+- `validationMessage`: `string` - The action to do to validate. Default: `Please, type in <code>confirm</code> to confirm.`
+- `validationValue`: `string` - The dialog content override. Default: `confirm`
+- `confirmButton`: `string` - The dialog confirmation button override.
+- `confirmCancel`: `string` - The dialog cancel button override.
+
+Example:
+
+```typescript
+
+this.matDialog
+  .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData, boolean>(GioConfirmAndValidateDialogComponent, {
+    data: {
+      title: 'title override',
+      warning: 'warning override',
+      content: 'content override',
+      validationMessage: 'validationMessage override',
+      validationValue: 'validationValue override',
+      confirmButton: 'confirmButton override',
+      cancelButton: 'cancelButton override',
+    },
+    role: 'alertdialog',
+    id: 'confirmDialog',
+  })
+  .afterClosed()
+  .pipe(
+    tap(confirmed => {
+      action('confirmed?')(confirmed);
+    }),
+  )
+  .subscribe((confirmed => {});
+```

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.html
@@ -31,12 +31,20 @@
       [ngModel]="confirmValue"
       (ngModelChange)="onConfirmChange($event)"
       required
+      data-testid="confirm-input-dialog"
     />
   </mat-form-field>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="confirm-dialog__actions">
-  <button class="confirm-dialog__confirm-button" [disabled]="!isValid" color="warn" mat-raised-button [mat-dialog-close]="true">
+  <button
+    class="confirm-dialog__confirm-button"
+    [disabled]="!isValid"
+    color="warn"
+    mat-raised-button
+    [mat-dialog-close]="true"
+    data-testid="confirm-dialog"
+  >
     {{ confirmButton }}
   </button>
   <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.html
@@ -1,0 +1,45 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title class="confirm-dialog__title">{{ title }}</h2>
+
+<mat-dialog-content class="confirm-dialog__body">
+  <gio-banner-warning *ngIf="warning"><span [innerHTML]="warning"></span></gio-banner-warning>
+  <p class="confirm-dialog__body__content" *ngIf="content" [innerHTML]="content"></p>
+  <p class="confirm-dialog__body__validate-message" [innerHTML]="validationMessage"></p>
+  <mat-form-field class="confirm-dialog__body__validate-input" appearance="outline" floatLabel="always">
+    <mat-label>Confirm</mat-label>
+    <input
+      matInput
+      cdkFocusInitial
+      type="text"
+      [placeholder]="validationValue"
+      [ngModel]="confirmValue"
+      (ngModelChange)="onConfirmChange($event)"
+      required
+    />
+  </mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="confirm-dialog__actions">
+  <button class="confirm-dialog__confirm-button" [disabled]="!isValid" color="warn" mat-raised-button [mat-dialog-close]="true">
+    {{ confirmButton }}
+  </button>
+  <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">
+    {{ cancelButton }}
+  </button>
+</mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.scss
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@use '../../scss' as gio;
+
+.confirm-dialog {
+  &__body {
+    &__content {
+      color: mat.get-color-from-palette(gio.$mat-content-palette);
+    }
+
+    &__validate-input {
+      overflow: hidden;
+      width: 100%;
+      height: 62px;
+    }
+  }
+
+  &__actions {
+    /* Reverse button to have the next focus on confirm button */
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: flex-start;
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+import { GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData } from './gio-confirm-and-validate-dialog.component';
+import { GioConfirmAndValidateDialogModule } from './gio-confirm-and-validate-dialog.module';
+import { GioConfirmAndValidateDialogHarness } from './gio-confirm-and-validate-dialog.harness';
+
+@Component({
+  selector: 'gio-confirm-and-validate-dialog-test',
+  template: `<button mat-button id="open-confirm-dialog" (click)="openConfirmDialog()">Open confirm dialog</button>`,
+})
+class TestComponent {
+  public confirmed?: boolean;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openConfirmDialog() {
+    this.matDialog
+      .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData, boolean>(GioConfirmAndValidateDialogComponent, {
+        data: {},
+        role: 'alertdialog',
+        id: 'confirmDialog',
+      })
+      .afterClosed()
+      .subscribe(confirmed => (this.confirmed = confirmed));
+  }
+}
+
+describe('GioConfirmDialogComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [GioConfirmAndValidateDialogModule, NoopAnimationsModule],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  });
+
+  it('should return true with the user confirms', async () => {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+
+    const confirmDialogHarness = await loader.getHarness(GioConfirmAndValidateDialogHarness);
+    await confirmDialogHarness.confirm();
+
+    expect(component.confirmed).toBe(true);
+  });
+
+  it('should return false with the user cancels', async () => {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+
+    const confirmDialogHarness = await loader.getHarness(GioConfirmAndValidateDialogHarness);
+    await confirmDialogHarness.cancel();
+
+    expect(component.confirmed).toBe(false);
+  });
+});

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { toLower } from 'lodash';
+
+export type GioConfirmAndValidateDialogData = {
+  title?: string;
+  warning?: string;
+  content?: string;
+  validationMessage?: string;
+  validationValue?: string;
+  confirmButton?: string;
+  cancelButton?: string;
+};
+
+@Component({
+  selector: 'gio-confirm-and-validate-dialog',
+  templateUrl: './gio-confirm-and-validate-dialog.component.html',
+  styleUrls: ['./gio-confirm-and-validate-dialog.component.scss'],
+})
+export class GioConfirmAndValidateDialogComponent {
+  public title: string;
+  public warning?: string;
+  public content?: string;
+  public validationMessage?: string;
+  public validationValue: string;
+  public confirmButton: string;
+  public cancelButton: string;
+
+  public confirmValue?: string;
+  public isValid = false;
+
+  constructor(
+    public dialogRef: MatDialogRef<GioConfirmAndValidateDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) confirmDialogData: GioConfirmAndValidateDialogData,
+  ) {
+    this.title = confirmDialogData?.title ?? 'Are you sure?';
+    this.warning = confirmDialogData?.warning;
+    this.content = confirmDialogData?.content;
+    this.validationMessage = extendValidationMessage(
+      confirmDialogData?.validationMessage ?? 'Please, type <code>confirm</code> to confirm.',
+    );
+    this.validationValue = confirmDialogData?.validationValue ?? 'confirm';
+    this.confirmButton = confirmDialogData?.confirmButton ?? 'Confirm';
+    this.cancelButton = confirmDialogData?.cancelButton ?? 'Cancel';
+  }
+
+  public onConfirmChange(confirmValue: string): void {
+    this.isValid = toLower(confirmValue) === toLower(this.validationValue);
+  }
+}
+
+const extendValidationMessage = (validationMessage: string) => {
+  return validationMessage.replace('<code>', '<code class="gio-badge-warning">');
+};

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.harness.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class GioConfirmAndValidateDialogHarness extends ComponentHarness {
+  public static hostSelector = 'gio-confirm-and-validate-dialog';
+
+  private getConfirmBtn = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__confirm-button' }));
+  private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__cancel-button' }));
+  private getConfirmInput = this.locatorFor(MatInputHarness);
+
+  public async confirm(): Promise<void> {
+    const confirmInput = await this.getConfirmInput();
+    await confirmInput.setValue(await confirmInput.getPlaceholder());
+
+    const button = await this.getConfirmBtn();
+    if (!(await button.isDisabled())) {
+      await button.click();
+    }
+  }
+
+  public async cancel(): Promise<void> {
+    const button = await this.getCancelBtn();
+    await button.click();
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.module.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { A11yModule } from '@angular/cdk/a11y';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+import { GioBannerModule } from '../public-api';
+
+import { GioConfirmAndValidateDialogComponent } from './gio-confirm-and-validate-dialog.component';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, MatButtonModule, MatDialogModule, MatInputModule, MatFormFieldModule, A11yModule, GioBannerModule],
+  declarations: [GioConfirmAndValidateDialogComponent],
+  exports: [GioConfirmAndValidateDialogComponent],
+  entryComponents: [GioConfirmAndValidateDialogComponent],
+})
+export class GioConfirmAndValidateDialogModule {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.stories.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Component, Input } from '@angular/core';
+import { tap } from 'rxjs/operators';
+import { action } from '@storybook/addon-actions';
+
+import { GioBannerModule } from '../public-api';
+
+import { GioConfirmAndValidateDialogModule } from './gio-confirm-and-validate-dialog.module';
+import { GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData } from './gio-confirm-and-validate-dialog.component';
+
+@Component({
+  selector: 'gio-confirm-and-validate-dialog-story',
+  template: `<button id="open-confirm-dialog" (click)="openConfirmDialog()">Open confirm dialog</button>`,
+})
+class ConfirmAndValidateDialogStoryComponent {
+  @Input() public title?: string;
+  @Input() public warning?: string;
+  @Input() public content?: string;
+  @Input() public validationMessage?: string;
+  @Input() public validationValue?: string;
+  @Input() public confirmButton?: string;
+  @Input() public cancelButton?: string;
+
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openConfirmDialog() {
+    this.matDialog
+      .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData, boolean>(GioConfirmAndValidateDialogComponent, {
+        data: {
+          title: this.title,
+          warning: this.warning,
+          content: this.content,
+          validationMessage: this.validationMessage,
+          validationValue: this.validationValue,
+          confirmButton: this.confirmButton,
+          cancelButton: this.cancelButton,
+        },
+        role: 'alertdialog',
+        id: 'confirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        tap(confirmed => {
+          action('confirmed?')(confirmed);
+        }),
+      )
+      .subscribe();
+  }
+}
+
+export default {
+  title: 'Components / Confirm and validate dialog',
+  component: GioConfirmAndValidateDialogComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [ConfirmAndValidateDialogStoryComponent],
+      imports: [GioConfirmAndValidateDialogModule, GioBannerModule, MatDialogModule, NoopAnimationsModule],
+    }),
+  ],
+  argTypes: {
+    title: {
+      type: { name: 'string', required: false },
+    },
+    warning: {
+      type: { name: 'string', required: false },
+    },
+    content: {
+      type: { name: 'string', required: false },
+    },
+    validationMessage: {
+      type: { name: 'string', required: false },
+    },
+    validationValue: {
+      type: { name: 'string', required: false },
+    },
+    confirmButton: {
+      type: { name: 'string', required: false },
+    },
+    cancelButton: {
+      type: { name: 'string', required: false },
+    },
+  },
+  render: args => ({
+    component: ConfirmAndValidateDialogStoryComponent,
+    props: { ...args },
+  }),
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
+} as Meta;
+
+export const Default: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-confirm-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+
+export const Custom: StoryObj<GioConfirmAndValidateDialogData> = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-confirm-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+Custom.args = {
+  title: 'Are you sure you want to remove all cats ?',
+  warning: 'This action is irreversible',
+  content: '🙀😿 Are you sure? You can’t undo this action afterwards.',
+  validationMessage: 'Type "remove" to confirm',
+  validationValue: 'remove',
+  confirmButton: 'Yes, I want',
+  cancelButton: 'Nope',
+};

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.html
@@ -25,7 +25,14 @@
   <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">
     {{ cancelButton }}
   </button>
-  <button class="confirm-dialog__confirm-button" color="warn" mat-raised-button [mat-dialog-close]="true" cdkFocusInitial>
+  <button
+    class="confirm-dialog__confirm-button"
+    color="warn"
+    mat-raised-button
+    [mat-dialog-close]="true"
+    cdkFocusInitial
+    data-testid="confirm-dialog"
+  >
     {{ confirmButton }}
   </button>
 </mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
@@ -32,6 +32,10 @@ export * from './gio-confirm-dialog/gio-confirm-dialog.component';
 export * from './gio-confirm-dialog/gio-confirm-dialog.module';
 export * from './gio-confirm-dialog/gio-confirm-dialog.harness';
 
+export * from './gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component';
+export * from './gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.module';
+export * from './gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.harness';
+
 export * from './gio-icons/gio-icons.module';
 
 export * from './gio-form-headers/gio-form-headers.component';


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

<img width="821" alt="image" src="https://user-images.githubusercontent.com/4974420/195570916-9c8d273b-30f8-42ef-97cb-ed9a727107d1.png">
<img width="633" alt="image" src="https://user-images.githubusercontent.com/4974420/195570958-d42503a9-066b-4a89-bc41-4681f2404c73.png">
<img width="821" alt="image" src="https://user-images.githubusercontent.com/4974420/195571014-bcb31eba-ae85-4f3b-82b6-99aba9bae918.png">

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-beydhyymzl.chromatic.com)
<!-- Storybook placeholder end -->
