### PR TITLE
fix: enable markdown in monaco editor

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -36,10 +36,14 @@ import { GioMonacoEditorConfig, GIO_MONACO_EDITOR_CONFIG } from './models/GioMon
 import { GioLanguageJsonService } from './services/gio-language-json.service';
 import { GioMonacoEditorService } from './services/gio-monaco-editor.service';
 
-export type MonacoEditorLanguageConfig = {
-  language: 'json';
-  schemas: { uri: string; schema: unknown }[];
-};
+export type MonacoEditorLanguageConfig =
+  | {
+      language: 'json' | 'markdown';
+      schemas: { uri: string; schema: unknown }[];
+    }
+  | {
+      language: 'markdown';
+    };
 
 @Component({
   selector: 'gio-monaco-editor',
@@ -190,20 +194,14 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
       return;
     }
 
-    const { language } = languageConfig;
-
-    if (language) {
-      const lang = language.toLowerCase();
-
-      switch (lang) {
-        case 'json':
-          if (languageConfig.schemas) {
-            this.languageJsonService.addSchemas(uri, languageConfig.schemas);
-          }
-          break;
-        default:
-          break;
-      }
+    switch (languageConfig.language) {
+      case 'json':
+        if (languageConfig.schemas) {
+          this.languageJsonService.addSchemas(uri, languageConfig.schemas);
+        }
+        break;
+      default:
+        break;
     }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -143,3 +143,17 @@ export const InsideMatFormField: Story = {
   },
   args: {},
 };
+
+export const LanguageMarkdown: Story = {
+  args: {
+    languageConfig: {
+      language: 'markdown',
+    },
+    value: `# Header 1 #
+## Header 2 ##
+### Header 3 ###             (Hashes on right are optional)
+## Markdown plus h2 with a custom ID ##   {#id-goes-here}
+[Link back to H2](#id-goes-here)
+`,
+  },
+};


### PR DESCRIPTION
**Issue**

Necessary for https://gravitee.atlassian.net/browse/APIM-2792

**Description**

Enable markdown language config for gio-monaco-editor

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.37.2-allow-md-in-monaco-editor-2205d0b
```
```
yarn add @gravitee/ui-policy-studio-angular@7.37.2-allow-md-in-monaco-editor-2205d0b
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.37.2-allow-md-in-monaco-editor-2205d0b
```
```
yarn add @gravitee/ui-particles-angular@7.37.2-allow-md-in-monaco-editor-2205d0b
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-bwqnwhdfln.chromatic.com)
<!-- Storybook placeholder end -->
