### PR TITLE
feat: impl ControlValueAccessor for GioFormJsonSchemaComponent

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/README.stories.mdx
@@ -18,14 +18,13 @@ yarn add @ngx-formly/core @ngx-formly/material
 
 ## Usage
 
-To create a form based on a json schema, you can include this component like this.
+To create a form based on a json schema, you can include this component like this. With ReactiveForm
 
 ```html
 <gio-form-json-schema
   [jsonSchema]="jsonSchema"
   [options]="options"
-  [formGroup]="form"
-  [initialValue]="initialValue"
+  formControlName="formControl"
 ></gio-form-json-schema>
 ```
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
@@ -13,44 +13,116 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, ElementRef, Host, Input, OnDestroy, OnInit, Optional } from '@angular/core';
+import { ControlValueAccessor, FormGroup, NgControl } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
 import { cloneDeep, isObject } from 'lodash';
 import { JSONSchema7 } from 'json-schema';
+import { filter, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { FocusMonitor } from '@angular/cdk/a11y';
 
 import { GioJsonSchema } from './model/GioJsonSchema';
 
 @Component({
   selector: 'gio-form-json-schema',
-  template: `<formly-form [fields]="fields" [options]="options" [form]="formGroup" [model]="model"></formly-form>`,
+  template: `<formly-form *ngIf="formGroup" [fields]="fields" [options]="options" [form]="formGroup" [model]="model"></formly-form>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GioFormJsonSchemaComponent {
+export class GioFormJsonSchemaComponent implements ControlValueAccessor, OnInit, OnDestroy {
+  private unsubscribe$: Subject<void> = new Subject<void>();
+
   @Input()
   public set jsonSchema(jsonSchema: GioJsonSchema) {
     if (isObject(jsonSchema)) {
       this.fields = [this.toFormlyFieldConfig(jsonSchema)];
     }
   }
-  @Input()
+
   public formGroup: FormGroup = new FormGroup({});
 
   @Input()
   public options: FormlyFormOptions = {};
 
-  public model = {};
-
-  @Input()
-  public set initialValue(initialValue: object) {
-    if (initialValue) {
-      this.model = cloneDeep(initialValue);
-    }
-  }
+  public model: unknown = {};
 
   public fields: FormlyFieldConfig[] = [];
 
-  constructor(private readonly formlyJsonschema: FormlyJsonschema) {}
+  public _onChange: (value: unknown | null) => void = () => ({});
+
+  public _onTouched: () => void = () => ({});
+
+  private touched = false;
+
+  constructor(
+    private readonly formlyJsonschema: FormlyJsonschema,
+    private readonly elRef: ElementRef,
+    private readonly fm: FocusMonitor,
+    @Host() @Optional() public readonly ngControl?: NgControl,
+  ) {
+    if (ngControl) {
+      // Setting the value accessor directly (instead of using
+      // the providers `NG_VALUE_ACCESSOR`) to avoid running into a circular import.
+      ngControl.valueAccessor = this;
+    }
+
+    // When the user interact with the form, mark it as touched
+    fm.monitor(elRef.nativeElement, true)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => {
+        this._onTouched();
+        this.touched = true;
+      });
+  }
+
+  public ngOnInit(): void {
+    this.formGroup.statusChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(status => {
+      if (status === 'VALID') {
+        this.ngControl?.control?.setErrors(null);
+      }
+      if (status === 'INVALID') {
+        this.ngControl?.control?.setErrors({ invalid: true });
+      }
+    });
+
+    // To simulate the behavior of classic form controls, emit value only when the form is touched
+    // Allow to keep the formControl pristine until the user interact with it
+    this.formGroup.valueChanges
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        filter(() => this.touched),
+      )
+      .subscribe(value => {
+        this._onChange(value);
+      });
+  }
+
+  public ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+    this.fm.stopMonitoring(this.elRef.nativeElement);
+  }
+
+  // From ControlValueAccessor
+  public writeValue(value: unknown): void {
+    this.model = cloneDeep(value) ?? {};
+  }
+
+  // From ControlValueAccessor
+  public registerOnChange(fn: (value: unknown | null) => void): void {
+    this._onChange = fn;
+  }
+
+  // From ControlValueAccessor
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  // From ControlValueAccessor
+  public setDisabledState?(_isDisabled: boolean): void {
+    throw new Error('Method not implemented.');
+  }
 
   private toFormlyFieldConfig(jsonSchema: GioJsonSchema): FormlyFieldConfig {
     return this.formlyJsonschema.toFieldConfig(jsonSchema, {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
@@ -18,6 +18,7 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule } from '@ngx-formly/core';
 import { FormlyMaterialModule } from '@ngx-formly/material';
+import { A11yModule } from '@angular/cdk/a11y';
 
 import { GioIconsModule } from '../gio-icons/gio-icons.module';
 
@@ -53,6 +54,7 @@ import { GioFjsMultiSchemaTypeComponent } from './type-component/multischema-typ
   ],
   imports: [
     CommonModule,
+    A11yModule,
     ReactiveFormsModule,
     FormlyModule.forRoot({
       validationMessages: [
@@ -78,6 +80,9 @@ import { GioFjsMultiSchemaTypeComponent } from './type-component/multischema-typ
         { name: 'multischema', component: GioFjsMultiSchemaTypeComponent },
       ],
       extensions: [{ name: 'banner', extension: { onPopulate: bannerExtension } }],
+      extras: {
+        checkExpressionOn: 'changeDetectionCheck',
+      },
     }),
     FormlyMaterialModule,
     GioIconsModule,

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.html
@@ -38,16 +38,14 @@
 
     <mat-card-content>
       <form *ngIf="form" [formGroup]="form" (ngSubmit)="onSubmit()">
-        <gio-form-json-schema
-          [jsonSchema]="jsonSchema"
-          [options]="options"
-          [formGroup]="form"
-          [initialValue]="initialValue"
-        ></gio-form-json-schema>
+        <gio-form-json-schema [jsonSchema]="jsonSchema" [options]="options" formControlName="schemaValue"></gio-form-json-schema>
 
         --- <br />
         <button type="submit">Submit</button><br />
         --- <br />
+        <pre>{{ form.status }}</pre>
+        <pre>{{ form.dirty ? 'DIRTY' : 'PRISTINE' }}</pre>
+        <pre>{{ form.touched ? 'TOUCHED' : 'UNTOUCHED' }}</pre>
         <pre>{{ formValue | json }}</pre>
       </form>
     </mat-card-content>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import { ChangeDetectorRef, Component, Input, OnChanges } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { FormlyFormOptions } from '@ngx-formly/core';
+import { startWith } from 'rxjs/operators';
 
 import { FormlyJSONSchema7 } from './model/FormlyJSONSchema7';
 
@@ -39,8 +40,10 @@ export class DemoComponent implements OnChanges {
   constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
   public ngOnChanges(): void {
-    this.form = new FormGroup({});
-    this.form.valueChanges.subscribe(value => {
+    this.form = new FormGroup({
+      schemaValue: new FormControl(this.initialValue),
+    });
+    this.form.valueChanges.pipe(startWith(this.form.value)).subscribe(value => {
       this.formValue = value;
       this.changeDetectorRef.detectChanges();
     });


### PR DESCRIPTION
**Issue**

n/a

**Description**

Improve GioFormJsonSchemaComponent with ControlValueAccessor to simplify the use of JsonForm Input.
And connect dirty  & touched to be able to use it

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-policy-studio-angular@5.7.3-improve-form-json-compo-cb73491
```
```
yarn add @gravitee/ui-policy-studio-angular@5.7.3-improve-form-json-compo-cb73491
```
<!-- Prerelease placeholder end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-cqasnoermm.chromatic.com)
<!-- Storybook placeholder end -->
