### PR TITLE
Configure the flow execution in the Policy Studio

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog-result.model.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog-result.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Flow.fixture';
-export * from './FlowExecution.fixture';
+
+import { FlowExecution } from '../../models';
+
+export type GioPolicyStudioFlowExecutionFormDialogResult = FlowExecution | false;

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.html
@@ -1,0 +1,56 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title class="title">
+  Flow execution
+
+  <button class="title__closeBtn" mat-icon-button aria-label="Close dialog" [mat-dialog-close]="false">
+    <mat-icon svgIcon="gio:cancel"></mat-icon>
+  </button>
+</h2>
+
+<mat-dialog-content *ngIf="flowExecutionFormGroup" class="content" [formGroup]="flowExecutionFormGroup">
+  <div class="content__row">
+    <gio-banner-info>
+      By default, flow selection is based on the operators defined in your flows, either when it “matches with” or “starts with” a path. You
+      can choose the "Best match" option to select a flow from the closest path.
+    </gio-banner-info>
+  </div>
+  <div class="content__row">
+    <mat-form-field>
+      <mat-label>Default flow mode</mat-label>
+      <mat-select formControlName="mode">
+        <mat-option value="BEST_MATCH">Best Match</mat-option>
+        <mat-option value="DEFAULT">Default</mat-option>
+      </mat-select>
+      <mat-hint>Change how the flow selection is made</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <div class="content__row">
+    <gio-form-slide-toggle>
+      <gio-form-label>Fail on flow mismatch</gio-form-label>
+      Respond with an error when requests don’t match any defined flow
+      <mat-slide-toggle gioFormSlideToggle formControlName="matchRequired"></mat-slide-toggle>
+    </gio-form-slide-toggle>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions class="actions">
+  <button class="actions__cancelBtn" mat-flat-button [mat-dialog-close]="false">Cancel</button>
+  <button class="actions__saveBtn" color="primary" mat-stroked-button role="dialog" (click)="onSubmit()">Save</button>
+</mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Flow.fixture';
-export * from './FlowExecution.fixture';
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+.title {
+  &__closeBtn {
+    top: -20px;
+    right: -20px;
+    float: right;
+  }
+}
+
+.content {
+  &__row {
+    display: flex;
+    gap: 16px;
+
+    mat-form-field {
+      flex: 1 1 auto;
+    }
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
+import { FlowExecution } from '../../models';
+import { fakeBestMatchFlowExecution, fakeDefaultFlowExecution } from '../../models/flow/FlowExecution.fixture';
+
+import { GioPolicyStudioFlowExecutionFormDialogResult } from './gio-ps-flow-execution-form-dialog-result.model';
+import {
+  GioPolicyStudioFlowExecutionFormDialogComponent,
+  GioPolicyStudioFlowExecutionFormDialogData,
+} from './gio-ps-flow-execution-form-dialog.component';
+import { GioPolicyStudioFlowExecutionFormDialogHarness } from './gio-ps-flow-execution-form-dialog.harness';
+
+@Component({
+  selector: 'gio-dialog-test',
+  template: `<button mat-button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+})
+class TestComponent {
+  public flowExecution?: FlowExecution;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<
+        GioPolicyStudioFlowExecutionFormDialogComponent,
+        GioPolicyStudioFlowExecutionFormDialogData,
+        GioPolicyStudioFlowExecutionFormDialogResult
+      >(GioPolicyStudioFlowExecutionFormDialogComponent, {
+        data: {
+          flowExecution: this.flowExecution,
+        },
+        role: 'alertdialog',
+        id: 'testDialog',
+      })
+      .afterClosed()
+      .subscribe(flowExecution => {
+        if (flowExecution) {
+          this.flowExecution = flowExecution;
+        }
+      });
+  }
+}
+
+describe('GioPolicyStudioFlowExecutionFormDialogComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [GioPolicyStudioModule, MatDialogModule, NoopAnimationsModule, MatIconTestingModule],
+    }).overrideProvider(InteractivityChecker, {
+      useValue: {
+        isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        isTabbable: () => true, // hidden elements
+      },
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  });
+
+  it('should return false on cancel', async () => {
+    component.flowExecution = fakeBestMatchFlowExecution();
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowExecutionFormDialogHarness);
+    await flowFormDialogHarness.setFlowFormValues({
+      mode: 'DEFAULT',
+      matchRequired: true,
+    });
+    await flowFormDialogHarness.cancel();
+
+    expect(component.flowExecution).toEqual(fakeBestMatchFlowExecution());
+  });
+
+  it('should edit flow execution without any changes', async () => {
+    component.flowExecution = fakeBestMatchFlowExecution();
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowExecutionFormDialogHarness);
+    await flowFormDialogHarness.save();
+
+    expect(component.flowExecution).toEqual(fakeBestMatchFlowExecution());
+  });
+
+  describe('should edit flow with full changes', () => {
+    it('From Best match to Default mode', async () => {
+      component.flowExecution = fakeBestMatchFlowExecution();
+      await componentTestingOpenDialog();
+
+      const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowExecutionFormDialogHarness);
+
+      await flowFormDialogHarness.setFlowFormValues({
+        mode: 'DEFAULT',
+        matchRequired: true,
+      });
+      await flowFormDialogHarness.save();
+
+      expect(component.flowExecution).toEqual({
+        mode: 'DEFAULT',
+        matchRequired: true,
+      });
+    });
+
+    it('From Default to Best match mode', async () => {
+      component.flowExecution = fakeDefaultFlowExecution();
+      await componentTestingOpenDialog();
+
+      const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowExecutionFormDialogHarness);
+
+      await flowFormDialogHarness.setFlowFormValues({
+        mode: 'BEST_MATCH',
+        matchRequired: true,
+      });
+      await flowFormDialogHarness.save();
+
+      expect(component.flowExecution).toEqual({
+        mode: 'BEST_MATCH',
+        matchRequired: true,
+      });
+    });
+  });
+
+  it('should uncheck toggle', async () => {
+    component.flowExecution = fakeBestMatchFlowExecution({ matchRequired: true });
+    await componentTestingOpenDialog();
+
+    const flowFormDialogHarness = await loader.getHarness(GioPolicyStudioFlowExecutionFormDialogHarness);
+
+    await flowFormDialogHarness.setFlowFormValues({
+      matchRequired: false,
+    });
+    await flowFormDialogHarness.save();
+
+    expect(component.flowExecution).toEqual({
+      mode: 'BEST_MATCH',
+      matchRequired: false,
+    });
+  });
+
+  async function componentTestingOpenDialog() {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+  }
+});

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FormControl, FormGroup } from '@angular/forms';
+import { cloneDeep } from 'lodash';
+
+import { FlowExecution } from '../../models';
+
+import { GioPolicyStudioFlowExecutionFormDialogResult } from './gio-ps-flow-execution-form-dialog-result.model';
+
+export type GioPolicyStudioFlowExecutionFormDialogData = {
+  flowExecution?: FlowExecution;
+};
+
+@Component({
+  selector: 'gio-ps-flow-execution-form-dialog',
+  templateUrl: './gio-ps-flow-execution-form-dialog.component.html',
+  styleUrls: ['./gio-ps-flow-execution-form-dialog.component.scss'],
+})
+export class GioPolicyStudioFlowExecutionFormDialogComponent {
+  public flowExecutionFormGroup?: FormGroup;
+
+  public existingFlowExecution?: FlowExecution;
+
+  constructor(
+    public dialogRef: MatDialogRef<GioPolicyStudioFlowExecutionFormDialogComponent, GioPolicyStudioFlowExecutionFormDialogResult>,
+    @Inject(MAT_DIALOG_DATA) flowDialogData: GioPolicyStudioFlowExecutionFormDialogData,
+  ) {
+    this.existingFlowExecution = cloneDeep(flowDialogData?.flowExecution);
+
+    this.flowExecutionFormGroup = new FormGroup({
+      mode: new FormControl(flowDialogData?.flowExecution?.mode ?? 'DEFAULT'),
+      matchRequired: new FormControl(flowDialogData?.flowExecution?.matchRequired ?? false),
+    });
+  }
+
+  public onSubmit(): void {
+    const flowExecutionToSave: FlowExecution = {
+      ...this.existingFlowExecution,
+      mode: this.flowExecutionFormGroup?.get('mode')?.value,
+      matchRequired: this.flowExecutionFormGroup?.get('matchRequired')?.value,
+    };
+
+    this.dialogRef.close({
+      ...flowExecutionToSave,
+    });
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.harness.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+
+import { FlowMode } from '../../models';
+
+export class GioPolicyStudioFlowExecutionFormDialogHarness extends ComponentHarness {
+  public static hostSelector = 'gio-ps-flow-execution-form-dialog';
+
+  private getSaveBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__saveBtn' }));
+  private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
+
+  public async setFlowFormValues(flowExecution: { mode?: FlowMode; matchRequired?: boolean }): Promise<void> {
+    const modeInput = await this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="mode"]' }))();
+    const matchRequiredInput = await this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="matchRequired"]' }))();
+
+    if (flowExecution.mode) {
+      await modeInput.open();
+
+      // Unselect all options before selecting the new one
+      for (const option of await modeInput.getOptions()) {
+        if (await option.isSelected()) {
+          await option.click();
+        }
+      }
+      const flowModeToValue: Record<FlowMode, string> = {
+        BEST_MATCH: 'Best match',
+        DEFAULT: 'Default',
+      };
+
+      await modeInput.clickOptions({ text: new RegExp(flowModeToValue[flowExecution.mode], 'i') });
+    }
+
+    if (flowExecution.matchRequired) {
+      await matchRequiredInput.check();
+    } else {
+      await matchRequiredInput.uncheck();
+    }
+  }
+
+  public async save(): Promise<void> {
+    const button = await this.getSaveBtn();
+    await button.click();
+  }
+
+  public async cancel(): Promise<void> {
+    const button = await this.getCancelBtn();
+    await button.click();
+  }
+}

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.stories.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Component, Input } from '@angular/core';
+import { tap } from 'rxjs/operators';
+import { action } from '@storybook/addon-actions';
+
+import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
+import { FlowExecution } from '../../models';
+import { fakeBestMatchFlowExecution } from '../../models/flow/FlowExecution.fixture';
+
+import {
+  GioPolicyStudioFlowExecutionFormDialogComponent,
+  GioPolicyStudioFlowExecutionFormDialogData,
+} from './gio-ps-flow-execution-form-dialog.component';
+import { GioPolicyStudioFlowExecutionFormDialogResult } from './gio-ps-flow-execution-form-dialog-result.model';
+
+@Component({
+  selector: 'gio-ps-flow-execution-form-dialog-story',
+  template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+})
+class GioPolicyStudioFlowExecutionFormDialogStoryComponent {
+  @Input() public flowExecution?: FlowExecution = undefined;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<
+        GioPolicyStudioFlowExecutionFormDialogComponent,
+        GioPolicyStudioFlowExecutionFormDialogData,
+        GioPolicyStudioFlowExecutionFormDialogResult
+      >(GioPolicyStudioFlowExecutionFormDialogComponent, {
+        data: {
+          flowExecution: this.flowExecution,
+        },
+        role: 'alertdialog',
+        id: 'gioPsFlowExecutionFormDialog',
+      })
+      .afterClosed()
+      .pipe(
+        tap(createdOrEdited => {
+          action('createdOrEdited')(createdOrEdited);
+        }),
+      )
+      .subscribe();
+  }
+}
+
+export default {
+  title: 'Policy Studio / components / Flow execution form dialog',
+  component: GioPolicyStudioFlowExecutionFormDialogStoryComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [GioPolicyStudioFlowExecutionFormDialogStoryComponent],
+      imports: [GioPolicyStudioModule, MatDialogModule, NoopAnimationsModule],
+    }),
+  ],
+  argTypes: {},
+  render: args => ({
+    component: GioPolicyStudioFlowExecutionFormDialogStoryComponent,
+    props: { ...args },
+  }),
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
+} as Meta;
+
+export const EditDefaultValue: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-dialog') as HTMLButtonElement;
+    button.click();
+  },
+  args: {
+    flowExecution: undefined,
+  },
+};
+
+export const EditExistingValue: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-dialog') as HTMLButtonElement;
+    button.click();
+  },
+  args: {
+    flowExecution: fakeBestMatchFlowExecution({ matchRequired: true }),
+  },
+};

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
@@ -21,7 +21,9 @@
     Flows <mat-icon svgIcon="gio:info" matTooltip="Flows allow you to apply different policies on your API event phases"></mat-icon>
   </div>
   <div class="header__configBtn">
-    <button mat-stroked-button mat-icon-button><mat-icon svgIcon="gio:settings"></mat-icon></button>
+    <button class="header__configBtn_edit" mat-stroked-button mat-icon-button (click)="onConfigureExecution(flowExecution)">
+      <mat-icon svgIcon="gio:settings"></mat-icon>
+    </button>
   </div>
 </div>
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -23,12 +23,17 @@ import {
   GioPolicyStudioFlowMessageFormDialogData,
 } from '../flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.component';
 import { FlowGroupVM, FlowVM } from '../../gio-policy-studio.model';
-import { ApiType, ChannelSelector, HttpSelector, Operation } from '../../models';
+import { ApiType, ChannelSelector, FlowExecution, HttpSelector, Operation } from '../../models';
 import {
   GioPolicyStudioFlowProxyFormDialogComponent,
   GioPolicyStudioFlowProxyFormDialogData,
 } from '../flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.component';
 import { GioPolicyStudioFlowFormDialogResult } from '../flow-form-dialog/gio-ps-flow-form-dialog-result.model';
+import {
+  GioPolicyStudioFlowExecutionFormDialogComponent,
+  GioPolicyStudioFlowExecutionFormDialogData,
+} from '../flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component';
+import { GioPolicyStudioFlowExecutionFormDialogResult } from '../flow-execution-form-dialog/gio-ps-flow-execution-form-dialog-result.model';
 
 interface FlowGroupMenuVM extends FlowGroupVM {
   flows: FlowMenuVM[];
@@ -54,6 +59,9 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
   public apiType!: ApiType;
 
   @Input()
+  public flowExecution!: FlowExecution;
+
+  @Input()
   public flowsGroups: FlowGroupVM[] = [];
 
   @Input()
@@ -67,6 +75,9 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
 
   @Output()
   public flowsGroupsChange = new EventEmitter<FlowGroupVM[]>();
+
+  @Output()
+  public flowExecutionChange = new EventEmitter<FlowExecution>();
 
   public flowsGroupsVMSelected: FlowGroupMenuVM[] = [];
 
@@ -185,6 +196,33 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
 
           this.flowsGroupsChange.emit(editedFlowsGroups);
           this.selectedFlowChange.emit(createdOrEdited);
+        }),
+      )
+      .subscribe();
+  }
+
+  public onConfigureExecution(flowExecution: FlowExecution): void {
+    const dialogResult = this.matDialog
+      .open<
+        GioPolicyStudioFlowExecutionFormDialogComponent,
+        GioPolicyStudioFlowExecutionFormDialogData,
+        GioPolicyStudioFlowExecutionFormDialogResult
+      >(GioPolicyStudioFlowExecutionFormDialogComponent, {
+        data: {
+          flowExecution,
+        },
+        role: 'alertdialog',
+        id: 'gioPsFlowExecutionFormDialog',
+      })
+      .afterClosed();
+
+    dialogResult
+      .pipe(
+        tap(edited => {
+          if (!edited) {
+            return;
+          }
+          this.flowExecutionChange.emit(edited);
         }),
       )
       .subscribe();

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
@@ -89,4 +89,8 @@ export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
       await (await flowsGroups.childLocatorFor(MatButtonHarness.with({ ancestor: '.list__flowsGroup__header__addBtn' }))()).click();
     }
   }
+
+  public async openFlowExecutionConfig(): Promise<void> {
+    await (await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn_edit' }))())?.click();
+  }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -33,6 +33,7 @@ export default {
   render: props => ({
     template: `<div style="height:calc(100vh - 2rem);"><gio-policy-studio
     [apiType]="apiType"
+    [flowExecution]="flowExecution"
     [entrypointsInfo]="entrypointsInfo"
     [endpointsInfo]="endpointsInfo"
     [commonFlows]="commonFlows"
@@ -54,6 +55,10 @@ export const MessageWithoutFlows: Story = {
   name: 'Message API without flows',
   args: {
     apiType: 'MESSAGE',
+    flowExecution: {
+      mode: 'BEST_MATCH',
+      matchRequired: false,
+    },
     entrypointsInfo: [
       {
         type: 'webhook',
@@ -73,6 +78,10 @@ export const MessageWithFlows: Story = {
   name: 'Message API with flows',
   args: {
     apiType: 'MESSAGE',
+    flowExecution: {
+      mode: 'BEST_MATCH',
+      matchRequired: false,
+    },
     entrypointsInfo: [
       {
         type: 'webhook',
@@ -101,6 +110,10 @@ export const MessageWithFlowsAndPlans: Story = {
   name: 'Message API with flows & plans',
   args: {
     apiType: 'MESSAGE',
+    flowExecution: {
+      mode: 'BEST_MATCH',
+      matchRequired: false,
+    },
     entrypointsInfo: [
       {
         type: 'webhook',
@@ -171,6 +184,10 @@ export const ProxyWithFlowsAndPlans: Story = {
   name: 'Proxy API with flows & plans',
   args: {
     apiType: 'PROXY',
+    flowExecution: {
+      mode: 'BEST_MATCH',
+      matchRequired: false,
+    },
     entrypointsInfo: [
       {
         type: 'http-proxy',

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -41,9 +41,11 @@
   <div class="wrapper__flowsMenu">
     <gio-ps-flows-menu
       [apiType]="apiType"
+      [flowExecution]="flowExecution"
       [flowsGroups]="flowsGroups"
       [entrypoints]="entrypointsType"
       (flowsGroupsChange)="onFlowsGroupsChange($event)"
+      (flowExecutionChange)="onFlowExecutionChange($event)"
       [(selectedFlow)]="selectedFlow"
     ></gio-ps-flows-menu>
   </div>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.harness.ts
@@ -17,11 +17,12 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
-import { ChannelSelector, ConditionSelector, Flow, HttpSelector } from './models';
+import { ChannelSelector, ConditionSelector, Flow, FlowExecution, HttpSelector } from './models';
 import { GioPolicyStudioFlowsMenuHarness } from './components/flows-menu/gio-ps-flows-menu.harness';
 import { GioPolicyStudioDetailsHarness } from './components/flow-details/gio-ps-flow-details.harness';
 import { GioPolicyStudioFlowProxyFormDialogHarness } from './components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness';
 import { GioPolicyStudioFlowMessageFormDialogHarness } from './components/flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.harness';
+import { GioPolicyStudioFlowExecutionFormDialogHarness } from './components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.harness';
 
 export class GioPolicyStudioHarness extends ComponentHarness {
   public static hostSelector = 'gio-policy-studio';
@@ -131,5 +132,13 @@ export class GioPolicyStudioHarness extends ComponentHarness {
     }
 
     throw new Error('No selector found for this flow. Needed to select Message or Proxy flow form dialog.');
+  }
+
+  public async setFlowExecutionConfig(flowExecution: FlowExecution): Promise<void> {
+    await (await this.menuHarness()).openFlowExecutionConfig();
+
+    const flowExecutionDialog = await this.documentRootLocatorFactory().locatorFor(GioPolicyStudioFlowExecutionFormDialogHarness)();
+    await flowExecutionDialog.setFlowFormValues(flowExecution);
+    await flowExecutionDialog.save();
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
@@ -15,7 +15,7 @@
  */
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { GioBannerModule, GioFormTagsInputModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormSlideToggleModule, GioFormTagsInputModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 import { CommonModule } from '@angular/common';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -24,6 +24,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatTabsModule } from '@angular/material/tabs';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { GioPolicyStudioFlowMessageFormDialogComponent } from './components/flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.component';
 import { GioPolicyStudioDetailsComponent } from './components/flow-details/gio-ps-flow-details.component';
@@ -33,12 +34,14 @@ import { GioPolicyStudioFlowProxyFormDialogComponent } from './components/flow-f
 import { GioPolicyStudioDetailsInfoBarComponent } from './components/flow-details-info-bar/gio-ps-flow-details-info-bar.component';
 import { GioPolicyStudioDetailsPhasePolicyComponent } from './components/flow-details-phase-policy/gio-ps-flow-details-phase-policy.component';
 import { GioPolicyStudioDetailsPhaseComponent } from './components/flow-details-phase/gio-ps-flow-details-phase.component';
+import { GioPolicyStudioFlowExecutionFormDialogComponent } from './components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component';
 
 @NgModule({
   declarations: [
     GioPolicyStudioComponent,
     GioPolicyStudioFlowsMenuComponent,
     GioPolicyStudioDetailsComponent,
+    GioPolicyStudioFlowExecutionFormDialogComponent,
     GioPolicyStudioFlowMessageFormDialogComponent,
     GioPolicyStudioFlowProxyFormDialogComponent,
     GioPolicyStudioDetailsInfoBarComponent,
@@ -54,10 +57,12 @@ import { GioPolicyStudioDetailsPhaseComponent } from './components/flow-details-
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
+    MatSlideToggleModule,
     MatDialogModule,
     MatTabsModule,
 
     GioIconsModule,
+    GioFormSlideToggleModule,
     GioFormTagsInputModule,
     GioBannerModule,
   ],

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -23,7 +23,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
-import { fakeChannelFlow, fakeHttpFlow, fakePlan } from '../public-testing-api';
+import { fakeChannelFlow, fakeDefaultFlowExecution, fakeHttpFlow, fakePlan } from '../public-testing-api';
 
 import { GioPolicyStudioModule } from './gio-policy-studio.module';
 import { GioPolicyStudioComponent } from './gio-policy-studio.component';
@@ -754,6 +754,40 @@ describe('GioPolicyStudioModule', () => {
         ]);
 
         expect(await detailsHarness.matchText(/HTTP/)).toEqual(true);
+      });
+    });
+  });
+
+  describe('Flow execution settings', () => {
+    beforeEach(() => {
+      component.flowExecution = fakeDefaultFlowExecution();
+      fixture.detectChanges();
+    });
+
+    it('should not enable save button', async () => {
+      await policyStudioHarness.setFlowExecutionConfig({
+        mode: 'DEFAULT',
+        matchRequired: false,
+      });
+
+      expect(await (await loader.getHarness(MatButtonHarness.with({ text: /Save/ }))).isDisabled()).toEqual(true);
+      component.save.subscribe(value => {
+        expect(value.flowExecution).toBeUndefined();
+      });
+    });
+
+    it('should enable save button', async () => {
+      await policyStudioHarness.setFlowExecutionConfig({
+        mode: 'BEST_MATCH',
+        matchRequired: false,
+      });
+
+      expect(await (await loader.getHarness(MatButtonHarness.with({ text: /Save/ }))).isDisabled()).toEqual(false);
+      component.save.subscribe(value => {
+        expect(value.flowExecution).toEqual({
+          mode: 'BEST_MATCH',
+          matchRequired: false,
+        });
       });
     });
   });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/SaveOutput.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/SaveOutput.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Flow } from './flow';
+import { Flow, FlowExecution } from './flow';
 import { Plan } from './plan';
 
 export type SaveOutput = {
@@ -21,4 +21,6 @@ export type SaveOutput = {
   commonFlows?: Flow[];
   // Return the list of plans with updated flows. Plans with no updated flows are not returned.
   plansToUpdate?: Plan[];
+  // Return the flow execution configuration if it has been updated.
+  flowExecution?: FlowExecution;
 };

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/FlowExecution.fixture.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/FlowExecution.fixture.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'lodash';
+
+import { FlowExecution } from './FlowExecution';
+
+export function fakeBestMatchFlowExecution(modifier?: Partial<FlowExecution> | ((baseApi: FlowExecution) => FlowExecution)): FlowExecution {
+  const base: FlowExecution = {
+    mode: 'BEST_MATCH',
+    matchRequired: false,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeDefaultFlowExecution(modifier?: Partial<FlowExecution> | ((baseApi: FlowExecution) => FlowExecution)): FlowExecution {
+  const base: FlowExecution = {
+    mode: 'DEFAULT',
+    matchRequired: false,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1552

**Description**

This PR adds a new form dialog to edit the flox execution configuration of an API and uses it in the new policy studio
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.7.1-apim-1552-select-flow-mode-bdede0e
```
```
yarn add @gravitee/ui-policy-studio-angular@7.7.1-apim-1552-select-flow-mode-bdede0e
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.7.1-apim-1552-select-flow-mode-bdede0e
```
```
yarn add @gravitee/ui-particles-angular@7.7.1-apim-1552-select-flow-mode-bdede0e
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-uhvbawmfsy.chromatic.com)
<!-- Storybook placeholder end -->
