### PR TITLE
Policy studio step 8

### DIFF
--- a/ui-particles-angular/.storybook/tsconfig.json
+++ b/ui-particles-angular/.storybook/tsconfig.json
@@ -4,9 +4,10 @@
   "include": ["../projects/**/*.ts", "*.ts"],
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true
-  },
-  "paths": {
-    "@gravitee/ui-particles-angular": ["../projects/ui-particles-angular/src/public-api.ts"]
+    "skipLibCheck": true,
+    "paths": {
+      "@gravitee/ui-particles-angular": ["projects/ui-particles-angular/src/public-api.ts"],
+      "@gravitee/ui-particles-angular/testing": ["projects/ui-particles-angular/testing/public-api.ts"]
+    }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
@@ -76,7 +76,10 @@ describe('GioFormJsonSchema', () => {
       fixture.detectChanges();
       expect(testComponent.form.touched).toEqual(false);
       expect(testComponent.form.dirty).toEqual(false);
-      expect(testComponent.form.invalid).toEqual(false);
+      expect(testComponent.form.status).toEqual('PENDING'); // PENDING because json schema is not initialized
+      // Wait initialization of json schema
+      await fixture.whenStable();
+      expect(testComponent.form.invalid).toEqual(false); // Valid after initialization
 
       const simpleStringInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="simpleString"]' }));
       await simpleStringInput.setValue('What the fox say?');
@@ -106,8 +109,38 @@ describe('GioFormJsonSchema', () => {
         required: ['simpleString'],
       };
       fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.form.touched).toEqual(false);
       expect(testComponent.form.dirty).toEqual(false);
+      expect(testComponent.form.invalid).toEqual(true);
+    });
+
+    it('should switch between valid and invalid state', async () => {
+      fixture.componentInstance.jsonSchema = {
+        type: 'object',
+        properties: {
+          simpleString: {
+            title: 'Simple String',
+            description: 'Simple string without validation',
+            type: 'string',
+          },
+        },
+        required: ['simpleString'],
+      };
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(testComponent.form.touched).toEqual(false);
+      expect(testComponent.form.dirty).toEqual(false);
+      expect(testComponent.form.invalid).toEqual(true);
+
+      const simpleStringInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="simpleString"]' }));
+      await simpleStringInput.setValue('a');
+
+      expect(testComponent.form.touched).toEqual(true);
+      expect(testComponent.form.dirty).toEqual(true);
+      expect(testComponent.form.invalid).toEqual(false);
+
+      await simpleStringInput.setValue('');
       expect(testComponent.form.invalid).toEqual(true);
     });
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.harness.ts
@@ -22,6 +22,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioPolicyStudioDetailsPhaseStepHarness } from '../flow-details-phase-step/gio-ps-flow-details-phase-step.harness';
 import { GioPolicyStudioStepEditDialogHarness } from '../step-edit-dialog/gio-ps-step-edit-dialog.harness';
 import { GioPolicyStudioPoliciesCatalogDialogHarness } from '../policies-catalog-dialog/gio-ps-policies-catalog-dialog.harness';
+import { StepForm } from '../step-form/gio-ps-step-form.harness';
 
 export type PhaseType = 'REQUEST' | 'RESPONSE' | 'PUBLISH' | 'SUBSCRIBE';
 
