### PR TITLE
chore: add story - tags input with autocomplete selection only

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
@@ -210,3 +210,53 @@ export const WithAutocomplete: Story = {
     placeholder: 'Add a tag',
   },
 };
+
+const httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'];
+export const WithAutocompleteOnly: Story = {
+  render: ({ tags, placeholder, required, disabled, tagValidationHook, autocompleteOptions }) => {
+    const tagsControl = new FormControl({ value: tags, disabled });
+
+    tagsControl.valueChanges.subscribe(value => {
+      action('Tags')(value);
+    });
+
+    return {
+      template: `
+      <mat-form-field appearance="fill" style="width:100%">
+        <mat-label>Http methods</mat-label>
+        <gio-form-tags-input
+          [required]="required" 
+          [placeholder]="placeholder" 
+          [formControl]="tagsControl"
+          [tagValidationHook]="tagValidationHook"
+          [autocompleteOptions]="autocompleteOptions"
+        >
+        </gio-form-tags-input>
+      </mat-form-field>
+      `,
+      props: {
+        tags,
+        placeholder,
+        required,
+        disabled,
+        tagsControl,
+        tagValidationHook,
+        autocompleteOptions,
+      },
+    };
+  },
+  args: {
+    tags: ['GET'],
+    disabled: false,
+    placeholder: 'Add http method',
+    autocompleteOptions: httpMethods,
+    tagValidationHook: (tag: string, validationCb: (shouldAddTag: boolean) => void) => {
+      validationCb(httpMethods.includes(tag.toUpperCase()));
+    },
+  },
+  argTypes: {
+    tagValidationHook: {
+      control: { type: 'function' },
+    },
+  },
+};


### PR DESCRIPTION
use http methods selection as example

**Issue**

n/a

**Description**

![image](https://github.com/gravitee-io/gravitee-ui-particles/assets/4974420/9b80bbdb-4037-4b1a-bea9-a546736a5b06)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.5.0-tag-http-methos-b2b5c0d
```
```
yarn add @gravitee/ui-policy-studio-angular@7.5.0-tag-http-methos-b2b5c0d
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.5.0-tag-http-methos-b2b5c0d
```
```
yarn add @gravitee/ui-particles-angular@7.5.0-tag-http-methos-b2b5c0d
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-iiymqiajkb.chromatic.com)
<!-- Storybook placeholder end -->
