### PR TITLE
fix(mat-form-field): apply styling on mat form field prefix

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
@@ -17,6 +17,8 @@
 
 @use '../gio-mat-theme-variable' as theme;
 
+@use '../gio-mat-palettes' as palettes;
+
 @mixin mat-form-field() {
   .mat-form-field {
     // Increase default padding to have space for two lines of hint & error bellow the input
@@ -30,5 +32,20 @@
 
   .mat-form-field-disabled * {
     cursor: not-allowed !important;
+  }
+
+  .mat-form-field-prefix {
+    // Apply same margin as the one on the left of the prefix
+    margin-right: 0.75em;
+    color: mat.get-color-from-palette(palettes.$mat-space-palette, 'lighter30');
+  }
+
+  .mat-form-field-appearance-outline .mat-form-field-prefix,
+  .mat-form-field-appearance-outline .mat-form-field-suffix {
+    place-self: center;
+  }
+
+  .mat-form-field-appearance-outline .mat-form-field-infix {
+    padding-top: 0.8em;
   }
 }


### PR DESCRIPTION
**Issue**

N.A.

**Description**

Improve mat-form-field layout

<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-particles-angular@5.1.3-fix-mat-form-field-prefix-f0764ec
```
```
yarn add @gravitee/ui-particles-angular@5.1.3-fix-mat-form-field-prefix-f0764ec
```
<!-- Prerelease placeholder end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-fsxzbwlmvk.chromatic.com)
<!-- Storybook placeholder end -->
