### PR TITLE
fix(submenu): resolve submenu position when deal with escape key

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.ts
@@ -51,11 +51,13 @@ export class GioSubmenuComponent implements AfterViewInit, OnDestroy {
         }),
         switchMap(() => this.gioMenuService.overlayObservable),
         tap(overlayOptions => {
-          const top = overlayOptions.top || 0;
           this.overlayOptions = overlayOptions;
-          this.gioSubmenu.nativeElement.style.top = `${top}px`;
-          this.gioSubmenu.nativeElement.style.height = 'auto';
-          this.gioSubmenu.nativeElement.style.maxHeight = `calc(100vh - ${top + 8}px)`;
+          if (overlayOptions.open) {
+            const top = overlayOptions.top || 0;
+            this.gioSubmenu.nativeElement.style.top = `${top}px`;
+            this.gioSubmenu.nativeElement.style.height = 'auto';
+            this.gioSubmenu.nativeElement.style.maxHeight = `calc(100vh - ${top + 8}px)`;
+          }
         }),
         filter(overlayOptions => !!overlayOptions.focus),
         delay(200),
@@ -98,7 +100,7 @@ export class GioSubmenuComponent implements AfterViewInit, OnDestroy {
   public onKeydownHandler(event: KeyboardEvent): void {
     of(this.reduced && event.key === 'Escape')
       .pipe(
-        filter(reducedAndEcape => reducedAndEcape),
+        filter(reducedAndEscape => reducedAndEscape),
         tap(() => this.gioMenuService.overlay({ open: false })),
         delay(100),
         tap(() => this.overlayOptions.parent?.focus()),


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-291


<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-policy-studio-angular@5.1.0-291-keyboard-accessibility-5ff1643
```
```
yarn add @gravitee/ui-policy-studio-angular@5.1.0-291-keyboard-accessibility-5ff1643
```
<!-- Prerelease placeholder end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-ncqmukkhph.chromatic.com)
<!-- Storybook placeholder end -->
