### PR TITLE
fix(license): remove storybook stuff from implementation

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.directive.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.directive.ts
@@ -15,7 +15,6 @@
  */
 import { Directive, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
 import { filter, map, takeUntil, tap } from 'rxjs/operators';
-import { action } from '@storybook/addon-actions';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
 
@@ -79,11 +78,6 @@ export class GioLicenseDirective implements OnInit, OnDestroy {
         id: 'gioLicenseDialog',
       })
       .afterClosed()
-      .pipe(
-        tap(confirmed => {
-          action('confirmed?')(confirmed);
-        }),
-      )
       .subscribe();
     return false;
   }


### PR DESCRIPTION

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.29.1-fix-license-directive-0218d90
```
```
yarn add @gravitee/ui-policy-studio-angular@7.29.1-fix-license-directive-0218d90
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.29.1-fix-license-directive-0218d90
```
```
yarn add @gravitee/ui-particles-angular@7.29.1-fix-license-directive-0218d90
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-dzkfbqbnhg.chromatic.com)
<!-- Storybook placeholder end -->
