### PR TITLE
Add flow edit test

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.harness.ts
@@ -18,11 +18,26 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 
+export type GioPolicyStudioFlowMessageHarnessData = {
+  name: string;
+  channelOperator: string;
+  channel: string;
+  entrypoints: string[];
+  operations: string[];
+  condition: string;
+};
+
 export class GioPolicyStudioFlowMessageFormDialogHarness extends ComponentHarness {
   public static hostSelector = 'gio-ps-flow-message-form-dialog';
 
   private getSaveBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__saveBtn' }));
   private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
+  private nameInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+  private channelOperatorInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="channelOperator"]' }));
+  private channelInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="channel"]' }));
+  private operationsInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="operations"]' }));
+  private entrypointsInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="entrypoints"]' }));
+  private conditionInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="condition"]' }));
 
   public async setFlowFormValues(flow: {
     name?: string;
@@ -32,17 +47,13 @@ export class GioPolicyStudioFlowMessageFormDialogHarness extends ComponentHarnes
     entrypoints?: string[];
     condition?: string;
   }): Promise<void> {
-    const nameInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }))();
-    const channelOperatorInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="channelOperator"]' }))();
-    const channelInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="channel"]' }))();
-    const operationsInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="operations"]' }))();
-    const entrypointsInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="entrypoints"]' }))();
-    const conditionInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="condition"]' }))();
-
     if (flow.name) {
+      const nameInput = await this.nameInput();
       await nameInput.setValue(flow.name);
     }
     if (flow.channelOperator) {
+      const channelOperatorInput = await this.channelOperatorInput();
+      const entrypointsInput = await this.entrypointsInput();
       await channelOperatorInput.open();
       // Unselect all options before selecting the new one
       for (const option of await entrypointsInput.getOptions()) {
@@ -53,9 +64,11 @@ export class GioPolicyStudioFlowMessageFormDialogHarness extends ComponentHarnes
       await channelOperatorInput.clickOptions({ text: new RegExp(flow.channelOperator, 'i') });
     }
     if (flow.channel) {
+      const channelInput = await this.channelInput();
       await channelInput.setValue(flow.channel);
     }
     if (flow.operations) {
+      const operationsInput = await this.operationsInput();
       await parallel(() =>
         (flow.operations ?? []).map(async operation => {
           await operationsInput.open();
@@ -70,6 +83,7 @@ export class GioPolicyStudioFlowMessageFormDialogHarness extends ComponentHarnes
       );
     }
     if (flow.entrypoints) {
+      const entrypointsInput = await this.entrypointsInput();
       await entrypointsInput.open();
       // Unselect all options before selecting the new one
       for (const option of await entrypointsInput.getOptions()) {
@@ -84,8 +98,33 @@ export class GioPolicyStudioFlowMessageFormDialogHarness extends ComponentHarnes
       );
     }
     if (flow.condition) {
+      const conditionInput = await this.conditionInput();
       await conditionInput.setValue(flow.condition);
     }
+  }
+
+  public async getName(): Promise<string> {
+    return this.nameInput().then(input => input.getValue());
+  }
+
+  public async getChannelOperator(): Promise<string> {
+    return this.channelOperatorInput().then(input => input.getValueText());
+  }
+
+  public async getChannel(): Promise<string> {
+    return this.channelInput().then(input => input.getValue());
+  }
+
+  public async getOperations(): Promise<string> {
+    return this.operationsInput().then(input => input.getValueText());
+  }
+
+  public async getEntrypoints(): Promise<string> {
+    return this.entrypointsInput().then(input => input.getValueText());
+  }
+
+  public async getCondition(): Promise<string> {
+    return this.conditionInput().then(input => input.getValue());
   }
 
   public async save(): Promise<void> {
@@ -96,5 +135,22 @@ export class GioPolicyStudioFlowMessageFormDialogHarness extends ComponentHarnes
   public async cancel(): Promise<void> {
     const button = await this.getCancelBtn();
     await button.click();
+  }
+
+  public async getFormValues(): Promise<GioPolicyStudioFlowMessageHarnessData> {
+    const name = await this.getName();
+    const channelOperator = await this.getChannelOperator();
+    const channel = await this.getChannel();
+    const entrypoints = (await this.getEntrypoints()).split(',');
+    const operations = (await this.getOperations()).split(',');
+    const condition = await this.getCondition();
+    return {
+      name,
+      channel,
+      channelOperator,
+      entrypoints,
+      operations,
+      condition,
+    };
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.html
@@ -47,6 +47,7 @@
 
     <mat-form-field>
       <mat-label>Path</mat-label>
+      <span matPrefix>/</span>
       <input matInput formControlName="path" />
       <mat-hint>Path</mat-hint>
     </mat-form-field>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.spec.ts
@@ -85,6 +85,21 @@ describe('GioPolicyStudioFlowProxyFormDialogComponent', () => {
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
   });
 
+  it('should display value from initial flow', async () => {
+    component.flowToEdit = {
+      _id: 'test-id',
+      _hasChanged: false,
+      ...fakeHttpFlow({ name: 'FlO1', selectors: [{ type: 'HTTP', path: '/path', pathOperator: 'EQUALS', methods: [] }] }),
+    };
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowProxyFormDialogHarness);
+    expect(await flowFormDialogHarness.getFlowPath()).toEqual('path');
+    expect(await flowFormDialogHarness.getFlowName()).toEqual('FlO1');
+    expect(await flowFormDialogHarness.getPathOperator()).toEqual('Equals');
+    expect(await flowFormDialogHarness.getMethods()).toEqual(['ALL']);
+  });
+
   it('should return false on cancel', async () => {
     component.flow = {
       _id: 'test-id',
@@ -128,7 +143,7 @@ describe('GioPolicyStudioFlowProxyFormDialogComponent', () => {
         {
           type: 'HTTP',
           pathOperator: 'EQUALS',
-          path: 'test-path',
+          path: '/test-path',
           methods: ['GET'],
         },
       ],
@@ -156,7 +171,7 @@ describe('GioPolicyStudioFlowProxyFormDialogComponent', () => {
         {
           type: 'HTTP',
           pathOperator: 'EQUALS',
-          path: 'test-path',
+          path: '/test-path',
           methods: [],
         },
       ],
@@ -185,7 +200,7 @@ describe('GioPolicyStudioFlowProxyFormDialogComponent', () => {
         {
           type: 'HTTP',
           pathOperator: 'EQUALS',
-          path: 'test-path',
+          path: '/test-path',
           methods: ['POST'],
         },
       ],
@@ -214,7 +229,7 @@ describe('GioPolicyStudioFlowProxyFormDialogComponent', () => {
         {
           type: 'HTTP',
           pathOperator: 'EQUALS',
-          path: 'test-path',
+          path: '/test-path',
           methods: ['GET'],
         },
         {
@@ -272,7 +287,7 @@ describe('GioPolicyStudioFlowProxyFormDialogComponent', () => {
         {
           type: 'HTTP',
           pathOperator: 'EQUALS',
-          path: 'test-path',
+          path: '/test-path',
           methods: ['GET'],
         },
         {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.ts
@@ -110,7 +110,7 @@ const sanitizeMethodFormValue: (methods?: HttpMethod[]) => HttpMethodVM[] = (met
   return methods;
 };
 
-const sanitizePath = (path: string) => {
+export const sanitizePath = (path: string) => {
   if (!path || !path.startsWith('/')) {
     return `/${path}`;
   }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component.ts
@@ -55,7 +55,7 @@ export class GioPolicyStudioFlowProxyFormDialogComponent {
     this.flowFormGroup = new FormGroup({
       name: new FormControl(flowDialogData?.flow?.name ?? ''),
       pathOperator: new FormControl(httpSelector?.pathOperator ?? 'EQUALS'),
-      path: new FormControl(httpSelector?.path ?? ''),
+      path: new FormControl(sanitizePathFormValue(httpSelector?.path)),
       methods: new FormControl(sanitizeMethodFormValue(httpSelector?.methods)),
       condition: new FormControl(conditionSelector?.condition ?? ''),
     });
@@ -64,7 +64,7 @@ export class GioPolicyStudioFlowProxyFormDialogComponent {
   public onSubmit(): void {
     const httpSelectorToSave: HttpSelector = {
       type: 'HTTP',
-      path: this.flowFormGroup?.get('path')?.value,
+      path: sanitizePath(this.flowFormGroup?.get('path')?.value),
       pathOperator: this.flowFormGroup?.get('pathOperator')?.value,
       methods: sanitizeMethods(this.flowFormGroup?.get('methods')?.value),
     };
@@ -108,4 +108,18 @@ const sanitizeMethods: (value: HttpMethodVM[]) => HttpMethod[] = (value?: HttpMe
 const sanitizeMethodFormValue: (methods?: HttpMethod[]) => HttpMethodVM[] = (methods?: HttpMethod[]) => {
   if (!methods || methods.length === 0) return ['ALL'];
   return methods;
+};
+
+const sanitizePath = (path: string) => {
+  if (!path || !path.startsWith('/')) {
+    return `/${path}`;
+  }
+  return path;
+};
+
+const sanitizePathFormValue = (path: string | undefined) => {
+  if (path && path.startsWith('/')) {
+    return path.substring(1);
+  }
+  return path ?? '';
 };

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness.ts
@@ -24,6 +24,11 @@ export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness 
 
   private getSaveBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__saveBtn' }));
   private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
+  private nameInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+  private pathOperatorInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="pathOperator"]' }));
+  private pathInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="path"]' }));
+  private methodsInput = this.locatorFor(GioFormTagsInputHarness.with({ selector: '[formControlName="methods"]' }));
+  private conditionInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="condition"]' }));
 
   public async setFlowFormValues(flow: {
     name?: string;
@@ -32,16 +37,12 @@ export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness 
     methods?: string[];
     condition?: string;
   }): Promise<void> {
-    const nameInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }))();
-    const pathOperatorInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="pathOperator"]' }))();
-    const pathInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="path"]' }))();
-    const methodsInput = await this.locatorFor(GioFormTagsInputHarness.with({ selector: '[formControlName="methods"]' }))();
-    const conditionInput = await this.locatorFor(MatInputHarness.with({ selector: '[formControlName="condition"]' }))();
-
     if (flow.name) {
+      const nameInput = await this.nameInput();
       await nameInput.setValue(flow.name);
     }
     if (flow.pathOperator) {
+      const pathOperatorInput = await this.pathOperatorInput();
       await pathOperatorInput.open();
 
       // Unselect all options before selecting the new one
@@ -53,17 +54,36 @@ export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness 
       await pathOperatorInput.clickOptions({ text: new RegExp(flow.pathOperator, 'i') });
     }
     if (flow.path) {
-      await pathInput.setValue(flow.path);
+      const input = await this.pathInput();
+      await input.setValue(flow.path);
     }
     if (flow.methods) {
+      const methodsInput = await this.methodsInput();
       await methodsInput.removeTag('ALL');
       for await (const method of flow.methods) {
         await methodsInput.addTag(method);
       }
     }
     if (flow.condition) {
+      const conditionInput = await this.conditionInput();
       await conditionInput.setValue(flow.condition);
     }
+  }
+
+  public async getFlowName(): Promise<string> {
+    return this.nameInput().then(input => input.getValue());
+  }
+
+  public async getFlowPath(): Promise<string> {
+    return this.pathInput().then(input => input.getValue());
+  }
+
+  public async getPathOperator(): Promise<string> {
+    return this.pathOperatorInput().then(input => input.getValueText());
+  }
+
+  public async getMethods(): Promise<string[]> {
+    return this.methodsInput().then(input => input.getTags());
   }
 
   public async save(): Promise<void> {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness.ts
@@ -19,6 +19,14 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { GioFormTagsInputHarness } from '@gravitee/ui-particles-angular';
 
+export type GioPolicyStudioFlowProxyHarnessData = {
+  name: string;
+  pathOperator: string;
+  path: string;
+  methods: string[];
+  condition: string;
+};
+
 export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness {
   public static hostSelector = 'gio-ps-flow-proxy-form-dialog';
 
@@ -70,6 +78,16 @@ export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness 
     }
   }
 
+  public async getFlowFormValues(): Promise<GioPolicyStudioFlowProxyHarnessData> {
+    return {
+      name: await this.getFlowName(),
+      pathOperator: await this.getPathOperator(),
+      path: await this.getFlowPath(),
+      methods: await this.getMethods(),
+      condition: await this.getCondition(),
+    };
+  }
+
   public async getFlowName(): Promise<string> {
     return this.nameInput().then(input => input.getValue());
   }
@@ -84,6 +102,10 @@ export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness 
 
   public async getMethods(): Promise<string[]> {
     return this.methodsInput().then(input => input.getTags());
+  }
+
+  public async getCondition(): Promise<string> {
+    return this.conditionInput().then(input => input.getValue());
   }
 
   public async save(): Promise<void> {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/HttpMethod.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/HttpMethod.ts
@@ -16,3 +16,30 @@
 
 export const HttpMethods = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'OTHER'] as const;
 export type HttpMethod = (typeof HttpMethods)[number];
+
+export const toHttpMethod: (value: string) => HttpMethod | undefined = (value: string) => {
+  switch (value) {
+    case 'CONNECT':
+      return 'CONNECT';
+    case 'DELETE':
+      return 'DELETE';
+    case 'GET':
+      return 'GET';
+    case 'HEAD':
+      return 'HEAD';
+    case 'OPTIONS':
+      return 'OPTIONS';
+    case 'PATCH':
+      return 'PATCH';
+    case 'POST':
+      return 'POST';
+    case 'PUT':
+      return 'PUT';
+    case 'TRACE':
+      return 'TRACE';
+    case 'OTHER':
+      return 'OTHER';
+    default:
+      return undefined;
+  }
+};


### PR DESCRIPTION
**Issue**

N.A.

**Description**

- Add suffix to path input in flow sync edit dialog
- Add init test for proxy and message dialogs
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.7.1-add-flow-edit-test-4674153
```
```
yarn add @gravitee/ui-policy-studio-angular@7.7.1-add-flow-edit-test-4674153
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.7.1-add-flow-edit-test-4674153
```
```
yarn add @gravitee/ui-particles-angular@7.7.1-add-flow-edit-test-4674153
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-fznafizqct.chromatic.com)
<!-- Storybook placeholder end -->
