### PR TITLE
refactor: remove deprecated colors

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.scss
@@ -25,7 +25,7 @@
 
   &__body {
     &__content {
-      color: mat.get-color-from-palette(gio.$mat-content-palette);
+      color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
       white-space: pre-wrap;
     }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.scss
@@ -20,6 +20,6 @@
 
 .confirm-dialog {
   &__content {
-    color: mat.get-color-from-palette(gio.$mat-content-palette);
+    color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
@@ -35,7 +35,7 @@ $typography: map.get(gio.$mat-theme, typography);
   padding: 4px;
 
   &__add-button {
-    border: 2px dashed mat.get-color-from-palette(gio.$mat-content-palette, 'default');
+    border: 2px dashed mat.get-color-from-palette(gio.$mat-space-palette, lighter40);
     border-radius: $radius;
     margin: 4px;
     cursor: pointer;
@@ -71,7 +71,7 @@ $typography: map.get(gio.$mat-theme, typography);
     flex-flow: column nowrap;
     justify-content: space-between;
     padding: 6px;
-    border: 2px solid mat.get-color-from-palette(gio.$mat-content-palette, 'default');
+    border: 2px solid mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
     border-radius: $radius;
     margin: 4px;
     inline-size: fit-content;
@@ -106,7 +106,7 @@ $typography: map.get(gio.$mat-theme, typography);
     }
 
     &.disabled {
-      border: 2px solid mat.get-color-from-palette(gio.$mat-content-palette, 'disabled');
+      border: 2px solid mat.get-color-from-palette(gio.$mat-basic-palette, 'disabled');
     }
   }
 
@@ -123,8 +123,8 @@ $typography: map.get(gio.$mat-theme, typography);
       width: 24px;
       height: 24px;
       border-radius: calc($radius / 2);
-      background-color: mat.get-color-from-palette(gio.$mat-decorative-palette, 'background', 0.7);
-      color: mat.get-color-from-palette(gio.$mat-content-palette, 'darker');
+      background-color: mat.get-color-from-palette(gio.$mat-dove-palette, 'default', 0.7);
+      color: mat.get-color-from-palette(gio.$mat-space-palette, 'default');
       cursor: pointer;
 
       &:hover {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.scss
@@ -51,7 +51,7 @@
         &__field:focus-within {
           z-index: 100;
           height: auto;
-          background-color: mat.get-color-from-palette(gio.$mat-content-palette, 'lighter');
+          background-color: mat.get-color-from-palette(gio.$mat-basic-palette, 'white');
 
           * {
             max-height: none;
@@ -76,7 +76,7 @@
     &__header-row:hover .gio-form-headers__table__header-row__td-value__button {
       z-index: 110;
       display: block;
-      background-color: mat.get-color-from-palette(gio.$mat-content-palette, 'lighter');
+      background-color: mat.get-color-from-palette(gio.$mat-basic-palette, 'white');
       opacity: 0.9;
     }
   }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.scss
@@ -18,7 +18,7 @@
 
 @use '../../scss' as gio;
 
-$background: map.get(gio.$mat-content-palette, darker);
+$background: map.get(gio.$mat-space-palette, default);
 $textLight: map.get(gio.$mat-basic-palette, white);
 
 :host {

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-badge/gio-badge.scss
@@ -79,8 +79,8 @@
   .gio-badge-neutral {
     @extend %gio-badge-base;
 
-    background-color: mat.get-color-from-palette(palettes.$mat-neutral-palette, default);
-    color: mat.get-color-from-palette(palettes.$mat-neutral-palette, default-contrast);
+    background-color: mat.get-color-from-palette(palettes.$mat-dove-palette, darker10);
+    color: mat.get-color-from-palette(palettes.$mat-dove-palette, darker10-contrast);
   }
 
   .gio-badge-success {

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-table-light/gio-table-light.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-table-light/gio-table-light.scss
@@ -38,7 +38,7 @@ $typography: map.get(theme.$mat-theme, typography);
     thead {
       @include mat.typography-level($typography, 'body-2');
 
-      background-color: mat.get-color-from-palette(palettes.$mat-decorative-palette, lighter-background);
+      background-color: mat.get-color-from-palette(palettes.$mat-dove-palette, default);
       text-align: left;
       text-transform: uppercase;
     }
@@ -46,7 +46,7 @@ $typography: map.get(theme.$mat-theme, typography);
     tbody {
       @include mat.typography-level($typography, 'body-1');
 
-      background-color: mat.get-color-from-palette(palettes.$mat-content-palette, lighter);
+      background-color: mat.get-color-from-palette(palettes.$mat-basic-palette, white);
     }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
@@ -165,10 +165,15 @@ $mat-basic-palette: mat.define-palette(
   (
     black: #000,
     white: #fff,
-    contrast: (
-      black: #fff,
-      white: #000,
-    ),
+    disabled: rgb(0 0 0 / 12%),
+    // Same color as the disabled color of material
+    contrast:
+      (
+        black: #fff,
+        white: #000,
+        disabled: rgb(0 0 0 / 26%),
+        // Same color as the disabled color of material
+      ),
   ),
   black,
   white,
@@ -275,71 +280,12 @@ $mat-blue-palette: mat.define-palette(
   default
 );
 
-/////////////////
-// DEPRECATED //
-/////////////////
-
-// DEPRECATED - Neutral color
-$mat-neutral-palette: mat.define-palette(
-  (
-    darker: mat.get-color-from-palette($mat-dove-palette, darker70),
-    default: mat.get-color-from-palette($mat-dove-palette, darker10),
-    lighter: mat.get-color-from-palette($mat-dove-palette, default),
-    contrast: (
-      darker: mat.get-color-from-palette($mat-basic-palette, white),
-      default: mat.get-color-from-palette($mat-space-palette, default),
-      lighter: mat.get-color-from-palette($mat-space-palette, default),
-    ),
-  ),
-  default,
-  lighter,
-  darker
-);
-
-// DEPRECATED - Content color
-$mat-content-palette: mat.define-palette(
-  (
-    darker: mat.get-color-from-palette($mat-space-palette, default),
-    default: mat.get-color-from-palette($mat-space-palette, lighter40),
-    disabled: #e0e0e0,
-    lighter: mat.get-color-from-palette($mat-basic-palette, white),
-    contrast: (
-      darker: mat.get-color-from-palette($mat-basic-palette, white),
-      default: mat.get-color-from-palette($mat-basic-palette, white),
-      disabled: #a6a6a6,
-      lighter: mat.get-color-from-palette($mat-basic-palette, black),
-    ),
-  ),
-  default,
-  lighter,
-  darker
-);
-
-// DEPRECATED - Decorative color
-$mat-decorative-palette: mat.define-palette(
-  (
-    background: mat.get-color-from-palette($mat-dove-palette, default),
-    lighter-background: mat.get-color-from-palette($mat-dove-palette, default),
-    surface: mat.get-color-from-palette($mat-basic-palette, white),
-    divider: mat.get-color-from-palette($mat-dove-palette, darker10),
-    contrast: (
-      background: mat.get-color-from-palette($mat-basic-palette, black),
-      lighter-background: mat.get-color-from-palette($mat-basic-palette, black),
-      surface: mat.get-color-from-palette($mat-basic-palette, black),
-      divider: mat.get-color-from-palette($mat-basic-palette, black),
-    ),
-  ),
-  surface,
-  surface,
-  surface
-);
-
-// DEPRECATED - Method color
+// Method color
 $mat-method-palette: mat.define-palette(
   (
     patch: mat.get-color-from-palette($mat-accent-palette, lighter80),
     post: mat.get-color-from-palette($mat-warning-palette, lighter80),
-    put: mat.get-color-from-palette($mat-neutral-palette, default),
+    put: mat.get-color-from-palette($mat-dove-palette, darker10),
     get: mat.get-color-from-palette($mat-primary-palette, lighter80),
     delete: mat.get-color-from-palette($mat-error-palette, lighter80),
     option: mat.get-color-from-palette($mat-success-palette, lighter80),
@@ -348,7 +294,7 @@ $mat-method-palette: mat.define-palette(
     contrast: (
       patch: mat.get-color-from-palette($mat-accent-palette, darker40),
       post: mat.get-color-from-palette($mat-warning-palette, darker20),
-      put: mat.get-color-from-palette($mat-neutral-palette, lighter70),
+      put: mat.get-color-from-palette($mat-dove-palette, lighter70),
       get: mat.get-color-from-palette($mat-primary-palette, darker60),
       delete: mat.get-color-from-palette($mat-error-palette, darker20),
       option: mat.get-color-from-palette($mat-success-palette, darker60),

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-theme-variable.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-theme-variable.scss
@@ -68,7 +68,7 @@ $mat-foreground: map.get($mat-theme-default, foreground);
 $gio-background: map.merge(
   $mat-background,
   (
-    background: mat.get-color-from-palette(palettes.$mat-decorative-palette, lighter-background),
+    background: mat.get-color-from-palette(palettes.$mat-dove-palette, default),
     tooltip: mat.get-color-from-palette(palettes.$mat-space-palette, default),
   )
 );
@@ -77,8 +77,8 @@ $gio-background: map.merge(
 $gio-foreground: map.merge(
   $mat-foreground,
   (
-    text: mat.get-color-from-palette(palettes.$mat-content-palette, darker),
-    slider-min: mat.get-color-from-palette(palettes.$mat-content-palette, darker),
+    text: mat.get-color-from-palette(palettes.$mat-space-palette, default),
+    slider-min: mat.get-color-from-palette(palettes.$mat-space-palette, default),
   )
 );
 $gio-background-foreground: (

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/index.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/index.scss
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-@forward './gio-mat-palettes' show $mat-primary-palette, $mat-accent-palette, $mat-content-palette, $mat-neutral-palette,
-  $mat-success-palette, $mat-warning-palette, $mat-error-palette, $mat-decorative-palette, $mat-method-palette, $mat-basic-palette,
-  $mat-blue-palette, $mat-cyan-palette, $mat-space-palette, $mat-dove-palette;
+@forward './gio-mat-palettes' show $mat-primary-palette, $mat-accent-palette, $mat-success-palette, $mat-warning-palette, $mat-error-palette,
+  $mat-method-palette, $mat-basic-palette, $mat-blue-palette, $mat-cyan-palette, $mat-space-palette, $mat-dove-palette;
 
 @forward './theme/typography/gio-typography' show subtitle-typography, code-typography, link-typography;
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/theme/color/gio-palettes.stories.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/theme/color/gio-palettes.stories.scss
@@ -21,7 +21,6 @@ $colorNames: lighter, lighter60, lighter40, lighter20, default, darker20, darker
 $palettes: (
   primary: gio.$mat-primary-palette,
   accent: gio.$mat-accent-palette,
-  neutral: gio.$mat-neutral-palette,
   success: gio.$mat-success-palette,
   warning: gio.$mat-warning-palette,
   error: gio.$mat-error-palette,
@@ -40,22 +39,12 @@ $palettes: (
 
   // Special palettes
 
-  @each $colorName in (darker, default, disabled, lighter) {
-    content__#{$colorName}: mat.get-color-from-palette(gio.$mat-content-palette, $colorName);
-    content__#{$colorName}-contrast: mat.get-color-from-palette(gio.$mat-content-palette, #{$colorName}-contrast);
-  }
-
-  @each $colorName in (background, lighter-background, surface, divider) {
-    decorative__#{$colorName}: mat.get-color-from-palette(gio.$mat-decorative-palette, $colorName);
-    decorative__#{$colorName}-contrast: mat.get-color-from-palette(gio.$mat-decorative-palette, #{$colorName}-contrast);
-  }
-
   @each $colorName in (patch, post, put, get, delete, option, trace, head) {
     method__#{$colorName}: mat.get-color-from-palette(gio.$mat-method-palette, $colorName);
     method__#{$colorName}-contrast: mat.get-color-from-palette(gio.$mat-method-palette, #{$colorName}-contrast);
   }
 
-  @each $colorName in (white, black) {
+  @each $colorName in (white, black, disabled) {
     basic__#{$colorName}: mat.get-color-from-palette(gio.$mat-basic-palette, $colorName);
     basic__#{$colorName}-contrast: mat.get-color-from-palette(gio.$mat-basic-palette, #{$colorName}-contrast);
   }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/theme/color/showcase-color.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/theme/color/showcase-color.component.scss
@@ -20,7 +20,7 @@
 
 .title {
   flex: 1 1 30%;
-  color: mat.get-color-from-palette(gio.$mat-neutral-palette, default-contrast);
+  color: mat.get-color-from-palette(gio.$mat-dove-palette, darker10-contrast);
 }
 
 .row {


### PR DESCRIPTION
**Issue**
n/a

**Description**

BREAKING CHANGE: removes deprecated colors. To migrate use the following correspondence:

## Neutral color
$mat-neutral-palette (default) -> $mat-dove-palette (darker10)
$mat-neutral-palette (darker) -> $mat-dove-palette (darker70)
$mat-neutral-palette (lighter) -> $mat-dove-palette (default)

## Content color
$mat-content-palette (default) -> $mat-space-palette (lighter40) 
$mat-content-palette (darker) -> $mat-space-palette (default), 
$mat-content-palette (disabled): $mat-basic-palette (disabled) 
$mat-content-palette (lighter) -> $mat-basic-palette (white)

## Decorative color
$mat-decorative-palette (background) -> $mat-dove-palette (default) 
$mat-decorative-palette (lighter-background) -> $mat-dove-palette (default) 
$mat-decorative-palette (surface) -> $mat-basic-palette (white) 
$mat-decorative-palette (divider) -> $mat-dove-palette (darker10)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@6.1.0-clean-color-2f66f1e
```
```
yarn add @gravitee/ui-particles-angular@6.1.0-clean-color-2f66f1e
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@6.1.0-clean-color-2f66f1e
```
```
yarn add @gravitee/ui-policy-studio-angular@6.1.0-clean-color-2f66f1e
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-sebxizmdut.chromatic.com)
<!-- Storybook placeholder end -->
