### PR TITLE
feat: add mat-icon-right class for right icon in btn

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.scss
@@ -42,6 +42,11 @@
       margin-right: 8px;
       line-height: 18px;
     }
+
+    .mat-icon.mat-icon-right {
+      margin-right: 0;
+      margin-left: 8px;
+    }
   }
 
   .mat-icon-button {
@@ -59,6 +64,7 @@
       width: 18px;
       height: 18px;
       margin-right: 0;
+      margin-left: 0;
       line-height: 18px;
     }
   }

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-button.stories.ts
@@ -54,9 +54,9 @@ export const MatButton: Story = {
                     <button mat-flat-button color="primary" class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
                 </div>
                 <div class="button-container">
-                    <button mat-flat-button color="primary" class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-flat-button color="primary" class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-flat-button color="primary" class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="large">Large button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="medium">Medium button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-flat-button color="primary" class="small">Small button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
                 </div>
             </div>
             <div>
@@ -78,9 +78,9 @@ export const MatButton: Story = {
                     <button mat-stroked-button class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
                 </div>
                 <div class="button-container">
-                    <button mat-stroked-button class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-stroked-button class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-stroked-button class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-stroked-button class="large">Large button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-stroked-button class="medium">Medium button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-stroked-button class="small">Small button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
                 </div>
             </div>
             <div>
@@ -102,9 +102,9 @@ export const MatButton: Story = {
                     <button mat-button class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
                 </div>
                 <div class="button-container">
-                    <button mat-button class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-button class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-button class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-button class="large">Large button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-button class="medium">Medium button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-button class="small">Small button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
                 </div>
             </div>
             <div>
@@ -126,9 +126,9 @@ export const MatButton: Story = {
                     <button mat-flat-button color="accent" class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
                 </div>
                 <div class="button-container">
-                    <button mat-flat-button color="accent" class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-flat-button color="accent" class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-flat-button color="accent" class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="large">Large button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="medium">Medium button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-flat-button color="accent" class="small">Small button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
                 </div>
             </div>
             <div>
@@ -150,9 +150,9 @@ export const MatButton: Story = {
                     <button mat-flat-button color="warn" class="small"><mat-icon svgIcon="gio:star-outline"></mat-icon>Small button</button>
                 </div>
                 <div class="button-container">
-                    <button mat-flat-button color="warn" class="large">Large button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-flat-button color="warn" class="medium">Medium button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
-                    <button mat-flat-button color="warn" class="small">Small button<mat-icon svgIcon="gio:star-outline"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="large">Large button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="medium">Medium button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
+                    <button mat-flat-button color="warn" class="small">Small button<mat-icon svgIcon="gio:star-outline" class="mat-icon-right"></mat-icon></button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-1938

![Capture d’écran 2023-06-26 à 17 58 29](https://github.com/gravitee-io/gravitee-ui-particles/assets/1457497/147cdd84-5224-4699-8d40-a488f989803c)
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.21.1-improve-btn-e5ff837
```
```
yarn add @gravitee/ui-particles-angular@7.21.1-improve-btn-e5ff837
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.21.1-improve-btn-e5ff837
```
```
yarn add @gravitee/ui-policy-studio-angular@7.21.1-improve-btn-e5ff837
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-tjcnbytvhf.chromatic.com)
<!-- Storybook placeholder end -->
