### PR TITLE
fix: json-schema - move init default value higher up in the lifecycle

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
@@ -150,6 +150,15 @@ export class GioFormJsonSchemaComponent implements ControlValueAccessor, OnChang
       );
     });
 
+    // Init control value with default value without emit event
+    this.formGroup.valueChanges.pipe(take(1), takeUntil(this.unsubscribe$)).subscribe(value => {
+      this.ngControl?.control?.reset(value, { emitEvent: false });
+      this.changeDetectorRef.markForCheck();
+      this.changeDetectorRef.detectChanges();
+    });
+    this.changeDetectorRef.markForCheck();
+    this.changeDetectorRef.detectChanges();
+
     // Subscribe to state changes to manage touches, status and value
     this.stateChanges$
       .pipe(
@@ -195,11 +204,6 @@ export class GioFormJsonSchemaComponent implements ControlValueAccessor, OnChang
   }
 
   public ngAfterViewInit(): void {
-    // Init control value with default value without emit event
-    this.ngControl?.control?.setValue(this.formGroup.value, { emitEvent: false });
-    this.changeDetectorRef.markForCheck();
-    this.changeDetectorRef.detectChanges();
-
     // Group all valueChanges events emit by formly in a single one
     merge(this.formGroup.statusChanges, this.formGroup.valueChanges)
       .pipe(


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.37.0-fix-ps-v2-de33006
```
```
yarn add @gravitee/ui-policy-studio-angular@7.37.0-fix-ps-v2-de33006
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.37.0-fix-ps-v2-de33006
```
```
yarn add @gravitee/ui-particles-angular@7.37.0-fix-ps-v2-de33006
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-blczgclifn.chromatic.com)
<!-- Storybook placeholder end -->
