### PR TITLE
chore: change help text for response phase

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -51,7 +51,7 @@
           <gio-ps-flow-details-phase
             class="content__phase"
             name="Response phase"
-            description="Policies will be applied during the connection termination"
+            description="Policies will be applied to the response from the initial connection"
             [startConnector]="endpointsInfo"
             [endConnector]="messageFlowEntrypointsInfo"
             [steps]="flow.response ?? []"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-2097

**Description**

For the response phase for messages APIs, it is actually sent back as the response to the initial request. So we should change the text to:

`Policies will be applied to the response from the initial connection`
