### PR TITLE
fix: the HTTP verb OPTIONS ends with an S

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/README.stories.mdx
@@ -27,7 +27,7 @@ Here are some examples with simple `span` elements:
 
 <span class="gio-method-badge-delete">DELETE</span>
 
-<span class="gio-method-badge-option">OPTION</span>
+<span class="gio-method-badge-options">OPTIONS</span>
 
 <span class="gio-method-badge-trace">TRACE</span>
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.scss
@@ -81,7 +81,7 @@
     color: mat.get-color-from-palette(palettes.$mat-method-palette, delete-contrast);
   }
 
-  .gio-method-badge-option {
+  .gio-method-badge-options {
     @extend %gio-method-badge-base;
 
     background-color: mat.get-color-from-palette(palettes.$mat-method-palette, option);

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-method-badge/gio-method-badge.stories.ts
@@ -33,7 +33,7 @@ const classByNames = {
   Patch: 'gio-method-badge-patch',
   Put: 'gio-method-badge-put',
   Delete: 'gio-method-badge-delete',
-  Option: 'gio-method-badge-option',
+  Options: 'gio-method-badge-options',
   Trace: 'gio-method-badge-trace',
   Head: 'gio-method-badge-head',
   Connect: 'gio-method-badge-connect',


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1921

**Description**

The HTTP verb is OPTIONS so the badge mechanism tries to apply the CSS style `gio-method-badge-options` but can't find it.

See https://github.com/gravitee-io/gravitee-ui-particles/blob/main/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts#L115
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.10.0-apim-1921-fix-option-badge-4cf8db1
```
```
yarn add @gravitee/ui-particles-angular@7.10.0-apim-1921-fix-option-badge-4cf8db1
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.10.0-apim-1921-fix-option-badge-4cf8db1
```
```
yarn add @gravitee/ui-policy-studio-angular@7.10.0-apim-1921-fix-option-badge-4cf8db1
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-jpcsstibpy.chromatic.com)
<!-- Storybook placeholder end -->
