### PR TITLE
Display multiple spaces properly in Confirm and Validate dialog

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.scss
@@ -19,13 +19,19 @@
 @use '../../scss' as gio;
 
 .confirm-dialog {
+  &__title {
+    white-space: pre-wrap;
+  }
+
   &__body {
     &__content {
       color: mat.get-color-from-palette(gio.$mat-content-palette);
+      white-space: pre-wrap;
     }
 
     &__validate-message {
       margin-bottom: 8px;
+      white-space: pre-wrap;
     }
 
     &__validate-input {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.stories.ts
@@ -120,11 +120,24 @@ export const Custom: StoryObj<GioConfirmAndValidateDialogData> = {
   },
 };
 Custom.args = {
-  title: 'Are you sure you want to remove all cats ?',
+  title: 'Are you sure you want to remove all cats?',
   warning: 'This action is irreversible',
   content: '🙀😿 Are you sure? You can’t undo this action afterwards.',
   validationMessage: 'Type "remove" to confirm',
   validationValue: 'remove',
   confirmButton: 'Yes, I want',
   cancelButton: 'Nope',
+};
+
+export const WithMultipleSpaces: StoryObj<GioConfirmAndValidateDialogData> = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-confirm-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+WithMultipleSpaces.args = {
+  ...Custom.args,
+  title: 'Are you sure you want to remove a `Specific   Cat`?',
+  content: '🙀😿 Are you sure? Removing a <code>Specific   Cat</code> can’t be undone afterwards.',
+  validationMessage: 'Type <code>Specific   Cat</code> to confirm',
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
@@ -39,7 +39,6 @@
     text-align: center;
     text-transform: capitalize;
     vertical-align: middle;
-    white-space: nowrap;
 
     .mat-icon {
       width: inherit;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8867
https://gravitee.atlassian.net/browse/APIM-779

**Description**

Display multiple spaces properly in Confirm and Validate dialog
<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-policy-studio-angular@5.7.1-fix-multiple-spaces-display-260cf45
```
```
yarn add @gravitee/ui-policy-studio-angular@5.7.1-fix-multiple-spaces-display-260cf45
```
<!-- Prerelease placeholder end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-gmbjnymehk.chromatic.com)
<!-- Storybook placeholder end -->
