### PR TITLE
fix: disable mutlischema mat-select when form is disabled

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.spec.ts
@@ -8,10 +8,12 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 
 import { GioJsonSchema } from './model/GioJsonSchema';
 import { GioFormJsonSchemaModule } from './gio-form-json-schema.module';
 import { GioFormJsonSchemaComponent } from './gio-form-json-schema.component';
+import { oneOfExample } from './json-schema-example/oneOf';
 
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
@@ -253,6 +255,24 @@ describe('GioFormJsonSchema', () => {
         await input2.setValue('test-2');
         tick(100);
         expect(await input2.getValue()).toStrictEqual('test-2');
+      }));
+
+      it('should disable/enable oneOf fields', fakeAsync(async () => {
+        fixture.componentInstance.jsonSchema = oneOfExample;
+        tick(100);
+        fixture.detectChanges();
+
+        const selectField = await loader.getHarness(MatSelectHarness.with({ selector: '[id*="enum__0"]' }));
+        expect(await selectField.isDisabled()).toEqual(false);
+
+        fixture.componentInstance.disableFormFields();
+        fixture.detectChanges();
+
+        expect(await selectField.isDisabled()).toEqual(true);
+        fixture.componentInstance.enableFormFields();
+        fixture.detectChanges();
+
+        expect(await selectField.isDisabled()).toEqual(false);
       }));
     });
   });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/multischema-type.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/type-component/multischema-type.component.ts
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 import { set } from 'lodash';
-import { takeUntil, tap } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 @Component({
@@ -33,7 +32,7 @@ import { Subject } from 'rxjs';
   `,
   styleUrls: ['./multischema-type.component.scss'],
 })
-export class GioFjsMultiSchemaTypeComponent extends FieldType implements OnInit, OnDestroy {
+export class GioFjsMultiSchemaTypeComponent extends FieldType implements OnInit, OnDestroy, AfterViewChecked {
   private unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(private readonly cdr: ChangeDetectorRef) {
@@ -48,16 +47,10 @@ export class GioFjsMultiSchemaTypeComponent extends FieldType implements OnInit,
   public ngOnInit(): void {
     set(this.field, 'fieldGroup[0].props.appearance', 'fill');
     set(this.field, 'fieldGroup[0].props.label', 'Select option');
-    set(this.field, 'fieldGroup[0].props.disabled', this.form.disabled);
+  }
 
-    this.form.valueChanges
-      .pipe(
-        tap(() => {
-          set(this.field, 'fieldGroup[0].props.disabled', this.form.disabled);
-          this.cdr.detectChanges();
-        }),
-        takeUntil(this.unsubscribe$),
-      )
-      .subscribe();
+  public ngAfterViewChecked(): void {
+    set(this.field, 'fieldGroup[0].props.disabled', this.formControl.disabled);
+    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Disable mat-select in json-schema-form component

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.28.6-fix-disable-multiform-select-6a8a04e
```
```
yarn add @gravitee/ui-particles-angular@7.28.6-fix-disable-multiform-select-6a8a04e
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.28.6-fix-disable-multiform-select-6a8a04e
```
```
yarn add @gravitee/ui-policy-studio-angular@7.28.6-fix-disable-multiform-select-6a8a04e
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-wmpllivfkc.chromatic.com)
<!-- Storybook placeholder end -->
