### PR TITLE
Add gio field wrapper

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/README.stories.mdx
@@ -16,4 +16,28 @@ To use this component you need to add optional dependencies to your project:
 yarn add @ngx-formly/core @ngx-formly/material
 ```
 
+## Usage
+
+To create a form based on a json schema, you can include this component like this.
+
+```html
+<gio-form-json-schema
+  [jsonSchema]="jsonSchema"
+  [options]="options"
+  [formGroup]="form"
+  [initialValue]="initialValue"
+></gio-form-json-schema>
+```
+
+## JSON schema
+
+The jsonSchema object passed to the component is of type `GioJsonSchema`, which is an extension of [JsonSchema7](https://jsonforms.io/api/core/interfaces/jsonschema7.html) type, plus some Gravitee specific options.
+
+### Banner
+
+In some case, we want to display some guidance to the user that would not fit in the `mat-hint` field in `mat-form-field`. For such cases, we can use banners like follows.
+
+<Story id="components-form-json-schema--field-with-banner" />
+
+
 🚧 **Note**: This component is in development.

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
@@ -15,9 +15,10 @@
  */
 import { Component, Input } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
 import { cloneDeep, isObject } from 'lodash';
+import { JSONSchema7 } from 'json-schema';
 
 import { GioJsonSchema } from './model/GioJsonSchema';
 
@@ -52,6 +53,23 @@ export class GioFormJsonSchemaComponent {
   constructor(private readonly formlyJsonschema: FormlyJsonschema) {}
 
   private toFormlyFieldConfig(jsonSchema: GioJsonSchema): FormlyFieldConfig {
-    return this.formlyJsonschema.toFieldConfig(jsonSchema);
+    return this.formlyJsonschema.toFieldConfig(jsonSchema, {
+      map: (mappedField: FormlyFieldConfig, mapSource: JSONSchema7) => {
+        // Casting fields into our specific type
+        const gioMapSource = mapSource as GioJsonSchema;
+        mappedField.props = {
+          ...mappedField.props,
+          ...(gioMapSource.gioConfig?.banner ? this.getBannerProperties(gioMapSource.gioConfig.banner) : {}),
+        };
+        return mappedField;
+      },
+    });
+  }
+
+  private getBannerProperties(banner: { title: string; text: string } | { text: string }) {
+    return {
+      bannerText: banner.text,
+      bannerTitle: 'title' in banner ? banner.title : undefined,
+    };
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
@@ -19,6 +19,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule } from '@ngx-formly/core';
 import { FormlyMaterialModule } from '@ngx-formly/material';
 
+import { GioIconsModule } from '../gio-icons/gio-icons.module';
+
 import { GioFjsNullTypeComponent } from './type-component/null-type.component';
 import { GioFjsObjectTypeComponent } from './type-component/object-type.component';
 import { GioFjsArrayTypeComponent } from './type-component/array-type.component';
@@ -36,9 +38,17 @@ import {
   constValidationMessage,
 } from './util/validation-message.util';
 import { GioFormJsonSchemaComponent } from './gio-form-json-schema.component';
+import { GioFormFieldWrapperComponent } from './wrappers/gio-form-field-wrapper.component';
+import { bannerExtension } from './wrappers/gio-banner-extension';
 
 @NgModule({
-  declarations: [GioFormJsonSchemaComponent, GioFjsNullTypeComponent, GioFjsObjectTypeComponent, GioFjsArrayTypeComponent],
+  declarations: [
+    GioFormJsonSchemaComponent,
+    GioFjsNullTypeComponent,
+    GioFjsObjectTypeComponent,
+    GioFjsArrayTypeComponent,
+    GioFormFieldWrapperComponent,
+  ],
   imports: [
     CommonModule,
     ReactiveFormsModule,
@@ -58,13 +68,16 @@ import { GioFormJsonSchemaComponent } from './gio-form-json-schema.component';
         { name: 'uniqueItems', message: 'Should NOT have duplicate items' },
         { name: 'const', message: constValidationMessage },
       ],
+      wrappers: [{ name: 'gio-with-banner', component: GioFormFieldWrapperComponent }],
       types: [
         { name: 'null', component: GioFjsNullTypeComponent, wrappers: ['form-field'] },
         { name: 'array', component: GioFjsArrayTypeComponent },
         { name: 'object', component: GioFjsObjectTypeComponent },
       ],
+      extensions: [{ name: 'banner', extension: { onPopulate: bannerExtension } }],
     }),
     FormlyMaterialModule,
+    GioIconsModule,
   ],
   exports: [GioFormJsonSchemaComponent, FormlyModule],
 })

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
@@ -75,8 +75,34 @@ export const Mixed: Story = {
 export const MixedWithValue: Story = {
   name: 'Mixed with value',
   render: () => ({
-    template: `<gio-demo [jsonSchema]="jsonSchema" [form]="formGroup" [initialValue]="initialValue"></gio-demo>`,
+    template: `<gio-demo [jsonSchema]="jsonSchema" [initialValue]="initialValue"></gio-demo>`,
     props: { jsonSchema: fakeMixed, initialValue: { body: '<xml></xml>' } },
+  }),
+};
+
+export const FieldWithBanner: Story = {
+  name: 'Field with banner',
+  render: () => ({
+    template: `<gio-demo [jsonSchema]="jsonSchema" [initialValue]="initialValue"></gio-demo>`,
+    props: {
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          sample: {
+            title: 'Sample property',
+            description: 'Additional hint',
+            type: 'string',
+            gioConfig: {
+              banner: {
+                title: 'Complex property',
+                text: 'This is a quite long description of what the field is, that would not fit into the hint field',
+              },
+            },
+          },
+        },
+      },
+      initialValue: { sample: 'sample value' },
+    },
   }),
 };
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/testing-json-schema/integer.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/testing-json-schema/integer.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FormlyJSONSchema7 } from '../model/FormlyJSONSchema7';
+import { GioJsonSchema } from '../model/GioJsonSchema';
 
-export const fakeInteger: FormlyJSONSchema7 = {
+export const fakeInteger: GioJsonSchema = {
   type: 'object',
   properties: {
     simpleString: {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/null-type.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/null-type.component.ts
@@ -17,7 +17,7 @@ import { Component } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 
 @Component({
-  selector: 'gio-fjs-object-type',
+  selector: 'gio-fjs-null-type',
   template: ``,
 })
 export class GioFjsNullTypeComponent extends FieldType {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-banner-extension.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-banner-extension.ts
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JSONSchema7 } from 'json-schema';
+import { FormlyFieldConfig } from '@ngx-formly/core';
 
-export interface GioJsonSchema extends JSONSchema7 {
-  gioConfig?: {
-    banner?:
-      | {
-          title: string;
-          text: string;
-        }
-      | {
-          text: string;
-        };
-  };
-  properties?: { [key: string]: GioJsonSchema };
+export function bannerExtension(field: FormlyFieldConfig) {
+  if (!field.props || (field.wrappers && field.wrappers.indexOf('gio-with-banner') !== -1)) {
+    return;
+  }
+
+  if (field.props.bannerTitle || field.props.bannerText) {
+    // WARNING: 'gio-with-banner' must be placed before field wrappers in order to put banner before mat-form-field if exists
+    field.wrappers = ['gio-with-banner', ...(field.wrappers || [])];
+  }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-form-field-wrapper.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-form-field-wrapper.component.html
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="wrapper">
+  <div class="banner">
+    <div class="banner__icon"><mat-icon svgIcon="gio:info"></mat-icon></div>
+    <div>
+      <div class="banner__title">{{ props.bannerTitle }}</div>
+      <div class="banner__text">{{ props.bannerText }}</div>
+    </div>
+  </div>
+  <ng-container #fieldComponent></ng-container>
+</div>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-form-field-wrapper.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-form-field-wrapper.component.scss
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '../../../scss' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.wrapper {
+  padding: 8px 0;
+}
+
+.banner {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: 8px;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  background: mat.get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+  gap: 8px;
+
+  &__icon {
+    padding-top: 2px;
+
+    mat-icon {
+      width: 16px;
+      height: 16px;
+      color: mat.get-color-from-palette(gio.$mat-accent-palette, 'darker20');
+    }
+  }
+
+  &__title {
+    @include mat.typography-level($typography, 'body-2');
+  }
+
+  &__text {
+    @include mat.typography-level($typography, 'body-1');
+
+    color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-form-field-wrapper.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-form-field-wrapper.component.ts
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JSONSchema7 } from 'json-schema';
+import { FieldWrapper } from '@ngx-formly/core';
+import { Component } from '@angular/core';
 
-export interface GioJsonSchema extends JSONSchema7 {
-  gioConfig?: {
-    banner?:
-      | {
-          title: string;
-          text: string;
-        }
-      | {
-          text: string;
-        };
-  };
-  properties?: { [key: string]: GioJsonSchema };
-}
+@Component({
+  selector: 'gio-form-field-wrapper',
+  templateUrl: 'gio-form-field-wrapper.component.html',
+  styleUrls: ['gio-form-field-wrapper.component.scss'],
+})
+export class GioFormFieldWrapperComponent extends FieldWrapper {}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-675

**Description**

Add bannerTitle and bannerText on json form properties in order to add a banner with detailed information instead of having long hints

For instance, a field with this description
```
    "bootstrapServers": {
      "type": "string",
      "title": "bootstrap.servers",
      "description": "This list should be in the form host1:port1,host2:port2,...",
      "widget": {
        "formlyConfig": {
          "props": {
            "bannerTitle": "Bootstrap servers",
            "bannerText": "A list of host/port pairs, separated by a comma, to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping—this list only impacts the initial hosts used to discover the full set of servers."
          }
        }
      }
    },
```

will have this rendering

![screenshot-localhost_9008-2023 02 14-12_16_42](https://user-images.githubusercontent.com/1655950/218721587-029ed673-a4cc-4cf8-9d53-0055f4ba7c85.png)
<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-particles-angular@5.5.0-add-gio-field-wrapper-102d1a5
```
```
yarn add @gravitee/ui-particles-angular@5.5.0-add-gio-field-wrapper-102d1a5
```
<!-- Prerelease placeholder end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xrbuvcmtab.chromatic.com)
<!-- Storybook placeholder end -->
