### PR TITLE
fix: allows to interact with elements under the sticky save-bar

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
@@ -16,7 +16,7 @@
 
 -->
 
-<div *ngIf="isOpen()" [@slideUpDown] [@.disabled]="creationMode">
+<div *ngIf="isOpen" [@slideUpDown] [@.disabled]="creationMode">
   <mat-card class="save-bar__content" [class.mat-elevation-z3]="creationMode" [class.mat-elevation-z6]="!creationMode">
     <div class="save-bar__content__label">{{ creationMode ? '' : 'You have unsaved changes' }}</div>
     <div>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.scss
@@ -25,6 +25,11 @@ $typography: map.get(gio.$mat-theme, typography);
   display: block;
   height: 68px;
   margin-top: 32px;
+  visibility: hidden;
+}
+
+:host.is-open {
+  visibility: visible;
 }
 
 :host(.save-bar-sticky) {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
@@ -68,7 +68,8 @@ export class GioSaveBarComponent {
   @Output()
   public submittedInvalidState = new EventEmitter();
 
-  public isOpen(): boolean {
+  @HostBinding('class.is-open')
+  public get isOpen(): boolean {
     if (this.creationMode) {
       return true;
     }


### PR DESCRIPTION
**Issue**
n/a

**Description**
By adding css hidden visibility when save bar is close

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/4974420/199545365-517d69ad-adea-4bbf-b011-4baaabcd13e9.png">

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hwtzxjupbi.chromatic.com)
<!-- Storybook placeholder end -->
