### PR TITLE
fix: check disabled state of array fields after adding an item

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.html
@@ -27,19 +27,7 @@
 
     <mat-card class="json-schema-story__preview" [class.isChromatic]="isChromatic">
       <form *ngIf="form; else loading" (ngSubmit)="onSubmit()" [formGroup]="form" gioFormFocusInvalid>
-        <div class="json-schema-story__header">
-          <mat-card-title>UI Preview</mat-card-title>
-          <gio-form-slide-toggle *ngIf="withToggle">
-            <gio-form-label>Disable form</gio-form-label>
-            <mat-slide-toggle
-              gioFormSlideToggle
-              aria-label="Disable form"
-              (change)="toggleDisabledProperty($event.checked)"
-              [checked]="disabled"
-            ></mat-slide-toggle>
-          </gio-form-slide-toggle>
-        </div>
-
+        <mat-card-title>UI Preview</mat-card-title>
         <mat-card-content>
           <gio-form-json-schema [jsonSchema]="jsonSchema" [options]="options" formControlName="schemaValue"></gio-form-json-schema>
         </mat-card-content>
@@ -47,6 +35,9 @@
         <mat-card-actions align="end">
           <pre>{{ form.status }} | {{ form.dirty ? 'DIRTY' : 'PRISTINE' }} | {{ form.touched ? 'TOUCHED' : 'UNTOUCHED' }}</pre>
 
+          <mat-slide-toggle aria-label="Disable form" (change)="toggleDisabledProperty($event.checked)" [checked]="disabled"
+            >Disable form</mat-slide-toggle
+          >
           <button mat-button type="reset" [disabled]="disabled">Reset</button>
           <button mat-stroked-button type="submit" [disabled]="disabled">Submit</button>
         </mat-card-actions>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.component.scss
@@ -78,15 +78,8 @@
     }
   }
 
-  &__header {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-
-    gio-form-slide-toggle {
-      margin: 8px 0;
-    }
+  .mat-slide-toggle {
+    margin-left: 16px;
   }
 }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
@@ -26,7 +26,6 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { GioMonacoEditorModule } from '../gio-monaco-editor/gio-monaco-editor.module';
@@ -66,7 +65,6 @@ import { codeEditorExample } from './json-schema-example/code-editor';
     MatButtonModule,
     MatButtonToggleModule,
     GioFormJsonSchemaModule,
-    GioFormSlideToggleModule,
     GioMonacoEditorModule.forRoot({ theme: 'vs-dark' }),
   ],
   exports: [DemoComponent, GioFormJsonSchemaModule],
@@ -86,15 +84,14 @@ export default {
       disable: true,
     },
   },
-  render: ({ jsonSchema, initialValue, disabled, withToggle }) => ({
+  render: ({ jsonSchema, initialValue, disabled }) => ({
     template: `<gio-demo 
                     [jsonSchema]="jsonSchema" 
                     [initialValue]="initialValue"
                     [isChromatic]="isChromatic()" 
                     [disabled]="disabled"
-                    [withToggle]="withToggle"
                 ></gio-demo>`,
-    props: { jsonSchema, initialValue, isChromatic, disabled, withToggle },
+    props: { jsonSchema, initialValue, isChromatic, disabled },
   }),
 } as Meta;
 
@@ -213,15 +210,6 @@ export const kafkaAdvanced: Story = {
   name: 'Kafka Advanced',
   args: {
     jsonSchema: kafkaAdvancedExample,
-  },
-};
-
-export const kafkaAdvancedWithDisableToggle: Story = {
-  name: 'Kafka Advanced Disabled With Disable Toggle',
-  args: {
-    jsonSchema: kafkaAdvancedExample,
-    withToggle: true,
-    disabled: true,
   },
 };
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/array-type.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/array-type.component.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component } from '@angular/core';
 import { FieldArrayType } from '@ngx-formly/core';
+import { Subject } from 'rxjs';
+import { FormlyValueChangeEvent } from '@ngx-formly/core/lib/models';
 
 @Component({
   selector: 'gio-fjs-array-type',
@@ -38,7 +40,7 @@ import { FieldArrayType } from '@ngx-formly/core';
 
       <div [hidden]="collapse" class="wrapper__rows" [class.collapse-open]="collapse" [class.collapse-close]="!collapse">
         <div *ngFor="let field of field.fieldGroup; let i = index" class="wrapper__rows__row">
-          <formly-field class="wrapper__rows__row__field" [field]="field"></formly-field>
+          <formly-field class="wrapper__rows__row__field" [field]="field" (focusin)="onFocusIn()"></formly-field>
           <div class="wrapper__rows__row__remove">
             <button type="button" mat-icon-button aria-label="Remove" [disabled]="this.form?.disabled ?? false" (click)="remove(i)">
               <mat-icon svgIcon="gio:cancel"></mat-icon>
@@ -56,6 +58,41 @@ import { FieldArrayType } from '@ngx-formly/core';
   `,
   styleUrls: ['./array-type.component.scss'],
 })
-export class GioFjsArrayTypeComponent extends FieldArrayType {
+export class GioFjsArrayTypeComponent extends FieldArrayType implements AfterViewChecked {
   public collapse = false;
+
+  constructor(private readonly cdr: ChangeDetectorRef) {
+    super();
+  }
+
+  /**
+   * This method is here to ensure that all fields of the array are disabled or enabled when the form is disabled or enabled.
+   */
+  public ngAfterViewChecked(): void {
+    this.field.props.disabled = this.form.disabled;
+    this.field.fieldGroup?.forEach(f => {
+      if (f && f.props) f.props.disabled = this.form.disabled;
+    });
+    this.cdr.detectChanges();
+  }
+
+  /**
+   * This method fix an issue with the fieldChanges Subject which can be undefined when we enable or disable the form.
+   */
+  public onFocusIn() {
+    if (this.field && this.field.options && this.field.options.fieldChanges === undefined) {
+      this.field.options.fieldChanges = new Subject<FormlyValueChangeEvent>();
+    }
+  }
+
+  /**
+   * This method fix an issue with the fieldChanges Subject which can be undefined when we enable or disable the form
+   * and then try to add a new field.
+   */
+  public add() {
+    if (this.field && this.field.options && this.field.options.fieldChanges === undefined) {
+      this.field.options.fieldChanges = new Subject<FormlyValueChangeEvent>();
+    }
+    super.add();
+  }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1416

**Description**

When a user enable / disable the form fields, using a toggle for example, we don't want to have observable errors in the logs ( see https://github.com/gravitee-io/gravitee-ui-particles/pull/267#pullrequestreview-1500114670 )
Here is a fix to ensure it not happens and that the added fields are consistent with the global state of the form.


https://github.com/gravitee-io/gravitee-ui-particles/assets/25704259/4f27f7a2-8c79-42bb-99f5-66f9530a6537


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.22.1-apim-1416-enable-disable-form-70f7ec2
```
```
yarn add @gravitee/ui-policy-studio-angular@7.22.1-apim-1416-enable-disable-form-70f7ec2
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.22.1-apim-1416-enable-disable-form-70f7ec2
```
```
yarn add @gravitee/ui-particles-angular@7.22.1-apim-1416-enable-disable-form-70f7ec2
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-odfkumlmun.chromatic.com)
<!-- Storybook placeholder end -->
