### PR TITLE
Policy studio - Init the layout with empty flows display

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
@@ -106,7 +106,7 @@ $typography: map.get(gio.$mat-theme, typography);
     }
 
     &.disabled {
-      border: 2px solid mat.get-color-from-palette(gio.$mat-basic-palette, 'disabled');
+      border: 2px solid mat.get-color-from-palette(gio.$mat-basic-palette, disabled);
     }
   }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.scss
@@ -51,7 +51,7 @@
         &__field:focus-within {
           z-index: 100;
           height: auto;
-          background-color: mat.get-color-from-palette(gio.$mat-basic-palette, 'white');
+          background-color: mat.get-color-from-palette(gio.$mat-basic-palette, white);
 
           * {
             max-height: none;
@@ -76,7 +76,7 @@
     &__header-row:hover .gio-form-headers__table__header-row__td-value__button {
       z-index: 110;
       display: block;
-      background-color: mat.get-color-from-palette(gio.$mat-basic-palette, 'white');
+      background-color: mat.get-color-from-palette(gio.$mat-basic-palette, white);
       opacity: 0.9;
     }
   }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.scss
@@ -42,4 +42,17 @@
       line-height: 18px;
     }
   }
+
+  .mat-stroked-button.mat-icon-button {
+    width: 36px;
+    height: 36px;
+    line-height: 18px;
+
+    .mat-icon {
+      width: 18px;
+      height: 18px;
+      margin-right: 0;
+      line-height: 18px;
+    }
+  }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
@@ -310,6 +310,26 @@ export const MatButton: Story = {
                   </div>
               </div>
               
+              <div>
+                  <h4>Stroked icon without text</h4>
+                  <div class="button-container">
+                      <button mat-stroked-button mat-icon-button aria-label="Example icon button with a settings icon">
+                          <mat-icon svgIcon="gio:settings"></mat-icon>
+                      </button>
+                      <button mat-stroked-button mat-icon-button color="primary" aria-label="Example icon button with a settings icon">
+                          <mat-icon svgIcon="gio:settings"></mat-icon>
+                      </button>
+                      <button mat-stroked-button mat-icon-button color="accent" aria-label="Example icon button with a settings icon">
+                          <mat-icon svgIcon="gio:settings"></mat-icon>
+                      </button>
+                      <button mat-stroked-button mat-icon-button color="warn" aria-label="Example icon button with a settings icon">
+                          <mat-icon svgIcon="gio:settings"></mat-icon>
+                      </button>
+                      <button mat-stroked-button mat-icon-button disabled aria-label="Example icon button with a settings icon">
+                          <mat-icon svgIcon="gio:settings"></mat-icon>
+                      </button>
+                  </div>
+              </div>
           </div>
         </div>
         `,

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -15,9 +15,17 @@
     limitations under the License.
 
 -->
+<ng-container *ngIf="flows.length; else emptyFlows">
+  <div class="header">
+    <div class="mat-h4">Flow details</div>
+  </div>
 
-<div class="header">
-  <div class="mat-h4">Flow details</div>
-</div>
+  <div class="content">🚧 Work in progress 🚧</div>
+</ng-container>
 
-<div class="content">🚧 Work in progress 🚧</div>
+<ng-template #emptyFlows>
+  <div class="emptyFlows">
+    <h2>No flows yet</h2>
+    <p class="mat-body-1">Flows allow you to customize the behavior of your API event phases through configurable policies</p>
+  </div>
+</ng-template>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.scss
@@ -13,3 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.emptyFlows {
+  display: flex;
+  width: 500px;
+  height: 100%;
+  flex-direction: column;
+  justify-content: center;
+  margin: auto;
+  text-align: center;
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input } from '@angular/core';
 
-import { Flow } from '../../models';
+import { ComponentHarness } from '@angular/cdk/testing';
 
-@Component({
-  selector: 'gio-ps-flow-details',
-  templateUrl: './gio-ps-flow-details.component.html',
-  styleUrls: ['./gio-ps-flow-details.component.scss'],
-})
-export class GioPolicyStudioDetailsComponent {
-  @Input()
-  public flows: Flow[] = [];
+export class GioPolicyStudioDetailsHarness extends ComponentHarness {
+  public static hostSelector = 'gio-ps-flow-details';
+
+  public async isDisplayEmptyFlow(): Promise<boolean> {
+    const hostText = await (await this.host()).text();
+    return hostText.includes('No flows yet');
+  }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
@@ -17,7 +17,21 @@
 -->
 
 <div class="header">
-  <div class="mat-h4">Flows</div>
+  <div class="header__label">
+    Flows <mat-icon svgIcon="gio:info" matTooltip="Flows allow you to apply different policies on your API event phases"></mat-icon>
+  </div>
+  <div class="header__configBtn">
+    <button mat-stroked-button mat-icon-button><mat-icon svgIcon="gio:settings"></mat-icon></button>
+  </div>
 </div>
 
-<div class="content">🚧 Work in progress 🚧</div>
+<div class="list">
+  <div class="list__flowsGroup">
+    <div class="list__flowsGroup__header">
+      <div class="list__flowsGroup__header__label">Common flows</div>
+      <div class="list__flowsGroup__header__addBtn">
+        <button mat-icon-button><mat-icon svgIcon="gio:plus" matTooltip="New flow"></mat-icon></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.scss
@@ -13,3 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+
+  &__label {
+    @include mat.typography-level($typography, subheading-1);
+
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    margin-bottom: 0;
+    gap: 8px;
+  }
+
+  &__configBtn {
+    margin-left: 8px;
+  }
+}
+
+.list {
+  &__flowsGroup {
+    &__header {
+      display: flex;
+      align-items: center;
+      padding: 8px;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      background-color: mat.get-color-from-palette(gio.$mat-cyan-palette, lighter80);
+
+      &__label {
+        @include mat.typography-level($typography, body-2);
+
+        display: flex;
+        flex: 1 1 auto;
+        align-items: center;
+        gap: 8px;
+      }
+
+      &__addBtn {
+        margin-left: 8px;
+      }
+    }
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+import { Flow } from '../../models';
 
 @Component({
   selector: 'gio-ps-flows-menu',
   templateUrl: './gio-ps-flows-menu.component.html',
   styleUrls: ['./gio-ps-flows-menu.component.scss'],
 })
-export class GioPolicyStudioFlowsMenuComponent {}
+export class GioPolicyStudioFlowsMenuComponent {
+  @Input()
+  public flows: Flow[] = [];
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+
+import { DivHarness } from '../../../testing';
+
+export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
+  public static hostSelector = 'gio-ps-flows-menu';
+
+  private locateFlowsGroups = this.locatorForAll(DivHarness.with({ selector: '.list__flowsGroup' }));
+
+  public async getAllFlowsGroups(): Promise<
+    {
+      name: string;
+    }[]
+  > {
+    const flowsGroups = await this.locateFlowsGroups();
+
+    return parallel(() =>
+      flowsGroups.map(async flowGroup => {
+        const flowGroupName = await flowGroup
+          .childLocatorFor(DivHarness.with({ selector: '.list__flowsGroup__header__label' }))()
+          .then(div => div.getText());
+
+        return {
+          name: flowGroupName,
+        };
+      }),
+    );
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -18,6 +18,7 @@ import { Story } from '@storybook/angular/dist/ts3.9/client/preview/types-7-0';
 
 import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 import { GioPolicyStudioModule } from './gio-policy-studio.module';
+import { fakeChannelFlow } from './models/index-testing';
 
 export default {
   title: 'Policy Studio / APIM',
@@ -29,11 +30,58 @@ export default {
   ],
 } as Meta;
 
-export const Default: Story = {
+export const MessageWithoutFlows: Story = {
+  name: 'Message API without flows',
   render: props => ({
-    template: `<gio-policy-studio>
+    template: `<gio-policy-studio
+    [apiType]="'MESSAGE'"
+    [entrypointsInfo]="entrypointsInfo"
+    [endpointsInfo]="endpointsInfo"
+    >
     </gio-policy-studio>`,
     props,
   }),
