### PR TITLE
fix: add missing method badge

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.scss
@@ -101,4 +101,18 @@
     background-color: mat.get-color-from-palette(palettes.$mat-method-palette, head);
     color: mat.get-color-from-palette(palettes.$mat-method-palette, head-contrast);
   }
+
+  .gio-method-badge-connect {
+    @extend %gio-method-badge-base;
+
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, connect);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, connect-contrast);
+  }
+
+  .gio-method-badge-other {
+    @extend %gio-method-badge-base;
+
+    background-color: mat.get-color-from-palette(palettes.$mat-method-palette, other);
+    color: mat.get-color-from-palette(palettes.$mat-method-palette, other-contrast);
+  }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
@@ -36,6 +36,8 @@ const classByNames = {
   Option: 'gio-method-badge-option',
   Trace: 'gio-method-badge-trace',
   Head: 'gio-method-badge-head',
+  Connect: 'gio-method-badge-connect',
+  Other: 'gio-method-badge-other',
 };
 
 export const All: Story = {

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-mat-palettes.scss
@@ -291,6 +291,8 @@ $mat-method-palette: mat.define-palette(
     option: mat.get-color-from-palette($mat-success-palette, lighter80),
     trace: mat.get-color-from-palette($mat-cyan-palette, lighter80),
     head: mat.get-color-from-palette($mat-blue-palette, lighter80),
+    connect: mat.get-color-from-palette($mat-blue-palette, lighter80),
+    other: mat.get-color-from-palette($mat-blue-palette, lighter80),
     contrast: (
       patch: mat.get-color-from-palette($mat-accent-palette, darker40),
       post: mat.get-color-from-palette($mat-warning-palette, darker20),
@@ -300,6 +302,8 @@ $mat-method-palette: mat.define-palette(
       option: mat.get-color-from-palette($mat-success-palette, darker60),
       trace: mat.get-color-from-palette($mat-cyan-palette, default),
       head: mat.get-color-from-palette($mat-blue-palette, default),
+      connect: mat.get-color-from-palette($mat-blue-palette, default),
+      other: mat.get-color-from-palette($mat-blue-palette, default),
     ),
   ),
   patch,


### PR DESCRIPTION
use same color as head

**Issue**

N.A.

**Description**

I noticed that colors were missing for CONNECT and OTHER methods