### PR TITLE
Fix form field

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.scss
@@ -39,6 +39,7 @@
           max-height: 32px;
           flex-direction: column;
           justify-content: center;
+          padding-bottom: 0;
 
           * {
             top: 0;
@@ -48,14 +49,8 @@
         }
 
         &__field:focus-within {
-          position: absolute;
           z-index: 100;
-          top: 1px;
-          right: 0;
-          left: 0;
           height: auto;
-          max-height: none;
-          padding: 0.2rem;
           background-color: mat.get-color-from-palette(gio.$mat-content-palette, 'lighter');
 
           * {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="gio-menu-selector">
-  <mat-form-field>
+  <mat-form-field class="gio-menu-selector__mat-form-field">
     <mat-label>{{ selectorTitle }}</mat-label>
     <mat-select [tabIndex]="tabIndex" [value]="selectedItemValue" (selectionChange)="onSelectionChange($event)" [disabled]="isDisabled()">
       <mat-option *ngFor="let item of selectorItems" [value]="item.value">

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
@@ -28,6 +28,10 @@ $text: map.get(gio.$mat-dove-palette, default);
   margin-bottom: 8px;
   border-radius: 4px;
   color: $text;
+
+  &__mat-form-field {
+    padding-bottom: 0;
+  }
 }
 
 ::ng-deep {

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  .mat-form-field-disabled {
-    cursor: not-allowed;
+  .mat-form-field-disabled * {
+    cursor: not-allowed !important;
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
@@ -19,15 +19,13 @@
 
 @mixin mat-form-field() {
   .mat-form-field {
+    // Increase default padding to have space for two lines of hint & error bellow the input
+    padding-bottom: 16px;
+
     .mat-hint,
     .mat-error {
       font-size: mat.font-size(theme.$mat-typography, caption);
     }
-  }
-
-  // Default margin between two mat-form-field
-  .mat-form-field + .mat-form-field {
-    margin-top: 8px;
   }
 
   .mat-form-field-disabled {

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.stories.ts
@@ -66,7 +66,7 @@ export const MatHintAndErrorFontSize: Story = {
   }),
 };
 
-export const MarginBetweenMatFormField: Story = {
+export const PaddingBottomMatFormField: Story = {
   render: () => ({
     template: `
       <p>
@@ -79,7 +79,7 @@ export const MarginBetweenMatFormField: Story = {
             <mat-label>Fill form field</mat-label>
             <input matInput placeholder="Placeholder" />
             <mat-icon matSuffix>sentiment_very_satisfied</mat-icon>
-            <mat-hint>Hint</mat-hint>
+            <mat-hint>Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br> Nullam auctor, nunc vel</mat-hint>
           </mat-form-field>
           <mat-form-field appearance="fill">
             <mat-label>Second Fill form field</mat-label>


### PR DESCRIPTION
**Issue**
n/a

**Description**

Adds a default margin under each form field to have 2 error & hint lines. 
Removes the added margin between form fields as it is not compatible with a `flex-direction: row`


- [x] Check with APIM
- [x] Check with AM


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vdfpnuawab.chromatic.com)
<!-- Storybook placeholder end -->