-  args: {},
+  args: {
+    entrypointsInfo: [
+      {
+        type: 'webhook',
+        icon: 'gio:webhook',
+      },
+    ],
+    endpointsInfo: [
+      {
+        type: 'kafka',
+        icon: 'gio:kafka',
+      },
+    ],
+  },
+};
+
+export const MessageWithFlows: Story = {
+  name: 'Message API with flow',
+  render: props => ({
+    template: `<gio-policy-studio
+    [apiType]="'MESSAGE'"
+    [entrypointsInfo]="entrypointsInfo"
+    [endpointsInfo]="endpointsInfo"
+    [flows]="flows"
+    >
+    </gio-policy-studio>`,
+    props,
+  }),
+  args: {
+    entrypointsInfo: [
+      {
+        type: 'webhook',
+        icon: 'gio:webhook',
+      },
+    ],
+    endpointsInfo: [
+      {
+        type: 'kafka',
+        icon: 'gio:kafka',
+      },
+    ],
+    flows: [fakeChannelFlow()],
+  },
 };

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -28,19 +28,21 @@ export default {
       imports: [GioPolicyStudioModule],
     }),
   ],
+
+  render: props => ({
+    template: `<div style="height:calc(100vh - 2rem);"><gio-policy-studio
+    [apiType]="'MESSAGE'"
+    [entrypointsInfo]="entrypointsInfo"
+    [endpointsInfo]="endpointsInfo"
+    [flows]="flows"
+    >
+    </gio-policy-studio></div>`,
+    props,
+  }),
 } as Meta;
 
 export const MessageWithoutFlows: Story = {
   name: 'Message API without flows',
-  render: props => ({
-    template: `<gio-policy-studio
-    [apiType]="'MESSAGE'"
-    [entrypointsInfo]="entrypointsInfo"
-    [endpointsInfo]="endpointsInfo"
-    >
-    </gio-policy-studio>`,
-    props,
-  }),
   args: {
     entrypointsInfo: [
       {
@@ -59,16 +61,6 @@ export const MessageWithoutFlows: Story = {
 
 export const MessageWithFlows: Story = {
   name: 'Message API with flow',
-  render: props => ({
-    template: `<gio-policy-studio
-    [apiType]="'MESSAGE'"
-    [entrypointsInfo]="entrypointsInfo"
-    [endpointsInfo]="endpointsInfo"
-    [flows]="flows"
-    >
-    </gio-policy-studio>`,
-    props,
-  }),
   args: {
     entrypointsInfo: [
       {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -17,8 +17,19 @@
 -->
 
 <div class="header">
-  <div class="header__apiName">
-    <span class="mat-h4">My API name</span><span class="gio-badge-neutral"><mat-icon class="gio-left" svgIcon="gio:lock"></mat-icon></span>
+  <div class="header__apiInfo">
+    <span class="gio-badge-primary">
+      {{ apiType | titlecase }}
+    </span>
+    <span
+      class="gio-badge-neutral"
+      [matTooltip]="connectorsTooltip"
+      matTooltipPosition="right"
+      matTooltipClass="gio-policy-studio__tooltip-line-break"
+    >
+      <mat-icon *ngFor="let entrypoint of entrypointsInfo" class="gio-left" [svgIcon]="entrypoint.icon"></mat-icon>
+      <mat-icon *ngFor="let endpoint of endpointsInfo" class="gio-left" [svgIcon]="endpoint.icon"></mat-icon>
+    </span>
   </div>
 
   <div class="header__btn">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -39,7 +39,7 @@
 
 <div class="wrapper">
   <div class="wrapper__flowsMenu">
-    <gio-ps-flows-menu></gio-ps-flows-menu>
+    <gio-ps-flows-menu [flows]="flows"></gio-ps-flows-menu>
   </div>
 
   <div class="wrapper__flowDetails">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.scss
@@ -18,7 +18,9 @@
 @use '@gravitee/ui-particles-angular' as gio;
 
 :host {
-  display: block;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
   padding: 8px;
   background-color: mat.get-color-from-palette(gio.$mat-basic-palette, white);
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.scss
@@ -23,12 +23,18 @@
   background-color: mat.get-color-from-palette(gio.$mat-basic-palette, white);
 }
 
+::ng-deep {
+  .gio-policy-studio__tooltip-line-break {
+    white-space: pre-line;
+  }
+}
+
 .header {
   display: flex;
   align-items: center;
   padding-bottom: 16px;
 
-  &__apiName {
+  &__apiInfo {
     flex: 1 1 auto;
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -13,11 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { capitalize } from 'lodash';
+
+import { ApiType, Flow } from './models';
+
+export interface ConnectorsInfo {
+  type: string;
+  icon: string;
+}
 
 @Component({
   selector: 'gio-policy-studio',
   templateUrl: './gio-policy-studio.component.html',
   styleUrls: ['./gio-policy-studio.component.scss'],
 })
-export class GioPolicyStudioComponent {}
+export class GioPolicyStudioComponent implements OnChanges {
+  @Input()
+  public apiType!: ApiType;
+
+  /**
+   * List of entrypoints to display
+   */
+  @Input()
+  public entrypointsInfo: ConnectorsInfo[] = [];
+
+  /**
+   * List of endpoints to display
+   */
+  @Input()
+  public endpointsInfo: ConnectorsInfo[] = [];
+
+  @Input()
+  public flows: Flow[] = [];
+
+  public connectorsTooltip = '';
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.entrypointsInfo || changes.endpointsInfo) {
+      this.connectorsTooltip = `Entrypoints: ${this.entrypointsInfo
+        .map(e => capitalize(e.type))
+        .join(', ')}\nEndpoints: ${this.endpointsInfo.map(e => capitalize(e.type)).join(', ')}`;
+    }
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
@@ -21,10 +21,10 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 import { GioPolicyStudioFlowsMenuComponent } from './components/flows-menu/gio-ps-flows-menu.component';
-import { GioPolicyStudioDetailsMenuComponent } from './components/flow-details/gio-ps-flow-details.component';
+import { GioPolicyStudioDetailsComponent } from './components/flow-details/gio-ps-flow-details.component';
 
 @NgModule({
-  declarations: [GioPolicyStudioComponent, GioPolicyStudioFlowsMenuComponent, GioPolicyStudioDetailsMenuComponent],
+  declarations: [GioPolicyStudioComponent, GioPolicyStudioFlowsMenuComponent, GioPolicyStudioDetailsComponent],
   imports: [CommonModule, MatButtonModule, MatTooltipModule, GioIconsModule],
   exports: [GioPolicyStudioComponent],
 })

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
@@ -16,6 +16,8 @@
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { GioIconsModule } from '@gravitee/ui-particles-angular';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 import { GioPolicyStudioFlowsMenuComponent } from './components/flows-menu/gio-ps-flows-menu.component';
@@ -23,7 +25,7 @@ import { GioPolicyStudioDetailsMenuComponent } from './components/flow-details/g
 
 @NgModule({
   declarations: [GioPolicyStudioComponent, GioPolicyStudioFlowsMenuComponent, GioPolicyStudioDetailsMenuComponent],
-  imports: [MatButtonModule, GioIconsModule],
+  imports: [CommonModule, MatButtonModule, MatTooltipModule, GioIconsModule],
   exports: [GioPolicyStudioComponent],
 })
 export class GioPolicyStudioModule {}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -14,27 +14,58 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltipHarness } from '@angular/material/tooltip/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { SimpleChange } from '@angular/core';
 
-import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 import { GioPolicyStudioModule } from './gio-policy-studio.module';
+import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 
 describe('GioPolicyStudioModule', () => {
+  let loader: HarnessLoader;
   let component: GioPolicyStudioComponent;
   let fixture: ComponentFixture<GioPolicyStudioComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GioPolicyStudioModule],
+      imports: [GioPolicyStudioModule, MatIconTestingModule],
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(GioPolicyStudioComponent);
     component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
+    component.apiType = 'MESSAGE';
     fixture.detectChanges();
   });
 
-  it('should work', () => {
-    expect(component).toBeTruthy();
+  it('should display api info', async () => {
+    component.entrypointsInfo = [
+      {
+        type: 'webhook',
+        icon: 'gio:webhook',
+      },
+    ];
+    component.endpointsInfo = [
+      {
+        type: 'kafka',
+        icon: 'gio:kafka',
+      },
+    ];
+    component.ngOnChanges({
+      entrypointsInfo: new SimpleChange(null, null, true),
+      endpointsInfo: new SimpleChange(null, null, true),
+    });
+    fixture.detectChanges();
+
+    const tooltip = await loader.getHarness(
+      MatTooltipHarness.with({ selector: '[mattooltipclass="gio-policy-studio__tooltip-line-break"]' }),
+    );
+    await tooltip.show();
+    expect(await tooltip.getTooltipText()).toEqual(`Entrypoints: Webhook\nEndpoints: Kafka`);
   });
 });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -22,6 +22,8 @@ import { SimpleChange } from '@angular/core';
 
 import { GioPolicyStudioModule } from './gio-policy-studio.module';
 import { GioPolicyStudioComponent } from './gio-policy-studio.component';
+import { GioPolicyStudioDetailsHarness } from './components/flow-details/gio-ps-flow-details.harness';
+import { GioPolicyStudioFlowsMenuHarness } from './components/flows-menu/gio-ps-flows-menu.harness';
 
 describe('GioPolicyStudioModule', () => {
   let loader: HarnessLoader;
@@ -67,5 +69,19 @@ describe('GioPolicyStudioModule', () => {
     );
     await tooltip.show();
     expect(await tooltip.getTooltipText()).toEqual(`Entrypoints: Webhook\nEndpoints: Kafka`);
+  });
+
+  it('should display empty flow', async () => {
+    const detailsHarness = await loader.getHarness(GioPolicyStudioDetailsHarness);
+
+    const flowsMenuHarness = await loader.getHarness(GioPolicyStudioFlowsMenuHarness);
+
+    expect(await detailsHarness.isDisplayEmptyFlow()).toEqual(true);
+
+    expect(await flowsMenuHarness.getAllFlowsGroups()).toEqual([
+      {
+        name: 'Common flows',
+      },
+    ]);
   });
 });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/ApiType.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/ApiType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './ApiType';
-export * from './Flow';
-export * from './FlowExecution';
-export * from './HttpMethod';
-export * from './Selector';
-export * from './Step';
+export type ApiType = 'MESSAGE' | 'PROXY';

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/testing/harnesses/div.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/testing/harnesses/div.harness.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncFactoryFn, BaseHarnessFilters, ComponentHarness, HarnessPredicate, HarnessQuery } from '@angular/cdk/testing';
+
+export type DivHarnessFilters = BaseHarnessFilters;
+
+export class DivHarness extends ComponentHarness {
+  public static hostSelector = 'div';
+
+  /**
+   * Get Harness with the given filter.
+   *
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  public static with(options: DivHarnessFilters = {}): HarnessPredicate<DivHarness> {
+    return new HarnessPredicate(DivHarness, options);
+  }
+
+  public childLocatorFor<T extends ComponentHarness>(query: HarnessQuery<T>): AsyncFactoryFn<T> {
+    return this.locatorFor(query);
+  }
+
+  public childLocatorForAll<T extends ComponentHarness>(query: HarnessQuery<T>): AsyncFactoryFn<T[]> {
+    return this.locatorForAll(query);
+  }
+
+  public async getText(): Promise<string> {
+    const hostText = await (await this.host()).text();
+    return hostText;
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/testing/harnesses/index.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/testing/harnesses/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input } from '@angular/core';
-
-import { Flow } from '../../models';
-
-@Component({
-  selector: 'gio-ps-flow-details',
-  templateUrl: './gio-ps-flow-details.component.html',
-  styleUrls: ['./gio-ps-flow-details.component.scss'],
-})
-export class GioPolicyStudioDetailsComponent {
-  @Input()
-  public flows: Flow[] = [];
-}
+export * from './div.harness';

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/testing/index.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/testing/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export * from './stories-resources';
+export * from './harnesses';


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1548

**Description**

Add empty flows display for policy studio

**Additional context**
![image](https://github.com/gravitee-io/gravitee-ui-particles/assets/4974420/b0c9efb0-5324-479f-8034-d18859f6db9a)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.0.0-apim-1548-init-layout-9ffda4a
```
```
yarn add @gravitee/ui-particles-angular@7.0.0-apim-1548-init-layout-9ffda4a
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.0.0-apim-1548-init-layout-31e6d58
```
```
yarn add @gravitee/ui-policy-studio-angular@7.0.0-apim-1548-init-layout-31e6d58
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-fkkdiwojgy.chromatic.com)
<!-- Storybook placeholder end -->
