### PR TITLE
feat: allow to add inner content like button inside save-bar

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/README.stories.mdx
@@ -8,7 +8,8 @@ Try to scroll and focus on the first invalid field of a form.
 
 ## Usage
 
-Add this directive to the form element.
+### On submit form
+Add this directive to the form element. When the form is submitted, the first invalid field will be focused.
 
 Example :
 
@@ -19,3 +20,15 @@ Example :
   <input type="submit" />
 </form>
 ```
+
+### On click button
+Add this directive to the button element. When the button is clicked, the first invalid field will be focused.
+
+Example :
+
+```html
+<form>
+  <input type="text" name="name" required />
+  <input type="email" name="email" required />
+  <button type="button" gioFormFocusInvalid>Go to first form error</button>
+</form>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid-ignore.directive.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid-ignore.directive.ts
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NgModule } from '@angular/core';
+import { Directive } from '@angular/core';
 
-import { GioFormFocusInvalidIgnoreDirective } from './gio-form-focus-first-invalid-ignore.directive';
-import { GioFormFocusInvalidFormDirective, GioButtonFocusInvalidButtonDirective } from './gio-form-focus-first-invalid.directive';
+export const GIO_FORM_FOCUS_INVALID_IGNORE_SELECTOR = 'gioFormFocusInvalidIgnore';
 
-@NgModule({
-  declarations: [GioFormFocusInvalidFormDirective, GioButtonFocusInvalidButtonDirective, GioFormFocusInvalidIgnoreDirective],
-  exports: [GioFormFocusInvalidFormDirective, GioButtonFocusInvalidButtonDirective, GioFormFocusInvalidIgnoreDirective],
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: `[${GIO_FORM_FOCUS_INVALID_IGNORE_SELECTOR}]`,
 })
