### PR TITLE
fix: avoid opening system file picker to trigger control emit value

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.spec.ts
@@ -122,6 +122,8 @@ describe('FilePickerInputComponent', () => {
       fixture.detectChanges();
 
       expect(await filePickerInputHarness.hasErrorClass()).toEqual(true);
+      expect(component.myForm.touched).toEqual(true);
+      expect(component.myForm.dirty).toEqual(false);
     });
   });
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.ts
@@ -135,8 +135,6 @@ export class GioFormFilePickerComponent implements OnInit, ControlValueAccessor 
 
   public onTouched(): void {
     this.onTouchedCallback();
-    // sends current value allows parent component to check validation
-    this.emitFileValue();
     this.dragHover = false;
   }
 


### PR DESCRIPTION
**Issue**

Fix FilePicker component to avoid form control status changing to dirty when no changes are made

<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xijwrztqbk.chromatic.com)
<!-- Storybook placeholder end -->
