### PR TITLE
feat: display cta banner when an un-deployed policy is selected

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.html
@@ -23,12 +23,17 @@
   [class.success]="type === 'success'"
 >
   <div class="banner__wrapper">
-    <div class="banner__wrapper__icon" [ngSwitch]="type">
-      <mat-icon *ngSwitchCase="'info'" svgIcon="gio:chat-lines"></mat-icon>
-      <mat-icon *ngSwitchCase="'error'" svgIcon="gio:chat-bubble-error"></mat-icon>
-      <mat-icon *ngSwitchCase="'warning'" svgIcon="gio:chat-bubble-warning"></mat-icon>
-      <mat-icon *ngSwitchCase="'success'" svgIcon="gio:chat-bubble-check"></mat-icon>
+    <div *ngIf="icon; else defaultTypeIcon" class="banner__wrapper__icon">
+      <mat-icon [svgIcon]="icon"></mat-icon>
     </div>
+    <ng-template #defaultTypeIcon>
+      <div class="banner__wrapper__icon" [ngSwitch]="type">
+        <mat-icon *ngSwitchCase="'info'" svgIcon="gio:chat-lines"></mat-icon>
+        <mat-icon *ngSwitchCase="'error'" svgIcon="gio:chat-bubble-error"></mat-icon>
+        <mat-icon *ngSwitchCase="'warning'" svgIcon="gio:chat-bubble-warning"></mat-icon>
+        <mat-icon *ngSwitchCase="'success'" svgIcon="gio:chat-bubble-check"></mat-icon>
+      </div>
+    </ng-template>
     <div class="banner__wrapper__head">
       <div class="banner__wrapper__title">
         <ng-content></ng-content>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.component.ts
