### PR TITLE
Improvement for  GioFormJsonSchema & GioFormTagsInputComponent

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
@@ -17,6 +17,7 @@ import { Injectable } from '@angular/core';
 import { FormlyFieldConfig, FormlyFormBuilder } from '@ngx-formly/core';
 import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
 import { JSONSchema7 } from 'json-schema';
+import { isArray, isEmpty } from 'lodash';
 
 import { GioJsonSchema } from './model/GioJsonSchema';
 
@@ -32,6 +33,7 @@ export class GioFormlyJsonSchemaService {
         mappedField = this.bannerMap(mappedField, mapSource);
         mappedField = this.toggleMap(mappedField, mapSource);
         mappedField = this.disabledMap(mappedField, mapSource);
+        mappedField = this.enumLabelMap(mappedField, mapSource);
 
         return mappedField;
       },
@@ -99,6 +101,22 @@ export class GioFormlyJsonSchemaService {
       ...mappedField.expressions,
       'props.disabled': field => field.options?.formState.disabled === true || field.props?.disabled === true,
     };
+    return mappedField;
+  }
+
+  private enumLabelMap(mappedField: FormlyFieldConfig, mapSource: JSONSchema7): FormlyFieldConfig {
+    if (mapSource.enum && !isEmpty(mapSource.enum) && mapSource.gioConfig?.enumLabelMap && isArray(mappedField.props?.options)) {
+      mappedField.props = {
+        ...mappedField.props,
+        options: mappedField.props?.options?.map(({ value }) => {
+          return {
+            label: value ? mapSource.gioConfig?.enumLabelMap?.[value] : value,
+            value: value,
+          };
+        }),
+      };
+    }
+
     return mappedField;
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/enum.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/enum.ts
@@ -37,6 +37,24 @@ export const enumExample: GioJsonSchema = {
         },
       },
     },
+    enumWithCustomLabel: {
+      type: 'object',
+      title: 'Enum with custom select label',
+      properties: {
+        type: {
+          title: 'Type',
+          description: 'The type of the trust store',
+          enum: [null, 'JKS', 'PKCS12', 'PEM'],
+          gioConfig: {
+            enumLabelMap: {
+              JKS: 'Java Trust Store (.jks)',
+              PKCS12: 'PKCS#12 (.p12) / PFX (.pfx)',
+              PEM: 'PEM (.pem)',
+            },
+          },
+        },
+      },
+    },
     enumWithTitle: {
       type: 'object',
       title: 'Enum with custom select label',

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/model/GioJsonSchema.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/model/GioJsonSchema.ts
@@ -21,6 +21,7 @@
 export interface GioConfig extends GioUiTypeConfig {
   banner?: GioBannerConfig;
   monacoEditorConfig?: GioMonacoEditorConfig;
+  enumLabelMap?: Record<string, string>;
 }
 
 type GioBannerConfig =

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.stories.mdx
@@ -8,18 +8,20 @@ Documentation and examples for Form Tags Input, a component to specify a list of
 
 ## Demo
 
-<Story id="components-form-tags-input--with-initial-value"/>
+<Story id="components-form-tags-input--with-initial-value" />
 
 ## Usage
 
 **Inputs**
- - `ariaLabel`: `string` - Aria label for the input.
- - `addOnBlur`: `boolean` - Whether or not the chipEnd event will be emitted when the input is blurred.
- - `tagValidationHook`: `function(tag, validationCallback())` - Function called each time a tag is added. Useful to hook inside the addition process to, for instance, have custom validation in the components using `gio-form-tags-input`.
- - `placeholder`: `string` - The input's placeholder text.
- - `required`: `boolean` - Whether the input requires to have at least one value.
- - `disabled`: `boolean` - Whether the input is disabled.
 
+- `ariaLabel`: `string` - Aria label for the input.
+- `addOnBlur`: `boolean` - Whether or not the chipEnd event will be emitted when the input is blurred.
+- `tagValidationHook`: `function(tag, validationCallback())` - Function called each time a tag is added. Useful to hook inside the addition process to, for instance, have custom validation in the components using `gio-form-tags-input`.
+- `placeholder`: `string` - The input's placeholder text.
+- `required`: `boolean` - Whether the input requires to have at least one value.
+- `disabled`: `boolean` - Whether the input is disabled.
+- `autocompleteOptions`: `AutocompleteOptions | ((search: string) => Observable<AutocompleteOptions>)` - List of options to autocomplete the input. Can be a static list or a function returning an observable to filter the options.
+- `displayValueWith`: `(value: string) => Observable<string>` - Function to display the label of the input value. Useful to display the label of an value id, for instance.
 Example:
 
 ```html

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
@@ -17,7 +17,7 @@
 -->
 <mat-chip-list #tagChipList [attr.aria-label]="ariaLabel" multiple [disabled]="disabled">
   <mat-chip *ngFor="let tag of value" [selectable]="false" [removable]="!disabled" (removed)="removeChipToFormControl(tag)">
-    {{ tag }}
+    {{ _displayValueWith ? (_displayValueWith(tag) | async) : tag }}
     <mat-icon matChipRemove>cancel</mat-icon>
   </mat-chip>
   <input
@@ -31,8 +31,8 @@
     (matChipInputTokenEnd)="onMatChipTokenEnd()"
   />
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onAutocompleteSelect($event)">
-    <mat-option *ngFor="let value of autocompleteFilteredOptions$ | async" [value]="value">
-      {{ value }}
+    <mat-option *ngFor="let option of autocompleteFilteredOptions$ | async" [value]="option.value">
+      {{ option.label }}
     </mat-option>
   </mat-autocomplete>
 </mat-chip-list>


### PR DESCRIPTION
**Issue**

n/a

**Description**

Add `enumLabelMap` to set label to json-schema enum

Improve GioFormTagsInputComponent to add dynamic search autocomplete

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-uxklbrhmsh.chromatic.com)
<!-- Storybook placeholder end -->
