### PR TITLE
feat: update gio-table-light style

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-table-light/gio-table-light.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/component/gio-table-light/gio-table-light.scss
@@ -24,15 +24,15 @@ $typography: map.get(theme.$mat-theme, typography);
 
 @mixin theme() {
   table.gio-table-light {
-    border-collapse: collapse;
+    border: 1px solid map.get(palettes.$mat-dove-palette, darker10);
+    border-radius: 4px;
+    border-collapse: inherit;
     border-spacing: 0;
 
     th,
     td {
       padding: 8px;
-
-      // FIXME: add color to palette ? replace/keep ?
-      border: 1px solid #e6e7e8;
+      border-bottom: 1px solid map.get(palettes.$mat-dove-palette, darker10);
     }
 
     thead {
@@ -47,6 +47,10 @@ $typography: map.get(theme.$mat-theme, typography);
       @include mat.typography-level($typography, 'body-1');
 
       background-color: mat.get-color-from-palette(palettes.$mat-basic-palette, white);
+
+      & > tr:last-child > td {
+        border-bottom: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1415

**Description**

Update `.gio-table-light` style to avoid to copy paste it everywhere

<img width="443" alt="Screenshot 2023-06-19 at 16 58 49" src="https://github.com/gravitee-io/gravitee-ui-particles/assets/25704259/8d2d7925-81d4-442e-9af3-ea1980054235">

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.15.0-apim-1415-table-style-c615123
```
```
yarn add @gravitee/ui-policy-studio-angular@7.15.0-apim-1415-table-style-c615123
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.15.0-apim-1415-table-style-c615123
```
```
yarn add @gravitee/ui-particles-angular@7.15.0-apim-1415-table-style-c615123
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xesxuzvpub.chromatic.com)
<!-- Storybook placeholder end -->
