### PR TITLE
Policy studio - Add create / edit / delete  message flow

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -17,7 +17,13 @@
 -->
 <ng-container *ngIf="flow; else emptyFlows">
   <div class="header">
-    <div class="mat-h4">Flow details</div>
+    <div class="header__label">Flow details</div>
+    <div class="header__configBtn">
+      <button class="header__configBtn__edit" mat-stroked-button mat-icon-button (click)="onEditFlow()">
+        <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+      </button>
+      <button class="header__configBtn__remove" mat-stroked-button mat-icon-button><mat-icon svgIcon="gio:trash"></mat-icon></button>
+    </div>
   </div>
 
   <div class="content">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -22,7 +22,9 @@
       <button class="header__configBtn__edit" mat-stroked-button mat-icon-button (click)="onEditFlow()">
         <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
       </button>
-      <button class="header__configBtn__remove" mat-stroked-button mat-icon-button><mat-icon svgIcon="gio:trash"></mat-icon></button>
+      <button class="header__configBtn__delete" mat-stroked-button mat-icon-button (click)="onDeleteFlow()">
+        <mat-icon svgIcon="gio:trash"></mat-icon>
+      </button>
     </div>
   </div>
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.scss
@@ -45,9 +45,9 @@ $typography: map.get(gio.$mat-theme, typography);
   }
 
   &__configBtn {
-    margin-left: 8px;
     display: flex;
     align-items: center;
+    margin-left: 8px;
     gap: 8px;
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.scss
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
 .emptyFlows {
   display: flex;
   width: 500px;
@@ -21,4 +27,27 @@
   justify-content: center;
   margin: auto;
   text-align: center;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+
+  &__label {
+    @include mat.typography-level($typography, subheading-1);
+
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    margin-bottom: 0;
+    gap: 8px;
+  }
+
+  &__configBtn {
+    margin-left: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -33,6 +33,9 @@ export class GioPolicyStudioDetailsComponent {
   @Input()
   public flow?: FlowVM = undefined;
 
+  @Input()
+  public entrypoints: string[] = [];
+
   @Output()
   public flowChange = new EventEmitter<FlowVM>();
 
@@ -48,7 +51,7 @@ export class GioPolicyStudioDetailsComponent {
         {
           data: {
             flow: this.flow,
-            entrypoints: [],
+            entrypoints: this.entrypoints,
           },
           role: 'alertdialog',
           id: 'gioPsFlowFormDialog',

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { tap } from 'rxjs/operators';
 
 import { FlowVM } from '../../gio-policy-studio.model';
+import {
+  GioPolicyStudioFlowFormDialogComponent,
+  GioPolicyStudioFlowFormDialogData,
+  GioPolicyStudioFlowFormDialogResult,
+} from '../flow-form-dialog/gio-ps-flow-form-dialog.component';
 
 @Component({
   selector: 'gio-ps-flow-details',
@@ -25,4 +32,35 @@ import { FlowVM } from '../../gio-policy-studio.model';
 export class GioPolicyStudioDetailsComponent {
   @Input()
   public flow?: FlowVM = undefined;
+
+  @Output()
+  public flowChange = new EventEmitter<FlowVM>();
+
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public onEditFlow(): void {
+    this.matDialog
+      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, GioPolicyStudioFlowFormDialogResult>(
+        GioPolicyStudioFlowFormDialogComponent,
+        {
+          data: {
+            flow: this.flow,
+            entrypoints: [],
+          },
+          role: 'alertdialog',
+          id: 'gioPsFlowFormDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        tap(createdOrEdited => {
+          if (!createdOrEdited) {
+            return;
+          }
+
+          this.flowChange.emit(createdOrEdited);
+        }),
+      )
+      .subscribe();
+  }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -36,6 +36,9 @@ export class GioPolicyStudioDetailsComponent {
   @Output()
   public flowChange = new EventEmitter<FlowVM>();
 
+  @Output()
+  public deleteFlow = new EventEmitter<FlowVM>();
+
   constructor(private readonly matDialog: MatDialog) {}
 
   public onEditFlow(): void {
@@ -62,5 +65,9 @@ export class GioPolicyStudioDetailsComponent {
         }),
       )
       .subscribe();
+  }
+
+  public onDeleteFlow(): void {
+    this.deleteFlow.emit(this.flow);
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
@@ -30,6 +30,11 @@ export class GioPolicyStudioDetailsHarness extends ComponentHarness {
     return hostText.match(/"name": "(.*)"/)?.[1] ?? '';
   }
 
+  public async matchText(matcher: RegExp): Promise<boolean> {
+    const hostText = await (await this.host()).text();
+    return matcher.test(hostText);
+  }
+
   public async clickEditFlowBtn(): Promise<void> {
     const editFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__edit' }))();
     await editFlowBtn.click();

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
@@ -15,6 +15,7 @@
  */
 
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class GioPolicyStudioDetailsHarness extends ComponentHarness {
   public static hostSelector = 'gio-ps-flow-details';
@@ -27,5 +28,10 @@ export class GioPolicyStudioDetailsHarness extends ComponentHarness {
   public async getFlowName(): Promise<string> {
     const hostText = await (await this.host()).text();
     return hostText.match(/"name": "(.*)"/)?.[1] ?? '';
+  }
+
+  public async clickEditFlowBtn(): Promise<void> {
+    const editFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__edit' }))();
+    await editFlowBtn.click();
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
@@ -34,4 +34,9 @@ export class GioPolicyStudioDetailsHarness extends ComponentHarness {
     const editFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__edit' }))();
     await editFlowBtn.click();
   }
+
+  public async clickDeleteFlowBtn(): Promise<void> {
+    const deleteFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__delete' }))();
+    await deleteFlowBtn.click();
+  }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.html
@@ -18,7 +18,7 @@
 <h2 mat-dialog-title class="title">
   {{ mode === 'create' ? 'Create a new flow' : 'Edit flow' }}
 
-  <button class="title__closeBtn" mat-icon-button aria-label="Close dialog" [mat-dialog-close]="true">
+  <button class="title__closeBtn" mat-icon-button aria-label="Close dialog" [mat-dialog-close]="false">
     <mat-icon svgIcon="gio:cancel"></mat-icon>
   </button>
 </h2>
@@ -29,7 +29,7 @@
   <div class="content__row">
     <mat-form-field>
       <mat-label>Flow name</mat-label>
-      <input matInput formControlName="name" />
+      <input matInput formControlName="name" cdkFocusInitial />
       <mat-hint>Names will be automatically generated with channel and operation if left blank</mat-hint>
     </mat-form-field>
   </div>
@@ -64,8 +64,8 @@
     <mat-form-field>
       <mat-label>Entrypoints supported operations</mat-label>
       <mat-select multiple formControlName="operations">
-        <mat-option value="SUBSCRIBE">Subscribe</mat-option>
         <mat-option value="PUBLISH">Publish</mat-option>
+        <mat-option value="SUBSCRIBE">Subscribe</mat-option>
       </mat-select>
     </mat-form-field>
   </div>
@@ -81,7 +81,7 @@
 
 <mat-dialog-actions class="actions">
   <button class="actions__cancelBtn" mat-flat-button [mat-dialog-close]="false">Cancel</button>
-  <button class="actions__saveBtn" color="primary" mat-stroked-button (click)="onSubmit()">
+  <button class="actions__saveBtn" color="primary" mat-stroked-button role="dialog" (click)="onSubmit()">
     {{ mode === 'create' ? 'Create' : 'Save' }}
   </button>
 </mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.html
@@ -1,0 +1,87 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title class="title">
+  {{ mode === 'create' ? 'Create a new flow' : 'Edit flow' }}
+
+  <button class="title__closeBtn" mat-icon-button aria-label="Close dialog" [mat-dialog-close]="true">
+    <mat-icon svgIcon="gio:cancel"></mat-icon>
+  </button>
+</h2>
+
+<mat-dialog-content *ngIf="flowFormGroup" class="content" [formGroup]="flowFormGroup">
+  <p>Flows allow you to apply different policies per event phases. For example you can reroute calls based on the URL specified.</p>
+
+  <div class="content__row">
+    <mat-form-field>
+      <mat-label>Flow name</mat-label>
+      <input matInput formControlName="name" />
+      <mat-hint>Names will be automatically generated with channel and operation if left blank</mat-hint>
+    </mat-form-field>
+  </div>
+  <div class="content__row">
+    <mat-form-field>
+      <mat-label>Operator</mat-label>
+      <mat-select formControlName="channelOperator">
+        <mat-option value="EQUALS">Equals</mat-option>
+        <mat-option value="STARTS_WITH">Starts with</mat-option>
+      </mat-select>
+      <mat-hint>Channel operator</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Channel</mat-label>
+      <input matInput formControlName="channel" />
+      <mat-hint>Publish or Subscribe channel. This is the path of your request.</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <div class="content__row">
+    <mat-form-field>
+      <mat-label>Entrypoints</mat-label>
+      <mat-select multiple formControlName="entrypoints">
+        <mat-option *ngFor="let entrypoint of entrypoints" [value]="entrypoint">{{ entrypoint }}</mat-option>
+      </mat-select>
+      <mat-hint>Entrypoints where your flow will be executed</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <div class="content__row">
+    <mat-form-field>
+      <mat-label>Entrypoints supported operations</mat-label>
+      <mat-select multiple formControlName="operations">
+        <mat-option value="SUBSCRIBE">Subscribe</mat-option>
+        <mat-option value="PUBLISH">Publish</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div class="content__row">
+    <mat-form-field>
+      <mat-label>Condition</mat-label>
+      <input matInput formControlName="condition" />
+      <mat-hint>Condition to execute the flow, supports Expression Language</mat-hint>
+    </mat-form-field>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions class="actions">
+  <button class="actions__cancelBtn" mat-flat-button [mat-dialog-close]="false">Cancel</button>
+  <button class="actions__saveBtn" color="primary" mat-stroked-button (click)="onSubmit()">
+    {{ mode === 'create' ? 'Create' : 'Save' }}
+  </button>
+</mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+.title {
+  &__closeBtn {
+    top: -20px;
+    right: -20px;
+    float: right;
+  }
+}
+
+.content {
+  &__row {
+    display: flex;
+    gap: 16px;
+
+    mat-form-field {
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.spec.ts
@@ -27,7 +27,11 @@ import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
 import { fakeChannelFlow } from '../../models/index-testing';
 import { FlowVM } from '../../gio-policy-studio.model';
 
-import { GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData } from './gio-ps-flow-form-dialog.component';
+import {
+  GioPolicyStudioFlowFormDialogComponent,
+  GioPolicyStudioFlowFormDialogData,
+  GioPolicyStudioFlowFormDialogResult,
+} from './gio-ps-flow-form-dialog.component';
 import { GioPolicyStudioFlowFormDialogHarness } from './gio-ps-flow-form-dialog.harness';
 
 @Component({
@@ -42,7 +46,7 @@ class TestComponent {
 
   public openDialog() {
     this.matDialog
-      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, FlowVM | false>(
+      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, GioPolicyStudioFlowFormDialogResult>(
         GioPolicyStudioFlowFormDialogComponent,
         {
           data: {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.spec.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
+import { fakeChannelFlow } from '../../models/index-testing';
+import { FlowVM } from '../../gio-policy-studio.model';
+
+import { GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData } from './gio-ps-flow-form-dialog.component';
+import { GioPolicyStudioFlowFormDialogHarness } from './gio-ps-flow-form-dialog.harness';
+
+@Component({
+  selector: 'gio-dialog-test',
+  template: `<button mat-button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+})
+class TestComponent {
+  public flow?: FlowVM;
+  public flowToEdit?: FlowVM;
+  public entrypoints = ['entrypoint1', 'entrypoint2'];
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, FlowVM | false>(
+        GioPolicyStudioFlowFormDialogComponent,
+        {
+          data: {
+            entrypoints: this.entrypoints,
+            flow: this.flowToEdit,
+          },
+          role: 'alertdialog',
+          id: 'testDialog',
+        },
+      )
+      .afterClosed()
+      .subscribe(flow => {
+        if (flow) {
+          this.flow = flow;
+        }
+      });
+  }
+}
+
+describe('GioPolicyStudioFlowFormDialogComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [GioPolicyStudioModule, MatDialogModule, NoopAnimationsModule, MatIconTestingModule],
+    }).overrideProvider(InteractivityChecker, {
+      useValue: {
+        isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        isTabbable: () => true, // hidden elements
+      },
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  });
+
+  it('should return false on cancel', async () => {
+    component.flow = {
+      _id: 'test-id',
+      ...fakeChannelFlow(),
+    };
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowFormDialogHarness);
+    await flowFormDialogHarness.setFlowFormValues({
+      name: 'Test name',
+      condition: 'Test condition',
+    });
+    await flowFormDialogHarness.cancel();
+
+    expect(component.flow).toEqual({
+      _id: 'test-id',
+      ...fakeChannelFlow(),
+    });
+  });
+
+  it('should create flow', async () => {
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowFormDialogHarness);
+    await flowFormDialogHarness.setFlowFormValues({
+      name: 'Test name',
+      channelOperator: 'EQUALS',
+      channel: 'test-channel',
+      operations: ['SUBSCRIBE'],
+      entrypoints: ['entrypoint1', 'entrypoint2'],
+    });
+    await flowFormDialogHarness.save();
+
+    expect(component.flow).toEqual({
+      _id: expect.any(String),
+      name: 'Test name',
+      enabled: true,
+      selectors: [
+        {
+          type: 'CHANNEL',
+          channelOperator: 'EQUALS',
+          channel: 'test-channel',
+          operations: ['SUBSCRIBE'],
+          entrypoints: ['entrypoint1', 'entrypoint2'],
+        },
+      ],
+    });
+  });
+
+  it('should create flow with condition', async () => {
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowFormDialogHarness);
+    await flowFormDialogHarness.setFlowFormValues({
+      name: 'Test name',
+      channelOperator: 'EQUALS',
+      channel: 'test-channel',
+      operations: ['SUBSCRIBE'],
+      entrypoints: ['entrypoint1', 'entrypoint2'],
+      condition: 'Test condition',
+    });
+    await flowFormDialogHarness.save();
+
+    expect(component.flow).toEqual({
+      _id: expect.any(String),
+      name: 'Test name',
+      enabled: true,
+      selectors: [
+        {
+          type: 'CHANNEL',
+          channelOperator: 'EQUALS',
+          channel: 'test-channel',
+          operations: ['SUBSCRIBE'],
+          entrypoints: ['entrypoint1', 'entrypoint2'],
+        },
+        {
+          type: 'CONDITION',
+          condition: 'Test condition',
+        },
+      ],
+    });
+  });
+
+  it('should edit flow without any changes', async () => {
+    component.flowToEdit = {
+      _id: 'test-id',
+      ...fakeChannelFlow(),
+    };
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowFormDialogHarness);
+    await flowFormDialogHarness.save();
+
+    expect(component.flow).toEqual({
+      _id: 'test-id',
+      ...fakeChannelFlow(),
+    });
+  });
+
+  it('should edit flow with full changes', async () => {
+    component.flowToEdit = {
+      _id: 'test-id',
+      ...fakeChannelFlow(),
+    };
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowFormDialogHarness);
+
+    await flowFormDialogHarness.setFlowFormValues({
+      name: 'Test name',
+      channelOperator: 'EQUALS',
+      channel: 'test-channel',
+      operations: ['SUBSCRIBE'],
+      entrypoints: ['entrypoint1', 'entrypoint2'],
+      condition: 'Test condition',
+    });
+    await flowFormDialogHarness.save();
+
+    expect(component.flow).toEqual({
+      _id: 'test-id',
+      ...fakeChannelFlow(),
+      name: 'Test name',
+      enabled: true,
+      selectors: [
+        {
+          type: 'CHANNEL',
+          channelOperator: 'EQUALS',
+          channel: 'test-channel',
+          operations: ['SUBSCRIBE', 'PUBLISH'],
+          entrypoints: ['entrypoint1', 'entrypoint2'],
+        },
+        {
+          type: 'CONDITION',
+          condition: 'Test condition',
+        },
+      ],
+    });
+  });
+
+  async function componentTestingOpenDialog() {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+  }
+});

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.spec.ts
@@ -215,7 +215,7 @@ describe('GioPolicyStudioFlowFormDialogComponent', () => {
           type: 'CHANNEL',
           channelOperator: 'EQUALS',
           channel: 'test-channel',
-          operations: ['SUBSCRIBE', 'PUBLISH'],
+          operations: ['PUBLISH', 'SUBSCRIBE'],
           entrypoints: ['entrypoint1', 'entrypoint2'],
         },
         {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.ts
@@ -26,6 +26,8 @@ export type GioPolicyStudioFlowFormDialogData = {
   entrypoints?: string[];
 };
 
+export type GioPolicyStudioFlowFormDialogResult = FlowVM | false;
+
 @Component({
   selector: 'gio-ps-flow-form-dialog',
   templateUrl: './gio-ps-flow-form-dialog.component.html',
@@ -39,7 +41,7 @@ export class GioPolicyStudioFlowFormDialogComponent {
   public mode: 'create' | 'edit' = 'create';
 
   constructor(
-    public dialogRef: MatDialogRef<GioPolicyStudioFlowFormDialogComponent, FlowVM | false>,
+    public dialogRef: MatDialogRef<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogResult>,
     @Inject(MAT_DIALOG_DATA) flowDialogData: GioPolicyStudioFlowFormDialogData,
   ) {
     this.entrypoints = flowDialogData?.entrypoints ?? [];
@@ -54,8 +56,8 @@ export class GioPolicyStudioFlowFormDialogComponent {
       name: new FormControl(flowDialogData?.flow?.name ?? ''),
       channelOperator: new FormControl(channelSelector?.channelOperator ?? ''),
       channel: new FormControl(channelSelector?.channel ?? ''),
-      operations: new FormControl(channelSelector?.operations ?? ''),
-      entrypoints: new FormControl(channelSelector?.entrypoints ?? ''),
+      operations: new FormControl(channelSelector?.operations ?? []),
+      entrypoints: new FormControl(channelSelector?.entrypoints ?? []),
       condition: new FormControl(conditionSelector?.condition ?? ''),
     });
   }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.ts
@@ -16,7 +16,7 @@
 import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { FormControl, FormGroup } from '@angular/forms';
-import { uniqueId } from 'lodash';
+import { cloneDeep, uniqueId } from 'lodash';
 
 import { FlowVM } from '../../gio-policy-studio.model';
 import { ChannelSelector, ConditionSelector } from '../../models';
@@ -46,7 +46,7 @@ export class GioPolicyStudioFlowFormDialogComponent {
   ) {
     this.entrypoints = flowDialogData?.entrypoints ?? [];
 
-    this.existingFlow = flowDialogData?.flow;
+    this.existingFlow = cloneDeep(flowDialogData?.flow);
     this.mode = this.existingFlow ? 'edit' : 'create';
 
     const channelSelector = flowDialogData?.flow?.selectors?.find(s => s.type === 'CHANNEL') as ChannelSelector;

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.component.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FormControl, FormGroup } from '@angular/forms';
+import { uniqueId } from 'lodash';
+
+import { FlowVM } from '../../gio-policy-studio.model';
+import { ChannelSelector, ConditionSelector } from '../../models';
+
+export type GioPolicyStudioFlowFormDialogData = {
+  flow?: FlowVM;
+  entrypoints?: string[];
+};
+
+@Component({
+  selector: 'gio-ps-flow-form-dialog',
+  templateUrl: './gio-ps-flow-form-dialog.component.html',
+  styleUrls: ['./gio-ps-flow-form-dialog.component.scss'],
+})
+export class GioPolicyStudioFlowFormDialogComponent {
+  public entrypoints: string[] = [];
+  public flowFormGroup?: FormGroup;
+
+  public existingFlow?: FlowVM;
+  public mode: 'create' | 'edit' = 'create';
+
+  constructor(
+    public dialogRef: MatDialogRef<GioPolicyStudioFlowFormDialogComponent, FlowVM | false>,
+    @Inject(MAT_DIALOG_DATA) flowDialogData: GioPolicyStudioFlowFormDialogData,
+  ) {
+    this.entrypoints = flowDialogData?.entrypoints ?? [];
+
+    this.existingFlow = flowDialogData?.flow;
+    this.mode = this.existingFlow ? 'edit' : 'create';
+
+    const channelSelector = flowDialogData?.flow?.selectors?.find(s => s.type === 'CHANNEL') as ChannelSelector;
+    const conditionSelector = flowDialogData?.flow?.selectors?.find(s => s.type === 'CONDITION') as ConditionSelector;
+
+    this.flowFormGroup = new FormGroup({
+      name: new FormControl(flowDialogData?.flow?.name ?? ''),
+      channelOperator: new FormControl(channelSelector?.channelOperator ?? ''),
+      channel: new FormControl(channelSelector?.channel ?? ''),
+      operations: new FormControl(channelSelector?.operations ?? ''),
+      entrypoints: new FormControl(channelSelector?.entrypoints ?? ''),
+      condition: new FormControl(conditionSelector?.condition ?? ''),
+    });
+  }
+
+  public onSubmit(): void {
+    const chanelSelectorToSave: ChannelSelector = {
+      type: 'CHANNEL',
+      channel: this.flowFormGroup?.get('channel')?.value,
+      channelOperator: this.flowFormGroup?.get('channelOperator')?.value,
+      operations: this.flowFormGroup?.get('operations')?.value,
+      entrypoints: this.flowFormGroup?.get('entrypoints')?.value,
+    };
+
+    const conditionValue: string = this.flowFormGroup?.get('condition')?.value;
+    const conditionSelectorToSave: ConditionSelector | undefined = conditionValue
+      ? {
+          type: 'CONDITION',
+          condition: conditionValue,
+        }
+      : undefined;
+
+    const flowToSave: FlowVM = {
+      // New id for new flow
+      _id: uniqueId('flow_'),
+      // If existing flow, keep root props
+      ...this.existingFlow,
+      name: this.flowFormGroup?.get('name')?.value,
+      selectors: conditionSelectorToSave ? [chanelSelectorToSave, conditionSelectorToSave] : [chanelSelectorToSave],
+      enabled: true,
+    };
+
+    this.dialogRef.close({
+      ...flowToSave,
+    });
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.harness.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class GioPolicyStudioFlowFormDialogHarness extends ComponentHarness {
+  public static hostSelector = 'gio-ps-flow-form-dialog';
+
+  private getSaveBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__saveBtn' }));
+  private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
+
+  public async setFlowFormValues(flow: {
+    name?: string;
+    channelOperator?: string;
+    channel?: string;
+    operations?: string[];
+    entrypoints?: string[];
+    condition?: string;
+  }): Promise<void> {
+    const nameInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }))();
+    const channelOperatorInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="channelOperator"]' }))();
+    const channelInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="channel"]' }))();
+    const operationsInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="operations"]' }))();
+    const entrypointsInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="entrypoints"]' }))();
+    const conditionInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="condition"]' }))();
+
+    if (flow.name) {
+      await nameInput.setValue(flow.name);
+    }
+    if (flow.channelOperator) {
+      await channelOperatorInput.open();
+      await channelOperatorInput.clickOptions({ text: new RegExp(flow.channelOperator, 'i') });
+    }
+    if (flow.channel) {
+      await channelInput.setValue(flow.channel);
+    }
+    if (flow.operations) {
+      await parallel(() =>
+        (flow.operations ?? []).map(async operation => {
+          await operationsInput.open();
+          await operationsInput.clickOptions({ text: new RegExp(operation, 'i') });
+        }),
+      );
+    }
+    if (flow.entrypoints) {
+      await parallel(() =>
+        (flow.entrypoints ?? []).map(async entrypoint => {
+          await entrypointsInput.open();
+          await entrypointsInput.clickOptions({ text: new RegExp(entrypoint, 'i') });
+        }),
+      );
+    }
+    if (flow.condition) {
+      await conditionInput.setValue(flow.condition);
+    }
+  }
+
+  public async save(): Promise<void> {
+    const button = await this.getSaveBtn();
+    await button.click();
+  }
+
+  public async cancel(): Promise<void> {
+    const button = await this.getCancelBtn();
+    await button.click();
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.stories.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Component, Input } from '@angular/core';
+import { tap } from 'rxjs/operators';
+import { action } from '@storybook/addon-actions';
+
+import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
+import { FlowVM } from '../../gio-policy-studio.model';
+import { fakeChannelFlow } from '../../models/index-testing';
+
+import { GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData } from './gio-ps-flow-form-dialog.component';
+
+@Component({
+  selector: 'gio-ps-flow-form-dialog-story',
+  template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+})
+class GioPolicyStudioFlowFormDialogStoryComponent {
+  @Input() public flow?: FlowVM = undefined;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, FlowVM | false>(
+        GioPolicyStudioFlowFormDialogComponent,
+        {
+          data: {
+            flow: this.flow,
+            entrypoints: ['entrypoint1', 'entrypoint2'],
+          },
+          role: 'alertdialog',
+          id: 'gioPsFlowFormDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        tap(createdOrEdited => {
+          action('createdOrEdited')(createdOrEdited);
+        }),
+      )
+      .subscribe();
+  }
+}
+
+export default {
+  title: 'Policy Studio / components / Flow form dialog',
+  component: GioPolicyStudioFlowFormDialogStoryComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [GioPolicyStudioFlowFormDialogStoryComponent],
+      imports: [GioPolicyStudioModule, MatDialogModule, BrowserAnimationsModule],
+    }),
+  ],
+  argTypes: {},
+  render: args => ({
+    component: GioPolicyStudioFlowFormDialogStoryComponent,
+    props: { ...args },
+  }),
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
+} as Meta;
+
+export const Create: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+
+export const Edit: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-dialog') as HTMLButtonElement;
+    button.click();
+  },
+  args: {
+    flow: {
+      ...fakeChannelFlow({
+        name: 'Flow name',
+        selectors: [
+          {
+            type: 'CHANNEL',
+            channel: 'channel1',
+            channelOperator: 'EQUALS',
+            operations: ['PUBLISH'],
+            entrypoints: ['entrypoint1', 'entrypoint2'],
+          },
+          {
+            type: 'CONDITION',
+            condition: 'My condition',
+          },
+        ],
+      }),
+      _id: 'flowId1',
+    },
+  },
+};

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.stories.ts
@@ -24,7 +24,11 @@ import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
 import { FlowVM } from '../../gio-policy-studio.model';
 import { fakeChannelFlow } from '../../models/index-testing';
 
-import { GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData } from './gio-ps-flow-form-dialog.component';
+import {
+  GioPolicyStudioFlowFormDialogComponent,
+  GioPolicyStudioFlowFormDialogData,
+  GioPolicyStudioFlowFormDialogResult,
+} from './gio-ps-flow-form-dialog.component';
 
 @Component({
   selector: 'gio-ps-flow-form-dialog-story',
@@ -36,7 +40,7 @@ class GioPolicyStudioFlowFormDialogStoryComponent {
 
   public openDialog() {
     this.matDialog
-      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, FlowVM | false>(
+      .open<GioPolicyStudioFlowFormDialogComponent, GioPolicyStudioFlowFormDialogData, GioPolicyStudioFlowFormDialogResult>(
         GioPolicyStudioFlowFormDialogComponent,
         {
           data: {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/gio-ps-flow-form-dialog.stories.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { Component, Input } from '@angular/core';
@@ -67,7 +67,7 @@ export default {
   decorators: [
     moduleMetadata({
       declarations: [GioPolicyStudioFlowFormDialogStoryComponent],
-      imports: [GioPolicyStudioModule, MatDialogModule, BrowserAnimationsModule],
+      imports: [GioPolicyStudioModule, MatDialogModule, NoopAnimationsModule],
     }),
   ],
   argTypes: {},

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
@@ -26,19 +26,19 @@
 </div>
 
 <div class="list">
-  <div *ngFor="let flowGroups of flowGroupVMSelected" class="list__flowsGroup">
+  <div *ngFor="let flowsGroup of flowsGroupsVMSelected" class="list__flowsGroup">
     <div class="list__flowsGroup__header">
       <div class="list__flowsGroup__header__label">
-        <mat-icon *ngIf="flowGroups.icon" [svgIcon]="flowGroups.icon"></mat-icon>
-        <span>{{ flowGroups.name }}</span>
+        <mat-icon *ngIf="flowsGroup.icon" [svgIcon]="flowsGroup.icon"></mat-icon>
+        <span>{{ flowsGroup.name }}</span>
       </div>
       <div class="list__flowsGroup__header__addBtn">
-        <button mat-icon-button><mat-icon svgIcon="gio:plus" matTooltip="New flow"></mat-icon></button>
+        <button mat-icon-button (click)="onAddFlow(flowsGroup)"><mat-icon svgIcon="gio:plus" matTooltip="New flow"></mat-icon></button>
       </div>
     </div>
 
     <div
-      *ngFor="let flow of flowGroups.flows"
+      *ngFor="let flow of flowsGroup.flows"
       class="list__flowsGroup__flow"
       [class.selected]="flow.selected"
       (click)="selectFlow(flow)"

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -76,10 +76,12 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
                 PUBLISH: 'PUB',
                 SUBSCRIBE: 'SUB',
               };
-              const operationBadges = (channelSelector.operations ?? []).map(operation => ({
-                label: operationToBadge[operation],
-                class: 'gio-badge-neutral',
-              }));
+              const operationBadges = (channelSelector.operations ?? [])
+                .map(operation => ({
+                  label: operationToBadge[operation],
+                  class: 'gio-badge-neutral',
+                }))
+                .sort((a, b) => a.label.localeCompare(b.label));
               operationBadges && badges.push(...operationBadges);
               pathOrChannelLabel = `${channelSelector.channel}${channelSelector.channelOperator === 'STARTS_WITH' ? '**' : ''}`;
             }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -52,6 +52,9 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
   @Input()
   public selectedFlow?: FlowVM = undefined;
 
+  @Input()
+  public entrypoints: string[] = [];
+
   @Output()
   public selectedFlowChange = new EventEmitter<FlowVM>();
 
@@ -133,7 +136,7 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
         {
           data: {
             flow: undefined,
-            entrypoints: [],
+            entrypoints: this.entrypoints,
           },
           role: 'alertdialog',
           id: 'gioPsFlowFormDialog',

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
@@ -15,6 +15,7 @@
  */
 
 import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { DivHarness } from '../../../testing';
 
@@ -35,6 +36,7 @@ export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
         isSelected: boolean;
         infos: string | null;
       }[];
+      clickAddFlowBtn: () => Promise<void>;
     }[]
   > {
     const flowsGroups = await this.locateFlowsGroups();
@@ -58,6 +60,8 @@ export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
         return {
           name: flowsGroupName,
           flows: await flowsInfos,
+          clickAddFlowBtn: async () =>
+            (await this.locatorFor(MatButtonHarness.with({ ancestor: '.list__flowsGroup__header__addBtn' }))()).click(),
         };
       }),
     );

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -15,6 +15,7 @@
  */
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/dist/ts3.9/client/preview/types-7-0';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 import { GioPolicyStudioModule } from './gio-policy-studio.module';
@@ -25,7 +26,7 @@ export default {
   component: GioPolicyStudioComponent,
   decorators: [
     moduleMetadata({
-      imports: [GioPolicyStudioModule],
+      imports: [BrowserAnimationsModule, GioPolicyStudioModule],
     }),
   ],
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -129,13 +129,14 @@ export const MessageWithFlowsAndPlans: Story = {
         name: 'Second plan',
         flows: [
           fakeChannelFlow({
-            name: 'Flow 1',
+            name: 'Flow 1 with webhook entrypoints',
             selectors: [
               {
                 type: 'CHANNEL',
                 channel: 'channel1',
                 channelOperator: 'EQUALS',
                 operations: ['PUBLISH', 'SUBSCRIBE'],
+                entrypoints: ['webhook'],
               },
             ],
           }),

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -47,6 +47,6 @@
   </div>
 
   <div class="wrapper__flowDetails">
-    <gio-ps-flow-details [flow]="selectedFlow"></gio-ps-flow-details>
+    <gio-ps-flow-details [flow]="selectedFlow" (flowChange)="onSelectedFlowChange($event)"></gio-ps-flow-details>
   </div>
 </div>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -41,6 +41,7 @@
   <div class="wrapper__flowsMenu">
     <gio-ps-flows-menu
       [flowsGroups]="flowsGroups"
+      [entrypoints]="entrypointsType"
       (flowsGroupsChange)="onFlowsGroupsChange($event)"
       [(selectedFlow)]="selectedFlow"
     ></gio-ps-flows-menu>
@@ -49,6 +50,7 @@
   <div class="wrapper__flowDetails">
     <gio-ps-flow-details
       [flow]="selectedFlow"
+      [entrypoints]="entrypointsType"
       (flowChange)="onSelectedFlowChange($event)"
       (deleteFlow)="onDeleteSelectedFlow($event)"
     ></gio-ps-flow-details>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -47,6 +47,10 @@
   </div>
 
   <div class="wrapper__flowDetails">
-    <gio-ps-flow-details [flow]="selectedFlow" (flowChange)="onSelectedFlowChange($event)"></gio-ps-flow-details>
+    <gio-ps-flow-details
+      [flow]="selectedFlow"
+      (flowChange)="onSelectedFlowChange($event)"
+      (deleteFlow)="onDeleteSelectedFlow($event)"
+    ></gio-ps-flow-details>
   </div>
 </div>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -39,7 +39,11 @@
 
 <div class="wrapper">
   <div class="wrapper__flowsMenu">
-    <gio-ps-flows-menu [flowsGroups]="flowsGroups" [(selectedFlow)]="selectedFlow"></gio-ps-flows-menu>
+    <gio-ps-flows-menu
+      [flowsGroups]="flowsGroups"
+      (flowsGroupsChange)="onFlowsGroupsChange($event)"
+      [(selectedFlow)]="selectedFlow"
+    ></gio-ps-flows-menu>
   </div>
 
   <div class="wrapper__flowDetails">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.scss
@@ -44,6 +44,7 @@
 .wrapper {
   display: flex;
   min-height: 0;
+  flex: 1 1 auto;
   flex-direction: row;
   gap: 16px;
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -70,6 +70,10 @@ export class GioPolicyStudioComponent implements OnChanges {
       }
     }
   }
+
+  public onFlowsGroupsChange(flowsGroups: FlowGroupVM[]): void {
+    this.flowsGroups = flowsGroups;
+  }
 }
 
 const getFlowsGroups = (commonFlows: Flow[] = [], plans: Plan[] = []): FlowGroupVM[] => {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -52,6 +52,8 @@ export class GioPolicyStudioComponent implements OnChanges {
 
   public flowsGroups: FlowGroupVM[] = [];
 
+  public entrypointsType: string[] = [];
+
   public ngOnChanges(changes: SimpleChanges): void {
     if (changes.entrypointsInfo || changes.endpointsInfo) {
       this.connectorsTooltip = `Entrypoints: ${(this.entrypointsInfo ?? []).map(e => capitalize(e.type)).join(', ')}\nEndpoints: ${(
@@ -59,6 +61,8 @@ export class GioPolicyStudioComponent implements OnChanges {
       )
         .map(e => capitalize(e.type))
         .join(', ')}`;
+
+      this.entrypointsType = (this.entrypointsInfo ?? []).map(e => e.type);
     }
 
     if (changes.commonFlows || changes.plans) {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -74,6 +74,14 @@ export class GioPolicyStudioComponent implements OnChanges {
   public onFlowsGroupsChange(flowsGroups: FlowGroupVM[]): void {
     this.flowsGroups = flowsGroups;
   }
+
+  public onSelectedFlowChange(flow: FlowVM): void {
+    this.flowsGroups = this.flowsGroups.map(flowGroup => ({
+      ...flowGroup,
+      flows: flowGroup.flows.map(f => (f._id === flow._id ? flow : f)),
+    }));
+    this.selectedFlow = flow;
+  }
 }
 
 const getFlowsGroups = (commonFlows: Flow[] = [], plans: Plan[] = []): FlowGroupVM[] => {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { capitalize, uniqueId } from 'lodash';
+import { capitalize, flatten, uniqueId } from 'lodash';
 
 import { ApiType, ConnectorsInfo, Flow, Plan } from './models';
 import { FlowGroupVM, FlowVM } from './gio-policy-studio.model';
@@ -81,6 +81,20 @@ export class GioPolicyStudioComponent implements OnChanges {
       flows: flowGroup.flows.map(f => (f._id === flow._id ? flow : f)),
     }));
     this.selectedFlow = flow;
+  }
+
+  public onDeleteSelectedFlow(flow: FlowVM): void {
+    // Define next selected flow and remove flow from flowsGroups
+    const allFLowsId = flatten(this.flowsGroups.map(flowGroup => flowGroup.flows)).map(f => f._id);
+    const flowToDeleteIndex = allFLowsId.indexOf(flow._id);
+    const nextSelectedFlow = allFLowsId[flowToDeleteIndex + 1] ?? allFLowsId[flowToDeleteIndex - 1];
+    this.flowsGroups = this.flowsGroups.map(flowGroup => ({
+      ...flowGroup,
+      flows: flowGroup.flows.filter(f => f._id !== flow._id),
+    }));
+    this.selectedFlow = this.flowsGroups
+      .find(flowGroup => flowGroup.flows.some(f => f._id === nextSelectedFlow))
+      ?.flows.find(f => f._id === nextSelectedFlow);
   }
 }
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
@@ -18,14 +18,37 @@ import { MatButtonModule } from '@angular/material/button';
 import { GioIconsModule } from '@gravitee/ui-particles-angular';
 import { CommonModule } from '@angular/common';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { ReactiveFormsModule } from '@angular/forms';
 
-import { GioPolicyStudioComponent } from './gio-policy-studio.component';
-import { GioPolicyStudioFlowsMenuComponent } from './components/flows-menu/gio-ps-flows-menu.component';
+import { GioPolicyStudioFlowFormDialogComponent } from './components/flow-form-dialog/gio-ps-flow-form-dialog.component';
 import { GioPolicyStudioDetailsComponent } from './components/flow-details/gio-ps-flow-details.component';
+import { GioPolicyStudioFlowsMenuComponent } from './components/flows-menu/gio-ps-flows-menu.component';
+import { GioPolicyStudioComponent } from './gio-policy-studio.component';
 
 @NgModule({
-  declarations: [GioPolicyStudioComponent, GioPolicyStudioFlowsMenuComponent, GioPolicyStudioDetailsComponent],
-  imports: [CommonModule, MatButtonModule, MatTooltipModule, GioIconsModule],
+  declarations: [
+    GioPolicyStudioComponent,
+    GioPolicyStudioFlowsMenuComponent,
+    GioPolicyStudioDetailsComponent,
+    GioPolicyStudioFlowFormDialogComponent,
+  ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+
+    MatButtonModule,
+    MatTooltipModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatDialogModule,
+
+    GioIconsModule,
+  ],
   exports: [GioPolicyStudioComponent],
 })
 export class GioPolicyStudioModule {}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -358,4 +358,44 @@ describe('GioPolicyStudioModule', () => {
       },
     ]);
   });
+
+  it('should edit flow into plan', async () => {
+    const planFooFlows = [fakeChannelFlow({ name: 'Foo flow 1' }), fakeChannelFlow({ name: 'Foo flow 2' })];
+    const plans = [fakePlan({ name: 'Foo plan', flows: planFooFlows }), fakePlan({ name: 'Bar plan', flows: [] })];
+    component.plans = plans;
+
+    component.ngOnChanges({
+      plans: new SimpleChange(null, null, true),
+    });
+
+    const flowsMenuHarness = await loader.getHarness(GioPolicyStudioFlowsMenuHarness);
+    const detailsHarness = await loader.getHarness(GioPolicyStudioDetailsHarness);
+
+    // Edit first selected flow
+    await detailsHarness.clickEditFlowBtn();
+
+    const flowFormDialog = await rootLoader.getHarness(GioPolicyStudioFlowFormDialogHarness);
+    await flowFormDialog.setFlowFormValues({ name: 'Edited flow name' });
+    await flowFormDialog.save();
+
+    const flowsGroupsUpdated = await flowsMenuHarness.getAllFlowsGroups();
+
+    expect(flowsGroupsUpdated).toMatchObject([
+      {
+        flows: [
+          {
+            isSelected: true,
+            name: 'Edited flow name',
+          },
+          {
+            isSelected: false,
+            name: 'Foo flow 2',
+          },
+        ],
+        name: 'Foo plan',
+      },
+      { name: 'Bar plan', flows: [] },
+      { name: 'Common flows', flows: [] },
+    ]);
+  });
 });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -398,4 +398,36 @@ describe('GioPolicyStudioModule', () => {
       { name: 'Common flows', flows: [] },
     ]);
   });
+
+  it('should delete flow into plan', async () => {
+    const planFooFlows = [fakeChannelFlow({ name: 'Foo flow 1' }), fakeChannelFlow({ name: 'Foo flow 2' })];
+    const plans = [fakePlan({ name: 'Foo plan', flows: planFooFlows }), fakePlan({ name: 'Bar plan', flows: [] })];
+    component.plans = plans;
+
+    component.ngOnChanges({
+      plans: new SimpleChange(null, null, true),
+    });
+
+    const flowsMenuHarness = await loader.getHarness(GioPolicyStudioFlowsMenuHarness);
+    const detailsHarness = await loader.getHarness(GioPolicyStudioDetailsHarness);
+
+    // Delete first selected flow
+    await detailsHarness.clickDeleteFlowBtn();
+
+    const flowsGroupsUpdated = await flowsMenuHarness.getAllFlowsGroups();
+
+    expect(flowsGroupsUpdated).toMatchObject([
+      {
+        flows: [
+          {
+            isSelected: true,
+            name: 'Foo flow 2',
+          },
+        ],
+        name: 'Foo plan',
+      },
+      { name: 'Bar plan', flows: [] },
+      { name: 'Common flows', flows: [] },
+    ]);
+  });
 });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -370,8 +370,14 @@ describe('GioPolicyStudioModule', () => {
     const planFooFlows = [fakeChannelFlow({ name: 'Foo flow 1' }), fakeChannelFlow({ name: 'Foo flow 2' })];
     const plans = [fakePlan({ name: 'Foo plan', flows: planFooFlows }), fakePlan({ name: 'Bar plan', flows: [] })];
     component.plans = plans;
-
+    component.entrypointsInfo = [
+      {
+        type: 'webhook',
+        icon: 'gio:webhook',
+      },
+    ];
     component.ngOnChanges({
+      entrypointsInfo: new SimpleChange(null, null, true),
       plans: new SimpleChange(null, null, true),
     });
 
@@ -382,7 +388,7 @@ describe('GioPolicyStudioModule', () => {
     await detailsHarness.clickEditFlowBtn();
 
     const flowFormDialog = await rootLoader.getHarness(GioPolicyStudioFlowFormDialogHarness);
-    await flowFormDialog.setFlowFormValues({ name: 'Edited flow name' });
+    await flowFormDialog.setFlowFormValues({ name: 'Edited flow name', entrypoints: ['webhook'] });
     await flowFormDialog.save();
 
     const flowsGroupsUpdated = await flowsMenuHarness.getAllFlowsGroups();
@@ -404,6 +410,8 @@ describe('GioPolicyStudioModule', () => {
       { name: 'Bar plan', flows: [] },
       { name: 'Common flows', flows: [] },
     ]);
+
+    expect(await detailsHarness.matchText(/webhook/)).toEqual(true);
   });
 
   it('should delete flow into plan', async () => {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -19,6 +19,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { SimpleChange } from '@angular/core';
+import { InteractivityChecker } from '@angular/cdk/a11y';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { fakeChannelFlow, fakeHttpFlow, fakePlan } from '../public-testing-api';
@@ -38,7 +39,13 @@ describe('GioPolicyStudioModule', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioPolicyStudioModule, MatIconTestingModule],
-    }).compileComponents();
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This checks focus trap, set it to true to  avoid the warning
+        },
+      })
+      .compileComponents();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-1550

**Description**

Add create / edit / delete  message flow


Next PR : same dialog but for proxy flow. Maybe i rename this dialog or not if a change only the content, we will see


**Additional context**

<img width="990" alt="image" src="https://github.com/gravitee-io/gravitee-ui-particles/assets/4974420/c044c89b-41bd-47a3-8173-16d73ec7f2b7">

<img width="1019" alt="image" src="https://github.com/gravitee-io/gravitee-ui-particles/assets/4974420/365b8651-e0d9-4377-b313-36340e7a2165">


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.3.0-apim-1550-crud-message-flow-c4fb521
```
```
yarn add @gravitee/ui-policy-studio-angular@7.3.0-apim-1550-crud-message-flow-c4fb521
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.3.0-apim-1550-crud-message-flow-c4fb521
```
```
yarn add @gravitee/ui-particles-angular@7.3.0-apim-1550-crud-message-flow-c4fb521
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vxyygdztqo.chromatic.com)
<!-- Storybook placeholder end -->