-export class GioFormFocusInvalidModule {}
+export class GioFormFocusInvalidIgnoreDirective {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.directive.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.directive.ts
@@ -16,14 +16,10 @@
 import { Directive, HostListener, Renderer2, Optional } from '@angular/core';
 import { FormGroupDirective } from '@angular/forms';
 
-@Directive({
-  selector: 'form[gioFormFocusInvalid]',
-})
-export class GioFormFocusInvalidDirective {
+@Directive()
+export class GioBaseFormFocusInvalidDirective {
   constructor(private readonly renderer: Renderer2, @Optional() protected readonly formGroupDirective: FormGroupDirective) {}
-
-  @HostListener('submit')
-  public onFormSubmit() {
+  protected focusOnFirstInvalid() {
     const selector = '.ng-invalid[formControlName],input.ng-invalid,mat-select.ng-invalid,textarea.ng-invalid,.gio-ng-invalid';
     try {
       // Mark all controls as touched to display errors
@@ -47,5 +43,25 @@ export class GioFormFocusInvalidDirective {
       // Best effort. If the focus doesn't work it's not very important
       // 🧪 Useful to avoid som error in tests
     }
+  }
+}
+
+@Directive({
+  selector: 'form[gioFormFocusInvalid]',
+})
+export class GioFormFocusInvalidFormDirective extends GioBaseFormFocusInvalidDirective {
+  @HostListener('submit')
+  public onFormSubmit() {
+    this.focusOnFirstInvalid();
+  }
+}
+
+@Directive({
+  selector: 'button[gioFormFocusInvalid]',
+})
+export class GioButtonFocusInvalidButtonDirective extends GioBaseFormFocusInvalidDirective {
+  @HostListener('click')
+  public onClick() {
+    this.focusOnFirstInvalid();
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.module.ts
@@ -15,10 +15,10 @@
  */
 import { NgModule } from '@angular/core';
 
-import { GioFormFocusInvalidDirective } from './gio-form-focus-first-invalid.directive';
+import { GioFormFocusInvalidFormDirective, GioButtonFocusInvalidButtonDirective } from './gio-form-focus-first-invalid.directive';
 
 @NgModule({
-  declarations: [GioFormFocusInvalidDirective],
-  exports: [GioFormFocusInvalidDirective],
+  declarations: [GioFormFocusInvalidFormDirective, GioButtonFocusInvalidButtonDirective],
+  exports: [GioFormFocusInvalidFormDirective, GioButtonFocusInvalidButtonDirective],
 })
 export class GioFormFocusInvalidModule {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.stories.ts
@@ -67,7 +67,7 @@ export const Demo: Story = {
 
         <mat-form-field>
           <mat-label>Input</mat-label>
-          <input matInput required formControlName="anInput">
+          <input gioFormFocusInvalidIgnore matInput required formControlName="anInput">
         </mat-form-field>
 
         <br *ngFor="let item of [].constructor(30)">

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/gio-form-focus-first-invalid.stories.ts
@@ -20,16 +20,17 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
 
 import { GioSaveBarModule } from '../gio-save-bar/gio-save-bar.module';
 import { GioFormTagsInputModule } from '../gio-form-tags-input/gio-form-tags-input.module';
 
-import { GioFormFocusInvalidDirective } from './gio-form-focus-first-invalid.directive';
+import { GioFormFocusInvalidFormDirective } from './gio-form-focus-first-invalid.directive';
 import { GioFormFocusInvalidModule } from './gio-form-focus-first-invalid.module';
 
 export default {
   title: 'Components / Form Focus invalid',
-  component: GioFormFocusInvalidDirective,
+  component: GioFormFocusInvalidFormDirective,
   decorators: [
     moduleMetadata({
       imports: [
@@ -40,6 +41,7 @@ export default {
         MatFormFieldModule,
         MatInputModule,
         MatSelectModule,
+        MatButtonModule,
         GioFormTagsInputModule,
       ],
     }),
@@ -104,10 +106,18 @@ export const Demo: Story = {
         <br *ngFor="let item of [].constructor(30)">
 
       </div>
+      <p>Focusing the 1st input in error when form is submitted</p>
       <gio-save-bar
         [creationMode]="true"
         [form]="form">
       </gio-save-bar>
+
+      <p>Focusing the 1st input in error with simple button</p>
+      <button
+        type="button"
+        gioFormFocusInvalid
+        mat-raised-button
+        >Go to first form error</button>
     </form>
     `,
       props: {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, ElementRef, Host, Input, OnDestroy, OnInit, Optional } from '@angular/core';
+import { Component, ElementRef, Host, HostBinding, Input, OnDestroy, OnInit, Optional } from '@angular/core';
 import { ControlValueAccessor, FormGroup, NgControl } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { cloneDeep, isEmpty, isObject } from 'lodash';
 import { debounceTime, distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
 import { combineLatest, Subject } from 'rxjs';
 import { FocusMonitor } from '@angular/cdk/a11y';
+
+import { GIO_FORM_FOCUS_INVALID_IGNORE_SELECTOR } from '../gio-form-focus-first-invalid/gio-form-focus-first-invalid-ignore.directive';
 
 import { GioJsonSchema } from './model/GioJsonSchema';
 import { GioFormlyJsonSchemaService } from './gio-formly-json-schema.service';
@@ -36,6 +38,9 @@ export class GioFormJsonSchemaComponent implements ControlValueAccessor, OnInit,
     return isObject(jsonSchema) && properties.some(property => !isEmpty(jsonSchema[property]));
   }
   private unsubscribe$: Subject<void> = new Subject<void>();
+
+  @HostBinding(`attr.${GIO_FORM_FOCUS_INVALID_IGNORE_SELECTOR}`)
+  private gioFormFocusInvalidIgnore = true;
 
   @Input()
   public set jsonSchema(jsonSchema: GioJsonSchema) {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
@@ -19,12 +19,20 @@
 <div *ngIf="isOpen" [@slideUpDown] [@.disabled]="creationMode">
   <mat-card class="save-bar__content" [class.mat-elevation-z3]="creationMode" [class.mat-elevation-z6]="!creationMode">
     <div class="save-bar__content__label">{{ creationMode ? '' : 'You have unsaved changes' }}</div>
-    <div>
-      <button *ngIf="!creationMode" class="save-bar__content__reset-button" mat-button type="button" (click)="onResetClicked()">
+    <div class="save-bar__content__actions">
+      <button
+        *ngIf="!creationMode && !hideDiscardButton"
+        class="save-bar__content__actions__reset-button"
+        mat-button
+        type="button"
+        (click)="onResetClicked()"
+      >
         Discard
       </button>
+      <ng-content></ng-content>
       <button
-        class="save-bar__content__submit-button"
+        *ngIf="!hideSubmitButton"
+        class="save-bar__content__actions__submit-button"
         [class.invalid]="(form && form.invalid) || invalidState"
         mat-flat-button
         color="primary"

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.scss
@@ -50,18 +50,19 @@ $typography: map.get(gio.$mat-theme, typography);
     @include mat.typography-level($typography, body-1);
   }
 
-  &__reset-button {
-    margin-right: 16px;
-  }
+  &__actions {
+    display: flex;
+    gap: 16px;
 
-  &__submit-button {
-    &.invalid {
-      background-color: mat.get-color-from-palette(gio.$mat-primary-palette, 'lighter');
-      color: mat.get-color-from-palette(gio.$mat-primary-palette, 'lighter-contrast');
+    &__submit-button {
+      &.invalid {
+        background-color: mat.get-color-from-palette(gio.$mat-primary-palette, 'lighter');
+        color: mat.get-color-from-palette(gio.$mat-primary-palette, 'lighter-contrast');
 
-      &:hover:enabled {
-        background-color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default');
-        color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default-contrast');
+        &:hover:enabled {
+          background-color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default');
+          color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default-contrast');
+        }
       }
     }
   }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
@@ -64,6 +64,12 @@ export class GioSaveBarComponent {
   @Input()
   public formInitialValues?: unknown;
 
+  @Input()
+  public hideSubmitButton = false;
+
+  @Input()
+  public hideDiscardButton = false;
+
   @Output()
   public resetClicked = new EventEmitter<void>();
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.harness.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.harness.ts
@@ -19,15 +19,16 @@ import { ComponentHarness } from '@angular/cdk/testing';
 export class GioSaveBarHarness extends ComponentHarness {
   public static hostSelector = 'gio-save-bar';
 
-  private readonly resetButtonSelector = '.save-bar__content__reset-button';
-  private readonly submitButtonSelector = '.save-bar__content__submit-button';
+  private readonly cardSelector = '.save-bar__content';
+  private readonly resetButtonSelector = '.save-bar__content__actions__reset-button';
+  private readonly submitButtonSelector = '.save-bar__content__actions__submit-button';
 
   protected getSubmitButton = this.locatorFor(this.submitButtonSelector);
   protected getResetButton = this.locatorFor(this.resetButtonSelector);
 
   public async isVisible(): Promise<boolean> {
-    const submitButton = await this.locatorForOptional(this.submitButtonSelector)();
-    return submitButton !== null;
+    const card = await this.locatorForOptional(this.cardSelector)();
+    return card !== null;
   }
 
   public async clickSubmit(): Promise<void> {
@@ -40,6 +41,11 @@ export class GioSaveBarHarness extends ComponentHarness {
   public async isSubmitButtonInvalid(): Promise<boolean> {
     const submitButton = await this.getSubmitButton();
     return submitButton.hasClass('invalid');
+  }
+
+  public async isSubmitButtonVisible(): Promise<boolean> {
+    const submitButton = await this.locatorForOptional(this.submitButtonSelector)();
+    return submitButton !== null;
   }
 
   public async isResetButtonVisible(): Promise<boolean> {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.module.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.module.spec.ts
@@ -37,6 +37,8 @@ describe('GioSaveBarModule', () => {
           <gio-save-bar
             [opened]="opened"
             [invalidState]="invalidState"
+            [hideSubmitButton]="hideSubmitButton"
+            [hideDiscardButton]="hideDiscardButton"
             (resetClicked)="onReset($event)"
             (submitted)="onSubmit($event)"
             (submittedInvalidState)="onSubmitInvalidState($event)"
@@ -47,6 +49,8 @@ describe('GioSaveBarModule', () => {
     class TestComponent {
       public opened = false;
       public invalidState = false;
+      public hideSubmitButton = false;
+      public hideDiscardButton = false;
       public onReset = onResetMock;
       public onSubmit = onSubmitMock;
       public onSubmitInvalidState = onSubmitInvalidStateMock;
@@ -113,6 +117,19 @@ describe('GioSaveBarModule', () => {
       await saveBar.clickSubmit();
       expect(onSubmitMock).not.toHaveBeenCalled();
       expect(onSubmitInvalidStateMock).toHaveBeenCalled();
+    });
+
+    it('should hide submit & discard button', async () => {
+      fixture.detectChanges();
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      component.opened = true;
+      component.hideSubmitButton = true;
+      component.hideDiscardButton = true;
+      fixture.detectChanges();
+      expect(await saveBar.isVisible()).toEqual(true);
+      expect(await saveBar.isSubmitButtonVisible()).toEqual(false);
+      expect(await saveBar.isResetButtonVisible()).toEqual(false);
     });
   });
 
@@ -241,11 +258,12 @@ describe('GioSaveBarModule', () => {
       template: `
         <div>
           <input />
-          <gio-save-bar creationMode="true" (submitted)="onSubmit($event)"></gio-save-bar>
+          <gio-save-bar creationMode="true" [hideSubmitButton]="hideSubmitButton" (submitted)="onSubmit($event)"></gio-save-bar>
         </div>
       `,
     })
     class TestComponent {
+      public hideSubmitButton = false;
       public onSubmit = onSubmitMock;
     }
 
@@ -279,6 +297,16 @@ describe('GioSaveBarModule', () => {
 
       await saveBar.clickSubmit();
       expect(onSubmitMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hide submit button', async () => {
+      fixture.detectChanges();
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      fixture.componentInstance.hideSubmitButton = true;
+      fixture.detectChanges();
+      expect(await saveBar.isSubmitButtonVisible()).toEqual(false);
+      expect(await saveBar.isResetButtonVisible()).toEqual(false);
     });
   });
 });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
@@ -18,6 +18,7 @@ import { Story } from '@storybook/angular/types-7-0';
 import { action } from '@storybook/addon-actions';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 
 import { GioSaveBarComponent } from './gio-save-bar.component';
 import { GioSaveBarModule } from './gio-save-bar.module';
@@ -27,7 +28,7 @@ export default {
   component: GioSaveBarComponent,
   decorators: [
     moduleMetadata({
-      imports: [FormsModule, GioSaveBarModule, BrowserAnimationsModule, ReactiveFormsModule],
+      imports: [FormsModule, MatButtonModule, GioSaveBarModule, BrowserAnimationsModule, ReactiveFormsModule],
     }),
   ],
 } as Meta;
@@ -118,6 +119,40 @@ export const SimpleUsageInCreationMode: Story = {
        <gio-save-bar
         [creationMode]="true"
         [opened]="true">
+      </gio-save-bar>
+    </div>
+    `,
+  }),
+};
+
+export const CustomInnerButtonInCreationMode: Story = {
+  name: 'Creation Mode / Custom Inner Button',
+  render: () => ({
+    template: `
+    <div style="padding: 16px">
+       <gio-save-bar
+        [creationMode]="true"
+        [hideSubmitButton]="true"
+        >
+        <button mat-flat-button color="primary">Next</button>
+      </gio-save-bar>
+    </div>
+    `,
+  }),
+};
+
+export const CustomInnerButtonInUpdateMode: Story = {
+  name: 'Update Mode / Custom Inner Button',
+  render: () => ({
+    template: `
+    <div style="padding: 16px">
+       <gio-save-bar
+        [creationMode]="false"
+        [opened]="true"
+        [hideSubmitButton]="true"
+        [hideDiscardButton]="true"
+        >
+        <button mat-flat-button color="primary">Next</button>
       </gio-save-bar>
     </div>
     `,

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/public-api.ts
@@ -62,6 +62,7 @@ export * from './gio-form-slide-toogle/gio-form-slide-toggle.module';
 export * from './gio-form-slide-toogle/gio-form-label.directive';
 
 export * from './gio-form-focus-first-invalid/gio-form-focus-first-invalid.directive';
+export * from './gio-form-focus-first-invalid/gio-form-focus-first-invalid-ignore.directive';
 export * from './gio-form-focus-first-invalid/gio-form-focus-first-invalid.module';
 
 export * from './gio-monaco-editor/gio-monaco-editor.component';


### PR DESCRIPTION

**Issue**

Part of : https://gravitee.atlassian.net/browse/APIM-966

**Description**

Allow to add inner content like button inside save-bar
Main goal is to add stepper next/back actions



<img width="1511" alt="image" src="https://user-images.githubusercontent.com/4974420/229802265-d7f1355d-444e-422e-b40e-f424726d85bc.png">

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@5.19.1-feat-save-bar-5d4fc8b
```
```
yarn add @gravitee/ui-particles-angular@5.19.1-feat-save-bar-5d4fc8b
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@5.19.1-feat-save-bar-5d4fc8b
```
```
yarn add @gravitee/ui-policy-studio-angular@5.19.1-feat-save-bar-5d4fc8b
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vvzbfvkzvi.chromatic.com)
<!-- Storybook placeholder end -->
