### PR TITLE
feat: improve json-schema GioUiTypeConfig to allow to pass props

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-clipboard/gio-clipboard.base.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-clipboard/gio-clipboard.base.component.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable, Input } from '@angular/core';
+import { Directive, Input } from '@angular/core';
 import { MatTooltip } from '@angular/material/tooltip';
 
-@Injectable()
+@Directive()
 export abstract class GioClipboardComponent {
   public tooltipMessage = 'Copy to clipboard';
   public tooltipHideDelay = 0;

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
@@ -44,7 +44,10 @@ export class GioFormlyJsonSchemaService {
       mappedField = {
         key: mappedField.key,
         type: mapSource.gioConfig?.uiType,
-        props: mappedField.props,
+        props: {
+          ...mappedField.props,
+          ...mapSource.gioConfig?.uiTypeProps,
+        },
       };
     }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/model/GioJsonSchema.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/model/GioJsonSchema.ts
@@ -18,9 +18,8 @@
  * GioConfig is used to add some custom configuration to the JSONSchema7
  * ⚠️ Keep updated with the GioJsonSchema.json to have the same interface ⚠️
  */
-export interface GioConfig {
+export interface GioConfig extends GioUiTypeConfig {
   banner?: GioBannerConfig;
-  uiType?: GioUiTypeConfig;
   monacoEditorConfig?: GioMonacoEditorConfig;
 }
 
@@ -35,7 +34,10 @@ type GioBannerConfig =
 /**
  * Used to override the default formly type. It's useful when we want to use a custom component.
  */
-type GioUiTypeConfig = 'gio-headers-array' | string;
+type GioUiTypeConfig = {
+  uiType?: 'gio-headers-array' | string;
+  uiTypeProps?: Record<string, unknown>;
+};
 
 /**
  * Override the JSONSchema7 interface to add gioConfig


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2088

**Description**

Improve json-schema GioUiTypeConfig to allow to pass props

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.24.2-json-schema-fd74fb5
```
```
yarn add @gravitee/ui-particles-angular@7.24.2-json-schema-fd74fb5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.24.2-json-schema-fd74fb5
```
```
yarn add @gravitee/ui-policy-studio-angular@7.24.2-json-schema-fd74fb5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vujitujpfc.chromatic.com)
<!-- Storybook placeholder end -->
