### PR TITLE
fix(gio-submenu): add static input flag to force submenu renderer

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.ts
@@ -45,6 +45,9 @@ export class GioSubmenuComponent implements AfterViewInit, OnDestroy {
   @Input()
   public theme: GioSubmenuTheme = 'dark';
 
+  @Input()
+  public static = false;
+
   public reduced = false;
   public loaded = false;
   public overlayOptions: OverlayOptions = { open: false };
@@ -94,7 +97,7 @@ export class GioSubmenuComponent implements AfterViewInit, OnDestroy {
 
     this.gioMenuService.reduced$
       .pipe(
-        switchMap(reduced => (reduced ? reduced$ : notReduced$)),
+        switchMap(reduced => (reduced && !this.static ? reduced$ : notReduced$)),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() => {


### PR DESCRIPTION
**Issue**

When the menu is collapse and go to organization level, the menu is not display.


![Capture d’écran 2023-07-11 à 14 02 38](https://github.com/gravitee-io/gravitee-ui-particles/assets/1457497/10d9481e-92ad-4b05-a2c3-fa3ac877a7ac)
![Capture d’écran 2023-07-11 à 14 02 30](https://github.com/gravitee-io/gravitee-ui-particles/assets/1457497/a7f04272-53c3-44c2-b414-c1a7103f0bbb)


**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.28.5-fix-org-submenu-a4d87dc
```
```
yarn add @gravitee/ui-policy-studio-angular@7.28.5-fix-org-submenu-a4d87dc
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.28.5-fix-org-submenu-a4d87dc
```
```
yarn add @gravitee/ui-particles-angular@7.28.5-fix-org-submenu-a4d87dc
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-kaszzokfpn.chromatic.com)
<!-- Storybook placeholder end -->
