### PR TITLE
fix: improve mapping of header values in gio-form-headers

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-headers/README.stories.mdx
@@ -15,7 +15,7 @@ Key autocomplete is provided for common headers.
 
 **Inputs**
 - Work with ReactiveFormsModule
-- `adaptOutputFn` (optional): A function to adapt the output of the component to the desired format. e.g. `(headers) => headers.map(({ key, value }) => ({ name: key, value }))`
+- `headerFieldMapper` (optional): A mapping definition for the default key/value attributes in order to adapt the output of the component to the desired format. e.g. `{keyName: 'name', valueName: 'value'}`
 
 **Output**
 
@@ -31,4 +31,18 @@ Example:
 
 ```html
 <gio-form-headers [formControl]="headersControl"></gio-form-headers>
+```
+
+To get an array of objects with `name` and `value` properties, you need to define the `headerFieldMapper`:
+```ts
+{
+  name: string;
+  value: string;
+}[]
+```
+
+Example:
+
+```html
+<gio-form-headers [headerFieldMapper]="{keyName: 'name', valueName: 'value'}" [formControl]="headersControl"></gio-form-headers>
 ```

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/headers-type.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/headers-type.component.ts
@@ -16,7 +16,7 @@
 import { Component } from '@angular/core';
 import { FieldType, FieldTypeConfig, FormlyFieldProps } from '@ngx-formly/core';
 
-import { FormHeaderAdaptOutputFn, Header } from '../../gio-form-headers/gio-form-headers.component';
+import { FormHeaderFieldMapper } from '../../gio-form-headers/gio-form-headers.component';
 
 type HeadersProps = FormlyFieldProps & {
   // The key and value names of the output array
@@ -48,7 +48,7 @@ type HeadersProps = FormlyFieldProps & {
         <formly-validation-message [field]="field"></formly-validation-message>
       </div>
       <div *ngIf="!collapse" class="wrapper__rows" [class.collapse-open]="collapse" [class.collapse-close]="!collapse">
-        <gio-form-headers [adaptOutputFn]="map" [formControl]="formControl"></gio-form-headers>
+        <gio-form-headers [headerFieldMapper]="outputConfig" [formControl]="formControl"></gio-form-headers>
       </div>
     </div>
   `,
@@ -57,22 +57,16 @@ type HeadersProps = FormlyFieldProps & {
 export class GioFjsHeadersTypeComponent extends FieldType<FieldTypeConfig<HeadersProps>> {
   public override defaultOptions?: Partial<FieldTypeConfig<HeadersProps>> | undefined = {
     props: {
-      outputConfig: {
-        keyName: 'name',
-        valueName: 'value',
-      },
+      outputConfig: this.outputConfig,
     },
   };
 
   public collapse = false;
 
-  public get map(): FormHeaderAdaptOutputFn<{ [x: string]: string }[]> {
-    return (headers: Header[] | null) =>
-      [...(headers ?? [])].map(header => {
-        return {
-          [this.props.outputConfig.keyName]: header.key,
-          [this.props.outputConfig.valueName]: header.value,
-        };
-      });
+  public get outputConfig(): FormHeaderFieldMapper {
+    return {
+      keyName: 'name',
+      valueName: 'value',
+    };
   }
 }


### PR DESCRIPTION
fix APIM-2134

**Description**

before this gio-form-headers convert the key attribute of header object to name attribute but when the data using "name" attribute is injected, the key field wasn't updated propertly.
This fix apply a bidirectionnal mapping.

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.24.2-apim-2134-6142ef5
```
```
yarn add @gravitee/ui-particles-angular@7.24.2-apim-2134-6142ef5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.24.2-apim-2134-6142ef5
```
```
yarn add @gravitee/ui-policy-studio-angular@7.24.2-apim-2134-6142ef5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-waidrywixq.chromatic.com)
<!-- Storybook placeholder end -->
