### PR TITLE
docs: add story to reflect button styles like defined in Figma

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
@@ -33,7 +33,138 @@ export default {
 export const MatButton: Story = {
   render: () => ({
     template: `
-          <h3>Buttons</h3>
+        <h3>Design System buttons</h3>
+        <div>
+            <div>
+                <h4>Button primary</h4>
+                <div class="button-container">
+                    <button mat-flat-button color="primary">Default</button>
+<!--                    TODO :see how we can define new css classes for sizing-->
+                    <button mat-flat-button color="primary" class="button-large">Large button</button>
+                    <button mat-flat-button color="primary" class="medium">Medium button</button>
+                    <button mat-flat-button color="primary" class="small">Small button</button>
+                    </div>
+                <div class="button-container">
+                    <button mat-flat-button color="primary" class="large"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="medium"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="small"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    </div>
+                <div class="button-container">
+                    <button mat-flat-button color="primary" class="large"><mat-icon svgIcon="gio:star-outline"></mat-icon>Large button</button>
+                    <button mat-flat-button color="primary" class="medium"><mat-icon svgIcon="gio:star-outline"></mat-icon>Medium button</button>
+                    <button mat-flat-button color="primary" class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
+                </div>
+                <div class="button-container">
+                    <button mat-flat-button color="primary" class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                </div>
+            </div>
+            <div>
+                <h4>Button secondary</h4>
+                <div class="button-container">
+                    <button mat-stroked-button>Default</button>
+<!--                    TODO :see how we can define new css classes for sizing-->
+                    <button mat-stroked-button class="large">Large button</button>
+                    <button mat-stroked-button class="medium">Medium button</button>
+                    <button mat-stroked-button class="small">Small button</button>
+                    </div>
+                <div class="button-container">
+                    <button mat-stroked-button class="large"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-stroked-button class="medium"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-stroked-button class="small"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    </div>
+                <div class="button-container">
+                    <button mat-stroked-button class="large"><mat-icon svgIcon="gio:star-outline"></mat-icon>Large button</button>
+                    <button mat-stroked-button class="medium"><mat-icon svgIcon="gio:star-outline"></mat-icon>Medium button</button>
+                    <button mat-stroked-button class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
+                </div>
+                <div class="button-container">
+                    <button mat-stroked-button class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-stroked-button class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-stroked-button class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                </div>
+            </div>
+            <div>
+                <h4>Button tertiary</h4>
+                <div class="button-container">
+                    <button mat-button>Default</button>
+<!--                    TODO :see how we can define new css classes for sizing-->
+                    <button mat-button class="large">Large button</button>
+                    <button mat-button class="medium">Medium button</button>
+                    <button mat-button class="small">Small button</button>
+                    </div>
+                <div class="button-container">
+                    <button mat-button class="large"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-button class="medium"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-button class="small"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    </div>
+                <div class="button-container">
+                    <button mat-button class="large"><mat-icon svgIcon="gio:star-outline"></mat-icon>Large button</button>
+                    <button mat-button class="medium"><mat-icon svgIcon="gio:star-outline"></mat-icon>Medium button</button>
+                    <button mat-button class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
+                </div>
+                <div class="button-container">
+                    <button mat-button class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-button class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-button class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                </div>
+            </div>
+            <div>
+                <h4>Button accent</h4>
+                <div class="button-container">
+                    <button mat-flat-button color="accent">Default</button>
+<!--                    TODO :see how we can define new css classes for sizing-->
+                    <button mat-flat-button color="accent" class="large">Large button</button>
+                    <button mat-flat-button color="accent" class="medium">Medium button</button>
+                    <button mat-flat-button color="accent" class="small">Small button</button>
+                    </div>
+                <div class="button-container">
+                    <button mat-flat-button color="accent" class="large"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="medium"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="small"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    </div>
+                <div class="button-container">
+                    <button mat-flat-button color="accent" class="large"><mat-icon svgIcon="gio:star-outline"></mat-icon>Large button</button>
+                    <button mat-flat-button color="accent" class="medium"><mat-icon svgIcon="gio:star-outline"></mat-icon>Medium button</button>
+                    <button mat-flat-button color="accent" class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
+                </div>
+                <div class="button-container">
+                    <button mat-flat-button color="accent" class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                </div>
+            </div>
+            <div>
+                <h4>Button danger</h4>
+                <div class="button-container">
+                    <button mat-flat-button color="warn">Default</button>
+<!--                    TODO :see how we can define new css classes for sizing-->
+                    <button mat-flat-button color="warn" class="large">Large button</button>
+                    <button mat-flat-button color="warn" class="medium">Medium button</button>
+                    <button mat-flat-button color="warn" class="small">Small button</button>
+                    </div>
+                <div class="button-container">
+                    <button mat-flat-button color="warn" class="large"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="medium"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="small"><mat-icon svgIcon="gio:plus"></mat-icon></button>
+                    </div>
+                <div class="button-container">
+                    <button mat-flat-button color="warn" class="large"><mat-icon svgIcon="gio:star-outline"></mat-icon>Large button</button>
+                    <button mat-flat-button color="warn" class="medium"><mat-icon svgIcon="gio:star-outline"></mat-icon>Medium button</button>
+                    <button mat-flat-button color="warn" class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
+                </div>
+                <div class="button-container">
+                    <button mat-flat-button color="warn" class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                </div>
+            </div>
+        </div>
+
+
+        <div>
+          <h3>Material Buttons</h3>
           <div>
               <div>
                   <h4>Default</h4>
@@ -185,6 +316,7 @@ export const MatButton: Story = {
               </div>
               
           </div>
+        </div>
         `,
     styles: [
       `


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-576

**Description**

Create a story to show buttons as they are defined in Figma 
https://www.figma.com/file/okDdv0Rs884yxKgXQROqaG/Perseverance-design-system?node-id=2067%3A23363&t=7hp2sZMBYASmzyR7-4

**Additional context**

As you can see there is some difference between what we have in Particles vs the buttons defined in Figma 
![screenshot-localhost_9008-2023 01 17-10_59_39](https://user-images.githubusercontent.com/1655950/212868541-474e7631-0ccf-4a1f-aaaf-f7abf032df12.png)
![screenshot-www figma com-2023 01 17-11_00_00](https://user-images.githubusercontent.com/1655950/212868550-5661a6d9-8852-4995-8bb8-cb77a6140209.png)

The goal here is just to list buttons, and we have other issues to make them have a consistent look (subtasks of https://gravitee.atlassian.net/browse/APIM-575)
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-jdmnjmvlwg.chromatic.com)
<!-- Storybook placeholder end -->
