### PR TITLE
fix: add light theme option to submenu group

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.html
@@ -16,6 +16,6 @@
 
 -->
 <div class="gio-submenu-group">
-  <div class="gio-submenu-group__title">{{ title }}</div>
+  <div class="gio-submenu-group__title" [class.gio-submenu-group__title__light]="theme === 'light'">{{ title }}</div>
   <ng-content></ng-content>
 </div>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.scss
@@ -19,6 +19,7 @@
 @use '../../../scss' as gio;
 
 $text: map.get(gio.$mat-space-palette, lighter60);
+$text-light: mat.get-color-from-palette(gio.$mat-dove-palette, darker20);
 
 .gio-submenu-group {
   display: flex;
@@ -32,5 +33,9 @@ $text: map.get(gio.$mat-space-palette, lighter60);
     margin: 1px 0;
     color: $text;
     letter-spacing: 0.4px;
+  }
+
+  &__title__light {
+    color: $text-light;
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.ts
@@ -15,6 +15,8 @@
  */
 import { Component, Input } from '@angular/core';
 
+import { GioSubmenuTheme } from '../gio-submenu.component';
+
 @Component({
   selector: 'gio-submenu-group',
   templateUrl: './gio-submenu-group.component.html',
@@ -22,4 +24,6 @@ import { Component, Input } from '@angular/core';
 })
 export class GioSubmenuGroupComponent {
   @Input() public title = '';
+
+  @Input() public theme: GioSubmenuTheme = 'dark';
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.stories.ts
@@ -76,22 +76,22 @@ export const Light: Story = {
         <gio-submenu theme="light">
             <div gioSubmenuTitle>Submenu title</div>   
             <gio-submenu-item (click)="onClick('message')" [active]="isActive('message')">Message</gio-submenu-item>
-            <gio-submenu-group title="Portal">
+            <gio-submenu-group title="Portal" theme="light">
               <gio-submenu-item (click)="onClick('general')" [active]="isActive('general')">General</gio-submenu-item>
               <gio-submenu-item (click)="onClick('plans')" [active]="isActive('plans')">Plans</gio-submenu-item>
               <gio-submenu-item (click)="onClick('doc')" [active]="isActive('doc')">Documentation</gio-submenu-item>
               <gio-submenu-item (click)="onClick('user')" [active]="isActive('user')">User & Group Access</gio-submenu-item>
             </gio-submenu-group>
-            <gio-submenu-group title="Proxy">
+            <gio-submenu-group title="Proxy" theme="light">
               <gio-submenu-item (click)="onClick('general-2')" [active]="isActive('general-2')">General</gio-submenu-item>
               <gio-submenu-item (click)="onClick('backend')" [active]="isActive('backend')">Backend services</gio-submenu-item>
             </gio-submenu-group>
-            <gio-submenu-group title="Design">
+            <gio-submenu-group title="Design" theme="light">
               <gio-submenu-item (click)="onClick('policies')" [active]="isActive('policies')">Policies</gio-submenu-item>
               <gio-submenu-item (click)="onClick('resources')" [active]="isActive('resources')">Resources</gio-submenu-item>
               <gio-submenu-item (click)="onClick('properties')" [active]="isActive('properties')">Properties</gio-submenu-item>
             </gio-submenu-group>
-            <gio-submenu-group title="Analytics">
+            <gio-submenu-group title="Analytics" theme="light">
               <gio-submenu-item (click)="onClick('overview')" [active]="isActive('overview')">Overview</gio-submenu-item>
               <gio-submenu-item (click)="onClick('logs')" [active]="isActive('logs')">Logs</gio-submenu-item>
               <gio-submenu-item (click)="onClick('path')" [active]="isActive('path')">Path mappings</gio-submenu-item>


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-2157
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.26.0-fix-light-submenu-title-15b961a
```
```
yarn add @gravitee/ui-particles-angular@7.26.0-fix-light-submenu-title-15b961a
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.26.0-fix-light-submenu-title-15b961a
```
```
yarn add @gravitee/ui-policy-studio-angular@7.26.0-fix-light-submenu-title-15b961a
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xhcrzfpzxp.chromatic.com)
<!-- Storybook placeholder end -->