@@ -123,8 +124,7 @@ export class GioPolicyStudioDetailsPhaseHarness extends ComponentHarness {
     index: number,
     stepConfig: {
       policyName: string;
-      description?: string;
-    },
+    } & StepForm,
   ): Promise<void> {
     await this.clickAddStep(index);
 
@@ -141,12 +141,7 @@ export class GioPolicyStudioDetailsPhaseHarness extends ComponentHarness {
    * @param index Index of the policy step to edit
    * @param stepConfig Step configuration
    */
-  public async editStep(
-    index: number,
-    stepConfig: {
-      description?: string;
-    },
-  ): Promise<void> {
+  public async editStep(index: number, stepConfig: StepForm): Promise<void> {
     const step = await this.getStep(index);
 
     await step.clickOnEdit();

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.stories.ts
@@ -32,6 +32,15 @@ import {
 @Component({
   selector: 'gio-ps-flow-execution-form-dialog-story',
   template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+  styles: [
+    `
+      :host {
+        display: block;
+        height: 100vh;
+        width: 100vh;
+      }
+    `,
+  ],
 })
 class GioPolicyStudioFlowExecutionFormDialogStoryComponent {
   @Input() public flowExecution?: FlowExecution = undefined;

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-message-form-dialog/gio-ps-flow-message-form-dialog.stories.ts
@@ -33,6 +33,15 @@ import {
 @Component({
   selector: 'gio-ps-flow-message-form-dialog-story',
   template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+  styles: [
+    `
+      :host {
+        display: block;
+        height: 100vh;
+        width: 100vh;
+      }
+    `,
+  ],
 })
 class GioPolicyStudioFlowMessageFormDialogStoryComponent {
   @Input() public flow?: FlowVM = undefined;

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.stories.ts
@@ -33,6 +33,15 @@ import {
 @Component({
   selector: 'gio-ps-flow-proxy-form-dialog-story',
   template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+  styles: [
+    `
+      :host {
+        display: block;
+        height: 100vh;
+        width: 100vh;
+      }
+    `,
+  ],
 })
 class GioPolicyStudioFlowProxyFormDialogStoryComponent {
   @Input() public flow?: FlowVM = undefined;

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.html
@@ -53,7 +53,7 @@
     <div *ngIf="selectedPolicy.description" class="policyForm__info__description">{{ selectedPolicy.description }}</div>
   </div>
 
-  <gio-ps-step-form [policy]="selectedPolicy" [(step)]="stepToAdd" (isValid)="isValid = $event"></gio-ps-step-form>
+  <gio-ps-step-form [policy]="selectedPolicy" (stepChange)="onStepChange($event)" (isValid)="onIsValid($event)"></gio-ps-step-form>
 </mat-dialog-content>
 
 <mat-dialog-actions class="actions">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
@@ -23,6 +23,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { of } from 'rxjs';
+import { MatInputHarness } from '@angular/material/input/testing';
 
 import { fakeAllPolicies } from '../../models/index-testing';
 import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
@@ -123,6 +124,11 @@ describe('GioPolicyStudioPoliciesCatalogDialogComponent', () => {
       const stepForm = await policiesCatalogDialog.getStepForm();
       await stepForm.setStepForm({
         description: 'My step description',
+        async waitForPolicyFormCompletionCb() {
+          // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+          const testPolicyConfigurationInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="test"]' }));
+          await testPolicyConfigurationInput.setValue('🦊');
+        },
       });
 
       await policiesCatalogDialog.clickAddPolicyButton();
@@ -132,6 +138,9 @@ describe('GioPolicyStudioPoliciesCatalogDialogComponent', () => {
         name: 'Policy to test UI',
         policy: 'test-policy',
         description: 'My step description',
+        configuration: {
+          test: '🦊',
+        },
       });
     });
   });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
@@ -66,6 +66,14 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent {
     this.selectedPolicy = policy;
   }
 
+  public onStepChange(step: Step) {
+    this.stepToAdd = step;
+  }
+
+  public onIsValid(isValid: boolean) {
+    this.isValid = isValid;
+  }
+
   public onAddPolicy() {
     this.dialogRef.close({
       ...this.stepToAdd,

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.stories.ts
@@ -36,6 +36,15 @@ import {
 @Component({
   selector: 'gio-ps-flow-proxy-form-dialog-story',
   template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+  styles: [
+    `
+      :host {
+        display: block;
+        height: 100vh;
+        width: 100vh;
+      }
+    `,
+  ],
 })
 class GioPolicyStudioPoliciesCatalogDialogStoryComponent {
   @Input()

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.spec.ts
@@ -23,6 +23,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { of } from 'rxjs';
+import { MatInputHarness } from '@angular/material/input/testing';
 
 import { fakeTestPolicyStep, fakeTestPolicy } from '../../models/index-testing';
 import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
@@ -112,11 +113,15 @@ describe('GioPolicyStudioStepEditDialogComponent', () => {
     expect(await stepForm.getStepFormValue()).toEqual({
       description: 'Test Policy description',
     });
+    // Check policy configuration
+    const testPolicyConfigurationInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="test"]' }));
+    expect(await testPolicyConfigurationInput.getValue()).toEqual('test');
 
     // Edit form values
     await stepForm.setStepForm({
       description: 'Edited description',
     });
+    await testPolicyConfigurationInput.setValue('edited');
 
     // Save
     await policyFormDialog.save();
@@ -125,6 +130,9 @@ describe('GioPolicyStudioStepEditDialogComponent', () => {
     expect(component.dialogResult).toEqual(
       fakeTestPolicyStep({
         description: 'Edited description',
+        configuration: {
+          test: 'edited',
+        },
       }),
     );
   });

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.stories.ts
@@ -36,6 +36,15 @@ import {
 @Component({
   selector: 'gio-ps-flow-proxy-form-dialog-story',
   template: `<button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+  styles: [
+    `
+      :host {
+        display: block;
+        height: 100vh;
+        width: 100vh;
+      }
+    `,
+  ],
 })
 class GioPolicyStudioStepEditDialogStoryComponent {
   @Input()
@@ -95,7 +104,7 @@ export default {
     },
   }),
   parameters: {
-    chromatic: { delay: 2000 },
+    chromatic: { delay: 1000 },
   },
 } as Meta;
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.html
@@ -19,17 +19,17 @@
 <div class="settings">
   <div class="settings__header">Settings</div>
 
-  <div *ngIf="stepForm" class="settings__content" [formGroup]="stepForm">
-    <mat-form-field>
-      <mat-label>Description</mat-label>
-      <input matInput formControlName="description" cdkFocusInitial />
-      <mat-hint>Describe how your policy works.</mat-hint>
-    </mat-form-field>
+  <ng-container *ngIf="policySchema$ | async as policySchema">
+    <div *ngIf="stepForm" class="settings__content" [formGroup]="stepForm">
+      <mat-form-field>
+        <mat-label>Description</mat-label>
+        <input matInput formControlName="description" cdkFocusInitial />
+        <mat-hint>Describe how your policy works.</mat-hint>
+      </mat-form-field>
 
-    <ng-container *ngIf="policySchema$">
-      {{ $any(policySchema$) | async | json }}
-    </ng-container>
-  </div>
+      <gio-form-json-schema [jsonSchema]="$any(policySchema)" formControlName="configuration"></gio-form-json-schema>
+    </div>
+  </ng-container>
 </div>
 
 <div class="documentation">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.harness.ts
@@ -14,18 +14,26 @@
  * limitations under the License.
  */
 
-import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentHarness, LocatorFactory } from '@angular/cdk/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 
+export type StepForm = {
+  description?: string;
+  // Callback to allow to fill the fields of the jsonSchemaForm specific to each policy, if necessary. Useful if some are required.
+  waitForPolicyFormCompletionCb?: (locator: LocatorFactory) => Promise<void>;
+};
 export class GioPolicyStudioStepFormHarness extends ComponentHarness {
   public static hostSelector = 'gio-ps-step-form';
 
   private getDescriptionInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="description"]' }));
 
-  public async setStepForm(stepForm: { description?: string }): Promise<void> {
+  public async setStepForm(stepForm: StepForm): Promise<void> {
     if (stepForm.description) {
       const descriptionInput = await this.getDescriptionInput();
       await descriptionInput.setValue(stepForm.description);
+    }
+    if (stepForm.waitForPolicyFormCompletionCb) {
+      await stepForm.waitForPolicyFormCompletionCb(this.locatorFactory);
     }
   }
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.module.ts
@@ -15,7 +15,13 @@
  */
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { GioBannerModule, GioFormSlideToggleModule, GioFormTagsInputModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import {
+  GioBannerModule,
+  GioFormJsonSchemaModule,
+  GioFormSlideToggleModule,
+  GioFormTagsInputModule,
+  GioIconsModule,
+} from '@gravitee/ui-particles-angular';
 import { CommonModule } from '@angular/common';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -76,6 +82,7 @@ import { GioPolicyStudioService } from './gio-policy-studio.service';
     GioFormSlideToggleModule,
     GioFormTagsInputModule,
     GioBannerModule,
+    GioFormJsonSchemaModule,
   ],
   exports: [GioPolicyStudioComponent],
   providers: [GioPolicyStudioService],

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -23,6 +23,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { of } from 'rxjs';
+import { MatInputHarness } from '@angular/material/input/testing';
 
 import {
   fakeAllPolicies,
@@ -637,10 +638,20 @@ describe('GioPolicyStudioModule', () => {
         await requestPhase?.addStep(0, {
           policyName: fakeTestPolicy().name,
           description: 'A',
+          async waitForPolicyFormCompletionCb(locator) {
+            // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+            const testPolicyConfigurationInput = await locator.locatorFor(MatInputHarness.with({ selector: '[id*="test"]' }))();
+            await testPolicyConfigurationInput.setValue('🦊');
+          },
         });
         await requestPhase?.addStep(2, {
           policyName: fakeTestPolicy().name,
           description: 'C',
+          async waitForPolicyFormCompletionCb(locator) {
+            // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+            const testPolicyConfigurationInput = await locator.locatorFor(MatInputHarness.with({ selector: '[id*="test"]' }))();
+            await testPolicyConfigurationInput.setValue('🦊');
+          },
         });
 
         // Add step A into undefined SUBSCRIBE phase
@@ -648,6 +659,11 @@ describe('GioPolicyStudioModule', () => {
         await subscribePhase?.addStep(0, {
           policyName: fakeTestPolicy().name,
           description: 'A',
+          async waitForPolicyFormCompletionCb(locator) {
+            // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+            const testPolicyConfigurationInput = await locator.locatorFor(MatInputHarness.with({ selector: '[id*="test"]' }))();
+            await testPolicyConfigurationInput.setValue('🦊');
+          },
         });
 
         // Save
@@ -659,12 +675,12 @@ describe('GioPolicyStudioModule', () => {
         const commonFlow = saveOutputToExpect?.commonFlows?.[0];
         expect(commonFlow).toBeDefined();
         expect(commonFlow?.request).toEqual([
-          fakeTestPolicyStep({ description: 'A' }),
+          fakeTestPolicyStep({ description: 'A', configuration: { test: '🦊' } }),
           fakeTestPolicyStep({ description: 'B' }),
-          fakeTestPolicyStep({ description: 'C' }),
+          fakeTestPolicyStep({ description: 'C', configuration: { test: '🦊' } }),
         ]);
 
-        expect(commonFlow?.subscribe).toEqual([fakeTestPolicyStep({ description: 'A' })]);
+        expect(commonFlow?.subscribe).toEqual([fakeTestPolicyStep({ description: 'A', configuration: { test: '🦊' } })]);
       });
 
       it('should edit step into phase', async () => {
@@ -971,10 +987,20 @@ describe('GioPolicyStudioModule', () => {
         await requestPhase?.addStep(0, {
           policyName: fakeTestPolicy().name,
           description: 'A',
+          async waitForPolicyFormCompletionCb(locator) {
+            // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+            const testPolicyConfigurationInput = await locator.locatorFor(MatInputHarness.with({ selector: '[id*="test"]' }))();
+            await testPolicyConfigurationInput.setValue('🦊');
+          },
         });
         await requestPhase?.addStep(2, {
           policyName: fakeTestPolicy().name,
           description: 'C',
+          async waitForPolicyFormCompletionCb(locator) {
+            // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+            const testPolicyConfigurationInput = await locator.locatorFor(MatInputHarness.with({ selector: '[id*="test"]' }))();
+            await testPolicyConfigurationInput.setValue('🦊');
+          },
         });
 
         // Add step A before B into RESPONSE phase
@@ -982,6 +1008,11 @@ describe('GioPolicyStudioModule', () => {
         await responsePhase?.addStep(0, {
           policyName: fakeTestPolicy().name,
           description: 'A',
+          async waitForPolicyFormCompletionCb(locator) {
+            // "Policy to test UI" have required configuration fields. We need to fill them to be able to add the step.
+            const testPolicyConfigurationInput = await locator.locatorFor(MatInputHarness.with({ selector: '[id*="test"]' }))();
+            await testPolicyConfigurationInput.setValue('🦊');
+          },
         });
 
         // Save
@@ -993,12 +1024,15 @@ describe('GioPolicyStudioModule', () => {
         const commonFlow = saveOutputToExpect?.commonFlows?.[0];
         expect(commonFlow).toBeDefined();
         expect(commonFlow?.request).toEqual([
-          fakeTestPolicyStep({ description: 'A' }),
+          fakeTestPolicyStep({ description: 'A', configuration: { test: '🦊' } }),
           fakeTestPolicyStep({ description: 'B' }),
-          fakeTestPolicyStep({ description: 'C' }),
+          fakeTestPolicyStep({ description: 'C', configuration: { test: '🦊' } }),
         ]);
 
-        expect(commonFlow?.response).toEqual([fakeTestPolicyStep({ description: 'A' }), fakeTestPolicyStep({ description: 'B' })]);
+        expect(commonFlow?.response).toEqual([
+          fakeTestPolicyStep({ description: 'A', configuration: { test: '🦊' } }),
+          fakeTestPolicyStep({ description: 'B' }),
+        ]);
       });
 
       it('should edit step into phase', async () => {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -340,8 +340,6 @@ describe('GioPolicyStudioModule', () => {
         const detailsHarness = await loader.getHarness(GioPolicyStudioDetailsHarness);
 
         // Edit first selected flow
-        await detailsHarness.clickEditFlowBtn();
-
         await policyStudioHarness.editFlowConfig(
           'Foo flow 1',
           fakeChannelFlow({
@@ -922,7 +920,6 @@ describe('GioPolicyStudioModule', () => {
         const detailsHarness = await loader.getHarness(GioPolicyStudioDetailsHarness);
 
         // Edit first selected flow
-
         await policyStudioHarness.editFlowConfig('Foo flow 1', fakeHttpFlow({ name: 'Edited flow name' }));
 
         let saveOutputToExpect: SaveOutput | undefined;

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/Step.fixture.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/Step.fixture.ts
@@ -15,7 +15,7 @@
  */
 import { isFunction } from 'lodash';
 
-import { fakeTestPolicy } from '../index-testing';
+import { fakeTestPolicy } from '../policy/Policy.fixture';
 
 import { Step } from './Step';
 
@@ -25,6 +25,9 @@ export function fakeTestPolicyStep(modifier?: Partial<Step> | ((base: Step) => S
     description: 'Test Policy description',
     enabled: true,
     policy: 'test-policy',
+    configuration: {
+      test: 'test',
+    },
   };
 
   if (isFunction(modifier)) {


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-1554

**Description**

- Improve chromatic usage
- fix storybook configuration
- add policy configuration form when editing/ adding policy into flow phase

![image](https://github.com/gravitee-io/gravitee-ui-particles/assets/4974420/460ba844-12a8-483a-af34-8192b84c20ea)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.14.0-policy-studio-step-8-b0320ce
```
```
yarn add @gravitee/ui-policy-studio-angular@7.14.0-policy-studio-step-8-b0320ce
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.14.0-policy-studio-step-8-b0320ce
```
```
yarn add @gravitee/ui-particles-angular@7.14.0-policy-studio-step-8-b0320ce
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-kedleqtllo.chromatic.com)
<!-- Storybook placeholder end -->