@@ -25,6 +25,9 @@ export type GioBannerTypes = 'error' | 'info' | 'success' | 'warning';
 export class GioBannerComponent {
   @Input()
   public type: GioBannerTypes = 'info';
+
+  @Input()
+  public icon?: string;
 }
 
 @Directive({
@@ -44,6 +47,7 @@ export class GioBannerActionDirective {}
 })
 export class GioBannerErrorComponent extends GioBannerComponent {
   public type = 'error' as GioBannerTypes;
+  public icon = 'gio:chat-bubble-error';
 }
 
 @Component({
@@ -53,6 +57,7 @@ export class GioBannerErrorComponent extends GioBannerComponent {
 })
 export class GioBannerInfoComponent extends GioBannerComponent {
   public type = 'info' as GioBannerTypes;
+  public icon = 'gio:chat-lines';
 }
 
 @Component({
@@ -62,6 +67,7 @@ export class GioBannerInfoComponent extends GioBannerComponent {
 })
 export class GioBannerSuccessComponent extends GioBannerComponent {
   public type = 'success' as GioBannerTypes;
+  public icon = 'gio:chat-bubble-check';
 }
 
 @Component({
@@ -71,4 +77,5 @@ export class GioBannerSuccessComponent extends GioBannerComponent {
 })
 export class GioBannerWarningComponent extends GioBannerComponent {
   public type = 'warning' as GioBannerTypes;
+  public icon = 'gio:chat-bubble-warning';
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.stories.ts
@@ -51,6 +51,8 @@ export const All: Story = {
     <gio-banner-warning>This is a warning banner!</gio-banner-warning>
     <br>
     <gio-banner-error>Error <br> Second line <br> Wow another one</gio-banner-error>
+    <gio-banner type="error">This an error type banner with the default icon</gio-banner>
+    <gio-banner type="error" icon="gio:universe">This an error banner with a custom icon</gio-banner>
     `,
   }),
 };

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.ts
@@ -69,6 +69,9 @@ export class GioPolicyStudioDetailsPhaseComponent implements OnChanges {
   @Input()
   public policyExecutionPhase!: ExecutionPhase;
 
+  @Input()
+  public trialUrl?: string;
+
   @Output()
   public stepsChange = new EventEmitter<Step[]>();
 
@@ -120,6 +123,7 @@ export class GioPolicyStudioDetailsPhaseComponent implements OnChanges {
           policies: this.policies,
           executionPhase: this.policyExecutionPhase,
           apiType: this.apiType,
+          trialUrl: this.trialUrl,
         },
         role: 'alertdialog',
         id: 'gioPolicyStudioPoliciesCatalogDialog',

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -45,6 +45,7 @@
             [steps]="flow.request ?? []"
             [apiType]="apiType"
             [policies]="policies"
+            [trialUrl]="trialUrl"
             policyExecutionPhase="REQUEST"
             (stepsChange)="onStepsChange('request', $event)"
           ></gio-ps-flow-details-phase>
@@ -57,6 +58,7 @@
             [steps]="flow.response ?? []"
             [apiType]="apiType"
             [policies]="policies"
+            [trialUrl]="trialUrl"
             policyExecutionPhase="RESPONSE"
             (stepsChange)="onStepsChange('response', $event)"
           ></gio-ps-flow-details-phase>
@@ -71,6 +73,7 @@
             [steps]="flow.publish ?? []"
             [apiType]="apiType"
             [policies]="policies"
+            [trialUrl]="trialUrl"
             policyExecutionPhase="MESSAGE_RESPONSE"
             (stepsChange)="onStepsChange('publish', $event)"
           ></gio-ps-flow-details-phase>
@@ -83,6 +86,7 @@
             [steps]="flow.subscribe ?? []"
             [apiType]="apiType"
             [policies]="policies"
+            [trialUrl]="trialUrl"
             policyExecutionPhase="MESSAGE_REQUEST"
             (stepsChange)="onStepsChange('subscribe', $event)"
           ></gio-ps-flow-details-phase>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -55,6 +55,9 @@ export class GioPolicyStudioDetailsComponent implements OnChanges {
   @Input()
   public policies: Policy[] = [];
 
+  @Input()
+  public trialUrl?: string;
+
   @Output()
   public flowChange = new EventEmitter<FlowVM>();
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.html
@@ -47,6 +47,14 @@
           <span *ngIf="policy.name" class="policiesCatalog__list__policy__head__name">{{ policy.name }}</span>
         </div>
 
+        <div class="policiesCatalog__list__policy__enterprise" *ngIf="policy.deployed === false">
+          <mat-icon
+            class="policiesCatalog__list__policy__enterprise__lock"
+            [svgIcon]="'gio:lock'"
+            matTooltip="This policy is only available for users with an enterprise license."
+          ></mat-icon>
+        </div>
+
         <div *ngIf="policy.description" class="policiesCatalog__list__policy__description">{{ policy.description }}</div>
 
         <button class="policiesCatalog__list__policy__selectBtn" mat-stroked-button role="dialog" (click)="onSelectPolicy(policy)">
@@ -66,6 +74,14 @@
     <mat-icon svgIcon="gio:arrow-left"></mat-icon>
     Go back
   </button>
+
+  <gio-banner *ngIf="isUnlicensed" type="error" icon="gio:universe">
+    This policy is only available for users with an enterprise license.
+    <span gioBannerBody>Request a license to upgrade your account and unlock this policy</span>
+    <div gioBannerAction>
+      <a *ngIf="trialUrl" mat-stroked-button [href]="trialUrl" target="_blank">Request upgrade</a>
+    </div>
+  </gio-banner>
 
   <div class="policyForm__info">
     <div class="policyForm__info__head">
@@ -88,7 +104,7 @@
     color="primary"
     mat-flat-button
     role="dialog"
-    [disabled]="!isValid"
+    [disabled]="!isValid || isUnlicensed"
     (click)="onAddPolicy()"
   >
     Add policy

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.scss
@@ -45,6 +45,7 @@ $typography: map.get(gio.$mat-theme, typography);
     grid-template-columns: repeat(auto-fill, minmax(max(var(--grid-item-min-width), var(--grid-item-max-width)), 1fr));
 
     &__policy {
+      position: relative;
       display: flex;
       flex-direction: column;
       align-items: flex-start;
@@ -56,7 +57,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
       &__head {
         display: flex;
-        max-width: 100%;
+        max-width: 95%;
         align-items: center;
 
         &__icon {
@@ -70,6 +71,22 @@ $typography: map.get(gio.$mat-theme, typography);
           flex: 1 1 auto;
           text-overflow: ellipsis;
           white-space: nowrap;
+        }
+      }
+
+      &__enterprise {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 8px 8px 8px 16px;
+        border-radius: 0 8px 0 38px;
+        background: mat.get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+        color: mat.get-color-from-palette(gio.$mat-accent-palette, 'darker20');
+
+        &__lock {
+          min-width: 16px;
+          max-width: 16px;
+          color: mat.get-color-from-palette(gio.$mat-accent-palette, 'darker20');
         }
       }
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
@@ -98,6 +98,7 @@ describe('GioPolicyStudioPoliciesCatalogDialogComponent', () => {
       apiType,
       policies: fakeAllPolicies(),
       executionPhase,
+      trialUrl: 'https://gravitee.io/self-hosted-trial',
     };
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
   };
@@ -220,6 +221,16 @@ describe('GioPolicyStudioPoliciesCatalogDialogComponent', () => {
       await componentTestingOpenDialog();
 
       await expectPoliciesCatalogContent('Request', p => p.proxy?.includes('REQUEST'));
+    });
+
+    it('should display a banner with a "Request upgrade" button when policy is not deployed (enterprise license)', async () => {
+      await componentTestingOpenDialog();
+
+      const policiesCatalogDialog = await loader.getHarness(GioPolicyStudioPoliciesCatalogDialogHarness);
+      await policiesCatalogDialog.selectPolicy('No license policy');
+
+      expect(await policiesCatalogDialog.getSelectedPolicyName()).toEqual('No license policy');
+      expect(await policiesCatalogDialog.hasRequestUpgradeButton()).toBe(true);
     });
   });
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
@@ -26,6 +26,7 @@ export type GioPolicyStudioPoliciesCatalogDialogData = {
   policies: Policy[];
   executionPhase: ExecutionPhase;
   apiType: ApiType;
+  trialUrl?: string;
 };
 
 export type GioPolicyStudioPoliciesCatalogDialogResult = undefined | Step;
@@ -65,6 +66,10 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent implements OnDestroy 
 
   private unsubscribe$ = new Subject<void>();
 
+  public isUnlicensed = false;
+
+  public trialUrl?: string;
+
   constructor(
     public dialogRef: MatDialogRef<GioPolicyStudioPoliciesCatalogDialogComponent, GioPolicyStudioPoliciesCatalogDialogResult>,
     @Inject(MAT_DIALOG_DATA) flowDialogData: GioPolicyStudioPoliciesCatalogDialogData,
@@ -82,6 +87,7 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent implements OnDestroy 
         ...policy,
         category: policy.category ?? 'Others',
       }));
+
     this.categories = uniq(this.allPolicies.map(policy => policy.category.toLowerCase()));
 
     // By default, all categories are selected
@@ -94,6 +100,8 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent implements OnDestroy 
           return categories.map(toLower).includes(toLower(policy.category));
         });
       });
+
+    this.trialUrl = flowDialogData.trialUrl;
   }
 
   public ngOnDestroy(): void {
@@ -102,6 +110,9 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent implements OnDestroy 
   }
 
   public onSelectPolicy(policy: Policy) {
+    if (policy.deployed === false) {
+      this.isUnlicensed = true;
+    }
     this.selectedPolicy = policy;
   }
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.harness.ts
@@ -37,19 +37,25 @@ export class GioPolicyStudioPoliciesCatalogDialogHarness extends ComponentHarnes
 
   public async selectPolicy(policyName: string): Promise<void> {
     const policies = await this.policiesLocator();
-    const policy = policies.find(
-      async p => (await p.getText({ childSelector: '.policiesCatalog__list__policy__head__name' })) === policyName,
-    );
-    if (!policy) {
-      throw new Error(`Policy ${policyName} not found`);
+    for (const policy of policies) {
+      const name = await policy.getText({ childSelector: '.policiesCatalog__list__policy__head__name' });
+      if (name === policyName) {
+        const selectBtn = await policy.childLocatorFor(MatButtonHarness.with({ selector: '.policiesCatalog__list__policy__selectBtn' }))();
+        await selectBtn.click();
+        return;
+      }
     }
-    const selectBtn = await policy.childLocatorFor(MatButtonHarness.with({ selector: '.policiesCatalog__list__policy__selectBtn' }))();
-    await selectBtn.click();
+    throw new Error(`Policy ${policyName} not found`);
   }
 
   public async getSelectedPolicyName(): Promise<string> {
     const policy = await this.locatorFor('.policyForm__info__head__name')();
     return policy.text();
+  }
+
+  public async hasRequestUpgradeButton(): Promise<boolean> {
+    const requestUpgradeButton = await this.locatorForOptional(MatButtonHarness.with({ text: 'Request upgrade' }))();
+    return !!requestUpgradeButton;
   }
 
   public async clickAddPolicyButton(): Promise<void> {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.stories.ts
@@ -103,6 +103,7 @@ export default {
         apiType: args.apiType,
         executionPhase: args.executionPhase,
         policies: fakeAllPolicies(),
+        trialUrl: 'https://gravitee.io/self-hosted-trial',
       },
     },
   }),

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -69,12 +69,14 @@ export default {
     [policies]="policies"
     [policySchemaFetcher]="policySchemaFetcher"
     [policyDocumentationFetcher]="policyDocumentationFetcher"
+    [trialUrl]="trialUrl"
     (save)="onSave($event)"
     >
     </gio-policy-studio></div>`,
     props: {
       ...props,
       policies: fakeAllPolicies(),
+      trialUrl: 'https://gravitee.io/self-hosted-trial',
       // Simulate a get policy schema http fetcher.
       policySchemaFetcher: (policy: Policy) => of(fakePolicySchema(policy.id)).pipe(delay(600)),
       policyDocumentationFetcher: (policy: Policy) => of(fakePolicyDocumentation(policy.id)).pipe(delay(600)),

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -66,6 +66,7 @@
       [entrypointsInfo]="entrypointsInfo"
       [endpointsInfo]="endpointsInfo"
       [policies]="policies"
+      [trialUrl]="trialUrl"
       (flowChange)="onSelectedFlowChange($event)"
       (deleteFlow)="onDeleteSelectedFlow($event)"
     ></gio-ps-flow-details>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -80,6 +80,13 @@ export class GioPolicyStudioComponent implements OnChanges {
   public policies: Policy[] = [];
 
   /**
+   * When a policy is not available with the current license,
+   * this URL is used to redirect the user to the trial page.
+   */
+  @Input()
+  public trialUrl?: string;
+
+  /**
    * Loading state
    */
   @Input()

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/Step.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/flow/Step.ts
@@ -42,4 +42,8 @@ export interface Step {
    * The message condition of the step
    */
   messageCondition?: string;
+  /**
+   * Is the policy deployed or not.
+   */
+  deployed?: boolean;
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.fixture.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.fixture.ts
@@ -133,6 +133,11 @@ export function fakeAllPolicies(): Policy[] {
       description:
         'Test policy description - With very long name to test overflow. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis sem at nibh elementum imperdiet.',
     }),
+    fakeTestPolicy({
+      name: 'No license policy',
+      deployed: false,
+      description: 'No license policy should display a lock icon and a clear CTA.',
+    }),
     ...POLICIES_V4_UNREGISTERED_ICON.map(policy => ({
       ...policy,
       // Replace all icons with the policy id. Icons are registred in the IconRegistry before.

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.ts
@@ -24,4 +24,5 @@ export interface Policy {
   version?: string;
   proxy?: ExecutionPhase[];
   message?: ExecutionPhase[];
+  deployed?: boolean;
 }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-1935
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.26.0-lock-policy-studio-v4-36bd70a
```
```
yarn add @gravitee/ui-policy-studio-angular@7.26.0-lock-policy-studio-v4-36bd70a
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.26.0-lock-policy-studio-v4-36bd70a
```
```
yarn add @gravitee/ui-particles-angular@7.26.0-lock-policy-studio-v4-36bd70a
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-alycgvtrsh.chromatic.com)
<!-- Storybook placeholder end -->
