### PR TITLE
fix: sort policies categories

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
@@ -165,11 +165,15 @@ describe('GioPolicyStudioPoliciesCatalogDialogComponent', () => {
 
       expect(await policiesCatalogDialog.getCategoriesSelection()).toEqual([
         {
-          name: 'Others',
+          name: 'Security',
           selected: true,
         },
         {
-          name: 'Security',
+          name: 'Transformation',
+          selected: true,
+        },
+        {
+          name: 'Others',
           selected: true,
         },
       ]);

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
@@ -88,7 +88,11 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent implements OnDestroy 
         category: policy.category ?? 'Others',
       }));
 
-    this.categories = uniq(this.allPolicies.map(policy => policy.category.toLowerCase()));
+    this.categories = uniq(this.allPolicies.map(policy => policy.category.toLowerCase())).sort((a, b) => a.localeCompare(b));
+    const othersIndex = this.categories.indexOf('others');
+    if (othersIndex !== -1) {
+      this.categories.push(this.categories.splice(othersIndex, 1)[0]);
+    }
 
     // By default, all categories are selected
     this.selectedCategoriesControl = new FormControl(this.categories);

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.fixture.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.fixture.ts
@@ -138,6 +138,12 @@ export function fakeAllPolicies(): Policy[] {
       deployed: false,
       description: 'No license policy should display a lock icon and a clear CTA.',
     }),
+    fakeTestPolicy({
+      id: 'transformation-policy',
+      name: 'transformation policy',
+      category: 'transformation',
+      proxy: ['REQUEST'],
+    }),
     ...POLICIES_V4_UNREGISTERED_ICON.map(policy => ({
       ...policy,
       // Replace all icons with the policy id. Icons are registred in the IconRegistry before.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2132

**Description**

Sort policies categories and push "others" at the end

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.28.0-apim-2132-sort-policy-filters-86c4ee5
```
```
yarn add @gravitee/ui-particles-angular@7.28.0-apim-2132-sort-policy-filters-86c4ee5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.28.0-apim-2132-sort-policy-filters-86c4ee5
```
```
yarn add @gravitee/ui-policy-studio-angular@7.28.0-apim-2132-sort-policy-filters-86c4ee5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-qgdquunlac.chromatic.com)
<!-- Storybook placeholder end -->
