### PR TITLE
feat: improve banner to have optional body

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/README.stories.mdx
@@ -12,7 +12,7 @@ Documentation and examples for banner. Allows you to display banner in cards or 
 
 ## Usage
 
-`<gio-banner></gio-banner>` can be used with a `type` input to change its color and icon dinamically.
+`<gio-banner></gio-banner>` can be used with a `type` input to change its color and icon dynamically.
 
 It is also possible to use it with the following tag declination:
 
@@ -28,4 +28,13 @@ It is also possible to use it with the following tag declination:
 <gio-banner-success>This is a success banner!</gio-banner-success>
 
 <gio-banner-warning>This is a warning banner!</gio-banner-warning>
+```
+
+It is possible to add body with [gioBannerBody] directive
+
+```html 
+<gio-banner>
+  Title content
+  <span gioBannerBody>This is the body of the banner.</span>
+</gio-banner>
 ```

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.html
@@ -22,13 +22,18 @@
   [class.warning]="type === 'warning'"
   [class.success]="type === 'success'"
 >
-  <div class="banner__icon" [ngSwitch]="type">
-    <mat-icon *ngSwitchCase="'info'" svgIcon="gio:chat-lines"></mat-icon>
-    <mat-icon *ngSwitchCase="'error'" svgIcon="gio:chat-bubble-error"></mat-icon>
-    <mat-icon *ngSwitchCase="'warning'" svgIcon="gio:chat-bubble-warning"></mat-icon>
-    <mat-icon *ngSwitchCase="'success'" svgIcon="gio:chat-bubble-check"></mat-icon>
+  <div class="banner__wrapper">
+    <div class="banner__wrapper__icon" [ngSwitch]="type">
+      <mat-icon *ngSwitchCase="'info'" svgIcon="gio:chat-lines"></mat-icon>
+      <mat-icon *ngSwitchCase="'error'" svgIcon="gio:chat-bubble-error"></mat-icon>
+      <mat-icon *ngSwitchCase="'warning'" svgIcon="gio:chat-bubble-warning"></mat-icon>
+      <mat-icon *ngSwitchCase="'success'" svgIcon="gio:chat-bubble-check"></mat-icon>
+    </div>
+    <div class="banner__wrapper__head">
+      <ng-content></ng-content>
+    </div>
   </div>
-  <div class="banner__content">
-    <ng-content></ng-content>
+  <div #body class="banner__body" [class.hide]="!body.children.length">
+    <ng-content select="[gioBannerBody]"></ng-content>
   </div>
 </div>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.scss
@@ -35,10 +35,9 @@ $types: (
 }
 
 .banner {
-  @include mat.typography-level($typography, body-2);
-
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   padding: 16px;
   border-radius: 8px;
 
@@ -50,13 +49,30 @@ $types: (
     }
   }
 
-  &__icon {
+  &__wrapper {
     display: flex;
-    margin-right: 18px;
+    align-items: center;
+
+    @include mat.typography-level($typography, body-2);
+
+    &__icon {
+      display: flex;
+      margin-right: 16px;
+    }
+
+    &__head {
+      flex: 1 1 auto;
+      line-height: normal;
+    }
   }
 
-  &__content {
-    flex: 1 1 auto;
-    line-height: normal;
+  &__body {
+    padding-top: 2px;
+    padding-left: 24px + 16px;
+    @include mat.typography-level($typography, body-1);
+
+    &.hide {
+      display: none;
+    }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, Directive, Input } from '@angular/core';
 
 export type GioBannerTypes = 'error' | 'info' | 'success' | 'warning';
 
@@ -26,6 +26,11 @@ export class GioBannerComponent {
   @Input()
   public type: GioBannerTypes = 'info';
 }
+
+@Directive({
+  selector: '[gioBannerBody]',
+})
+export class GioBannerBodyDirective {}
 
 @Component({
   selector: 'gio-banner-error',

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.module.ts
@@ -21,6 +21,7 @@ import { GioIconsModule } from '../gio-icons/gio-icons.module';
 
 import {
   GioBannerComponent,
+  GioBannerBodyDirective,
   GioBannerErrorComponent,
   GioBannerInfoComponent,
   GioBannerSuccessComponent,
@@ -29,8 +30,22 @@ import {
 
 @NgModule({
   imports: [CommonModule, MatIconModule, GioIconsModule],
-  declarations: [GioBannerComponent, GioBannerErrorComponent, GioBannerInfoComponent, GioBannerSuccessComponent, GioBannerWarningComponent],
-  exports: [GioBannerComponent, GioBannerErrorComponent, GioBannerInfoComponent, GioBannerSuccessComponent, GioBannerWarningComponent],
+  declarations: [
+    GioBannerComponent,
+    GioBannerErrorComponent,
+    GioBannerInfoComponent,
+    GioBannerSuccessComponent,
+    GioBannerWarningComponent,
+    GioBannerBodyDirective,
+  ],
+  exports: [
+    GioBannerComponent,
+    GioBannerErrorComponent,
+    GioBannerInfoComponent,
+    GioBannerSuccessComponent,
+    GioBannerWarningComponent,
+    GioBannerBodyDirective,
+  ],
   entryComponents: [
     GioBannerComponent,
     GioBannerErrorComponent,

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.stories.ts
@@ -84,10 +84,18 @@ export const AllWithTypeInput: Story = {
 
 export const Default: Story = {
   render: () => ({
-    template: `<gio-banner>This is a Default banner!</gio-banner>
+    template: `
+    <h5>Outside Mat Card</h5>
+    <gio-banner>This is a Default banner!</gio-banner>
+    <h5>Inside Mat Card</h5>
     <mat-card>
       <gio-banner-error>Error <br> Second line <br> Wow another one</gio-banner-error>
     </mat-card>
+    <h5>With content</h5>
+    <gio-banner>
+      Title content
+      <span gioBannerBody>This is the body of the banner.</span>
+    </gio-banner>
     `,
   }),
 };


### PR DESCRIPTION
**Issue**

Improve banner to have optional body

**Description**
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/4974420/199964979-c6609da2-ee8e-4898-82ad-87eb9355e092.png">

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-fulwewnzke.chromatic.com)
<!-- Storybook placeholder end -->
