### PR TITLE
Add a boolean to accept only tags available in autocomplete options

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.stories.mdx
@@ -22,6 +22,7 @@ Documentation and examples for Form Tags Input, a component to specify a list of
 - `disabled`: `boolean` - Whether the input is disabled.
 - `autocompleteOptions`: `AutocompleteOptions | ((search: string) => Observable<AutocompleteOptions>)` - List of options to autocomplete the input. Can be a static list or a function returning an observable to filter the options.
 - `displayValueWith`: `(value: string) => Observable<string>` - Function to display the label of the input value. Useful to display the label of an value id, for instance.
+- `useAutocompleteOptionsOnly`: `boolean` - Whether the input should only accept values from the autocomplete options.
 Example:
 
 ```html

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.ts
@@ -95,6 +95,12 @@ export class GioFormTagsInputComponent implements MatFormFieldControl<Tags>, Con
     };
   }
 
+  /**
+   * Set to true to force the chip to be part of the autocomplete options.
+   */
+  @Input()
+  public useAutocompleteOptionValueOnly = false;
+
   @ViewChild('tagInput')
   public set tagInput(v: ElementRef<HTMLInputElement> | null) {
     this._tagInput = v;
@@ -303,6 +309,9 @@ export class GioFormTagsInputComponent implements MatFormFieldControl<Tags>, Con
   }
 
   public onMatChipTokenEnd(): void {
+    if (this.useAutocompleteOptionValueOnly) {
+      return;
+    }
     // Give priority to the `onAutocompleteSelect` when validating with the blur event
     setTimeout(() => {
       this.addChipToFormControl({ value: this._tagInput?.nativeElement.value ?? '' });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
@@ -269,7 +269,7 @@ const applications = range(10).map(i => ({
 }));
 
 export const WithAsyncAutocompleteOnly: Story = {
-  render: ({ tags, placeholder, required, disabled, tagValidationHook, autocompleteOptions, displayValueWith }) => {
+  render: ({ tags, placeholder, required, disabled, autocompleteOptions, displayValueWith, useAutocompleteOptionValueOnly }) => {
     const tagsControl = new FormControl({ value: tags, disabled });
 
     tagsControl.valueChanges.subscribe(value => {
@@ -284,9 +284,9 @@ export const WithAsyncAutocompleteOnly: Story = {
           [required]="required" 
           [placeholder]="placeholder" 
           [formControl]="tagsControl"
-          [tagValidationHook]="tagValidationHook"
           [autocompleteOptions]="autocompleteOptions"
           [displayValueWith]="displayValueWith"
+          [useAutocompleteOptionValueOnly]="useAutocompleteOptionValueOnly"
         >
         </gio-form-tags-input>
       </mat-form-field>
@@ -297,9 +297,9 @@ export const WithAsyncAutocompleteOnly: Story = {
         required,
         disabled,
         tagsControl,
-        tagValidationHook,
         autocompleteOptions,
         displayValueWith,
+        useAutocompleteOptionValueOnly,
       },
     };
   },
@@ -314,9 +314,7 @@ export const WithAsyncAutocompleteOnly: Story = {
       const application = applications.find(a => a.value === tag);
       return of(application ? application.label : tag);
     },
-    tagValidationHook: (tag: string, validationCb: (shouldAddTag: boolean) => void) => {
-      validationCb(applications.map(a => a.value).includes(tag));
-    },
+    useAutocompleteOptionValueOnly: true,
   },
   argTypes: {
     tagValidationHook: {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/2023

**Description**

Add a boolean to accept only tags available in autocomplete options
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.28.2-use-autocomplete-options-only-d8afa02
```
```
yarn add @gravitee/ui-policy-studio-angular@7.28.2-use-autocomplete-options-only-d8afa02
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.28.2-use-autocomplete-options-only-d8afa02
```
```
yarn add @gravitee/ui-particles-angular@7.28.2-use-autocomplete-options-only-d8afa02
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-robetppzpy.chromatic.com)
<!-- Storybook placeholder end -->
