### PR TITLE
Fix json schema

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-focus-first-invalid/README.stories.mdx
@@ -4,7 +4,8 @@ import { Meta, Story } from '@storybook/addon-docs';
 
 # Form Focus invalid
 
-Try to scroll and focus on the first invalid field of a form.
+Try to scroll and focus on the first invalid field of a form. 
+The FormFocusInvalid get all invalid fields in parent form and find the first one to focus on.
 
 ## Usage
 
@@ -32,3 +33,24 @@ Example :
   <input type="email" name="email" required />
   <button type="button" gioFormFocusInvalid>Go to first form error</button>
 </form>
+```
+
+### Ignore fields
+Add this directive `gioFormFocusInvalidIgnore` to the field to ignore it.
+As the FormFocusInvalid get all invalid fields in parent form this directive will ignore the field to allow to focus on the next one.
+
+You can also add this attribute to host component (like custom form control) always to ignore it. If the component itself contains form elements it allows to focus on them.
+
+```ts 
+import {GIO_FORM_FOCUS_INVALID_IGNORE_SELECTOR} from "@gravitee/ui-particles-angular";
+
+...
+
+@Component(...)
+export class CustomFormComponent implements ControlValueAccessor {
+  ...
+  @HostBinding(`attr.${GIO_FORM_FOCUS_INVALID_IGNORE_SELECTOR}`)
+  private gioFormFocusInvalidIgnore = true;
+  ...
+}
+```

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
@@ -1,7 +1,7 @@
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatInputHarness } from '@angular/material/input/testing';
@@ -34,6 +34,7 @@ describe('GioFormJsonSchema', () => {
         <button type="submit">Submit</button>
       </form>
     `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
   })
   class TestComponent {
     public form = new FormGroup({
@@ -75,6 +76,7 @@ describe('GioFormJsonSchema', () => {
       fixture.detectChanges();
       expect(testComponent.form.touched).toEqual(false);
       expect(testComponent.form.dirty).toEqual(false);
+      expect(testComponent.form.invalid).toEqual(false);
 
       const simpleStringInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="simpleString"]' }));
       await simpleStringInput.setValue('What the fox say?');
@@ -84,10 +86,29 @@ describe('GioFormJsonSchema', () => {
       });
       expect(testComponent.form.touched).toEqual(true);
       expect(testComponent.form.dirty).toEqual(true);
+      expect(testComponent.form.invalid).toEqual(false);
 
       // No banner on simple elements
       const banner = fixture.nativeElement.querySelector('.banner');
       expect(banner).toBeNull();
+    });
+
+    it('should init invalid form', async () => {
+      fixture.componentInstance.jsonSchema = {
+        type: 'object',
+        properties: {
+          simpleString: {
+            title: 'Simple String',
+            description: 'Simple string without validation',
+            type: 'string',
+          },
+        },
+        required: ['simpleString'],
+      };
+      fixture.detectChanges();
+      expect(testComponent.form.touched).toEqual(false);
+      expect(testComponent.form.dirty).toEqual(false);
+      expect(testComponent.form.invalid).toEqual(true);
     });
 
     it('should show banner', async () => {
@@ -116,7 +137,7 @@ describe('GioFormJsonSchema', () => {
     });
   });
 
-  describe('GioFormJsonSchemaComponentisDisplayable', () => {
+  describe('GioFormJsonSchemaComponent.isDisplayable', () => {
     it('should return true if schema has properties', () => {
       const schema: GioJsonSchema = {
         type: 'object',


### PR DESCRIPTION
**Issue**

n/a

**Description**

Small bug see in api creation workflow. 

By default the json-schema control is valid. but if the schema form have required field we need to change it when detected.
and formly detect it after the AfterViewInit 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

