### PR TITLE
feat: improve use of mat-form-field inside table

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-table.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-table.scss
@@ -25,5 +25,28 @@ $background: map.get(theme.$mat-theme, background);
     tbody tr:hover {
       background-color: mat.get-color-from-palette($background, hover);
     }
+
+    // Remove bottom padding on mat-form-field inside mat-cell
+    // Note: In Angular 15, we should be able to use SubscriptSizing option for that
+    .mat-cell {
+      // appearance=fill
+      .mat-form-field.mat-form-field-appearance-outline:not(.ng-invalid, :has(mat-hint)) {
+        padding-bottom: 0;
+
+        .mat-form-field-wrapper {
+          padding-bottom: 0;
+        }
+      }
+
+      // appearance=standard
+      .mat-form-field.mat-form-field-appearance-standard:not(.ng-invalid, :has(mat-hint)) {
+        padding-bottom: 0;
+
+        .mat-form-field-wrapper {
+          // stylelint-disable-next-line number-max-precision
+          margin-bottom: -1.34375em;
+        }
+      }
+    }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-table.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-table.stories.ts
@@ -16,8 +16,11 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormsModule } from '@angular/forms';
 import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 
 interface PeriodicElement {
   name: string;
@@ -43,13 +46,13 @@ export default {
   title: 'Material Override',
   decorators: [
     moduleMetadata({
-      imports: [BrowserAnimationsModule, ReactiveFormsModule, MatTableModule],
+      imports: [BrowserAnimationsModule, FormsModule, MatTableModule, MatFormFieldModule, MatInputModule, MatSelectModule],
     }),
   ],
   render: () => ({}),
 } as Meta;
 
-export const MatTable: Story = {
+export const MatTableRowsHover: Story = {
   render: () => ({
     template: `
       <p>
@@ -97,6 +100,95 @@ export const MatTable: Story = {
     props: {
       displayedColumns: ['position', 'name', 'weight', 'symbol'],
       dataSource: ELEMENT_DATA,
+    },
+  }),
+};
+
+export const MatTableWithMatFormField: Story = {
+  render: () => ({
+    template: `<p>Keep or remove padding-bottom for mat-form-field in table td</p>
+
+    <table mat-table [dataSource]="dataSource" matSort style="width: 100%">
+      <!-- Position Column -->
+      <ng-container matColumnDef="position">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>No.</th>
+        <td mat-cell *matCellDef="let element">{{element.position}}</td>
+      </ng-container>
+    
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
+        <td mat-cell *matCellDef="let element">
+          <mat-form-field [appearance]="element.position === 4 ? 'standard': 'outline'">
+            <mat-label *ngIf="element.position === 1">Name</mat-label>
+            <input
+              matInput
+              [ngModel]="element.name"
+              [minlength]="element.position === 3 ? 42 : 1"
+              [errorStateMatcher]="errorStateMatcher"
+            />
+            <mat-hint *ngIf="element.position === 2"
+              >Keep padding for hint</mat-hint
+            >
+            <mat-error *ngIf="element.position === 3"
+              >Keep padding for error</mat-error
+            >
+          </mat-form-field>
+        </td>
+      </ng-container>
+    
+      <!-- Weight Column -->
+      <ng-container matColumnDef="weight">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Weight</th>
+        <td mat-cell *matCellDef="let element">{{element.weight}}</td>
+      </ng-container>
+    
+      <!-- Symbol Column -->
+      <ng-container matColumnDef="symbol">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Symbol</th>
+        <td mat-cell *matCellDef="let element">
+          <mat-form-field [appearance]="element.position === 4 ? 'standard': 'outline'">
+            <mat-label *ngIf="element.position === 1">Name</mat-label>
+            <mat-select
+              [ngModel]="element.position === 3 ? null : element.symbol"
+              [required]="element.position === 3 ? 42 : 1"
+              [errorStateMatcher]="errorStateMatcher"
+            >
+              <mat-option value="H">H</mat-option>
+              <mat-option value="He">He</mat-option>
+              <mat-option value="Li">Li</mat-option>
+              <mat-option value="Be">Be</mat-option>
+              <mat-option value="B">B</mat-option>
+              <mat-option value="C">C</mat-option>
+              <mat-option value="N">N</mat-option>
+            </mat-select>
+            <mat-hint *ngIf="element.position === 2"
+              >Keep padding for hint</mat-hint
+            >
+            <mat-error *ngIf="element.position === 3"
+              >Keep padding for error</mat-error
+            >
+          </mat-form-field>
+        </td>
+      </ng-container>
+    
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="displayedColumns.length">No Data</td>
+      </tr>
+    </table>
+    `,
+    props: {
+      displayedColumns: ['position', 'name', 'weight', 'symbol'],
+      dataSource: ELEMENT_DATA,
+      errorStateMatcher: {
+        // Invalid form immediately if invalid
+        isErrorState(control: FormControl | null): boolean {
+          return !!(control && control.invalid);
+        },
+      },
     },
   }),
 };


### PR DESCRIPTION
**Issue**
Not required but improve UI for

https://gravitee.atlassian.net/browse/APIM-653
And some others like path table inside api creation workflow

**Description**

With this override : 
<img width="988" alt="image" src="https://user-images.githubusercontent.com/4974420/221924179-738a6c4c-7292-40ac-81f4-66701866cdb6.png">

Without :
<img width="998" alt="image" src="https://user-images.githubusercontent.com/4974420/221924343-6c36469f-bdd4-413c-9a46-1d3af71a8bc0.png">
 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease
```
npm install @gravitee/ui-particles-angular@5.7.3-table-form-field-62c3e2d
```
```
yarn add @gravitee/ui-particles-angular@5.7.3-table-form-field-62c3e2d
```
<!-- Prerelease placeholder end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-nlqxcvrtms.chromatic.com)
<!-- Storybook placeholder end -->
