### PR TITLE
fix: add mutltischema type component for GioFormJsonSchemaModule

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
@@ -40,12 +40,14 @@ import {
 import { GioFormJsonSchemaComponent } from './gio-form-json-schema.component';
 import { GioFormFieldWrapperComponent } from './wrappers/gio-form-field-wrapper.component';
 import { bannerExtension } from './wrappers/gio-banner-extension';
+import { GioFjsMultiSchemaTypeComponent } from './type-component/multischema-type.component';
 
 @NgModule({
   declarations: [
     GioFormJsonSchemaComponent,
     GioFjsNullTypeComponent,
     GioFjsObjectTypeComponent,
+    GioFjsMultiSchemaTypeComponent,
     GioFjsArrayTypeComponent,
     GioFormFieldWrapperComponent,
   ],
@@ -73,6 +75,7 @@ import { bannerExtension } from './wrappers/gio-banner-extension';
         { name: 'null', component: GioFjsNullTypeComponent, wrappers: ['form-field'] },
         { name: 'array', component: GioFjsArrayTypeComponent },
         { name: 'object', component: GioFjsObjectTypeComponent },
+        { name: 'multischema', component: GioFjsMultiSchemaTypeComponent },
       ],
       extensions: [{ name: 'banner', extension: { onPopulate: bannerExtension } }],
     }),

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/multischema-type.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/multischema-type.component.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+
+@Component({
+  selector: 'gio-fjs-multi-schema-type',
+  template: `
+    <div class="card mb-3">
+      <div class="card-body">
+        <legend *ngIf="props.label">{{ props.label }}</legend>
+        <p *ngIf="props.description">{{ props.description }}</p>
+        <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
+          <formly-validation-message [field]="field"></formly-validation-message>
+        </div>
+        <formly-field *ngFor="let f of field.fieldGroup" [field]="f"></formly-field>
+      </div>
+    </div>
+  `,
+})
+export class GioFjsMultiSchemaTypeComponent extends FieldType {}


### PR DESCRIPTION
**Issue**

n/a

**Description**

fix console error and support oneOf,.. with formly

But we need to complet this supported feature with dedicated exemple and test/validate more complex stuff

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-policy-studio-angular@5.7.1-multischema-150635a
```
```
yarn add @gravitee/ui-policy-studio-angular@5.7.1-multischema-150635a
```
<!-- Prerelease placeholder end -->
