### PR TITLE
fix: make menu service singleton

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.module.ts
@@ -26,7 +26,6 @@ import { GioMenuFooterComponent } from './gio-menu-footer/gio-menu-footer.compon
 import { GioMenuListComponent } from './gio-menu-list/gio-menu-list.component';
 import { GioMenuSelectorComponent } from './gio-menu-selector/gio-menu-selector.component';
 import { GioMenuHeaderComponent } from './gio-menu-header/gio-menu-header.component';
-import { GioMenuService } from './gio-menu.service';
 
 @NgModule({
   declarations: [
@@ -46,6 +45,5 @@ import { GioMenuService } from './gio-menu.service';
     GioMenuSelectorComponent,
   ],
   imports: [CommonModule, MatIconModule, GioIconsModule, MatSelectModule],
-  providers: [GioMenuService],
 })
 export class GioMenuModule {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.service.ts
@@ -23,7 +23,7 @@ interface OverlayOptions {
   open: boolean;
 }
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class GioMenuService {
   private reduceSource = new BehaviorSubject<boolean>(false);
   private overlaySource = new BehaviorSubject<OverlayOptions>({ open: false });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.module.ts
@@ -18,7 +18,6 @@ import { NgModule } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 
 import { GioIconsModule } from '../gio-icons/gio-icons.module';
-import { GioMenuService } from '../gio-menu/gio-menu.service';
 
 import { GioSubmenuGroupComponent } from './gio-submenu-group/gio-submenu-group.component';
 import { GioSubmenuComponent } from './gio-submenu.component';
@@ -28,6 +27,5 @@ import { GioSubmenuItemComponent } from './gio-submenu-item/gio-submenu-item.com
   declarations: [GioSubmenuComponent, GioSubmenuGroupComponent, GioSubmenuItemComponent],
   exports: [GioSubmenuComponent, GioSubmenuGroupComponent, GioSubmenuItemComponent],
   imports: [CommonModule, MatIconModule, GioIconsModule],
-  providers: [GioMenuService],
 })
 export class GioSubmenuModule {}


### PR DESCRIPTION
**Issue**

N.A.

**Description**

Make GioMenuService singleton

**Additional context**

When using in Cockpit in different modules that are lazy loaded, we had several instances of the GioMenuService, causing the submenu not to collapse when collapsing the main menu.
<!-- Storybook placeholder -->
---
📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hijsokvuwm.chromatic.com)
<!-- Storybook placeholder end -->
