### PR TITLE
fix: add trial url to proxy policies

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -103,6 +103,7 @@
           [steps]="flow.request ?? []"
           [apiType]="apiType"
           [policies]="policies"
+          [trialUrl]="trialUrl"
           policyExecutionPhase="REQUEST"
           (stepsChange)="onStepsChange('request', $event)"
         ></gio-ps-flow-details-phase>
@@ -115,6 +116,7 @@
           [steps]="flow.response ?? []"
           [apiType]="apiType"
           [policies]="policies"
+          [trialUrl]="trialUrl"
           policyExecutionPhase="RESPONSE"
           (stepsChange)="onStepsChange('response', $event)"
         ></gio-ps-flow-details-phase>


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-1685
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.28.2-trial-url-proxy-87d390d
```
```
yarn add @gravitee/ui-particles-angular@7.28.2-trial-url-proxy-87d390d
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.28.2-trial-url-proxy-87d390d
```
```
yarn add @gravitee/ui-policy-studio-angular@7.28.2-trial-url-proxy-87d390d
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-ihmgoyicly.chromatic.com)
<!-- Storybook placeholder end -->
