### PR TITLE
fix(json-schema): move stateChanges subscribe into ngAfterViewInit

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
@@ -76,9 +76,8 @@ describe('GioFormJsonSchema', () => {
       fixture.detectChanges();
       expect(testComponent.form.touched).toEqual(false);
       expect(testComponent.form.dirty).toEqual(false);
-      expect(testComponent.form.status).toEqual('PENDING'); // PENDING because json schema is not initialized
-      // Wait initialization of json schema
-      await fixture.whenStable();
+      expect(testComponent.form.valid).toEqual(true);
+      expect(testComponent.form.status).toEqual('VALID');
       expect(testComponent.form.invalid).toEqual(false); // Valid after initialization
 
       const simpleStringInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="simpleString"]' }));
@@ -128,9 +127,9 @@ describe('GioFormJsonSchema', () => {
         required: ['simpleString'],
       };
       fixture.detectChanges();
-      await fixture.whenStable();
       expect(testComponent.form.touched).toEqual(false);
       expect(testComponent.form.dirty).toEqual(false);
+      expect(testComponent.form.status).toEqual('INVALID');
       expect(testComponent.form.invalid).toEqual(true);
 
       const simpleStringInput = await loader.getHarness(MatInputHarness.with({ selector: '[id*="simpleString"]' }));


### PR DESCRIPTION
**Issue**
n/a

**Description**

Try to fix and stabilise this component .. btw apim console & test & policy studio 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.16.1-fix-ps-6a2ed04
```
```
yarn add @gravitee/ui-particles-angular@7.16.1-fix-ps-6a2ed04
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.16.1-fix-ps-6a2ed04
```
```
yarn add @gravitee/ui-policy-studio-angular@7.16.1-fix-ps-6a2ed04
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-dufbzcbwds.chromatic.com)
<!-- Storybook placeholder end -->
