### PR TITLE
fix(gio-form-tags-input): call autocomplete options on focus

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
@@ -37,6 +37,9 @@
     (matChipInputTokenEnd)="onMatChipTokenEnd()"
   />
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onAutocompleteSelect($event)">
+    <mat-option *ngIf="loading" disabled id="loader">
+      <div class="loader-option"><gio-loader></gio-loader></div>
+    </mat-option>
     <mat-option *ngFor="let option of autocompleteFilteredOptions$ | async" [value]="option.value">
       {{ option.label }}
     </mat-option>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.scss
@@ -13,3 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.loader-option {
+  display: flex;
+
+  gio-loader {
+    width: 24px;
+  }
+}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.ts
@@ -23,10 +23,22 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 
+import { GioLoaderModule } from '../gio-loader/gio-loader.module';
+
 import { GioFormTagsInputComponent } from './gio-form-tags-input.component';
 
 @NgModule({
-  imports: [CommonModule, A11yModule, MatChipsModule, MatInputModule, FormsModule, MatIconModule, MatAutocompleteModule, MatSelectModule],
+  imports: [
+    CommonModule,
+    A11yModule,
+    MatChipsModule,
+    MatInputModule,
+    FormsModule,
+    MatIconModule,
+    MatAutocompleteModule,
+    MatSelectModule,
+    GioLoaderModule,
+  ],
   declarations: [GioFormTagsInputComponent],
   exports: [GioFormTagsInputComponent],
 })

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
@@ -21,6 +21,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { range } from 'lodash';
 import { of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 import { GioFormTagsInputComponent, Tags } from './gio-form-tags-input.component';
 import { GioFormTagsInputModule } from './gio-form-tags-input.module';
@@ -316,7 +317,7 @@ export const WithAsyncAutocompleteOnly: Story = {
     disabled: false,
     placeholder: 'Search application  ',
     autocompleteOptions: (tag: string) => {
-      return of(applications.filter(a => a.label.startsWith(tag)));
+      return of(applications.filter(a => a.label.startsWith(tag))).pipe(delay(1000));
     },
     displayValueWith: (tag: string) => {
       const application = applications.find(a => a.value === tag);

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-loader/gio-loader.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-loader/gio-loader.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,7 @@
   mat-icon {
     width: 100%;
     height: 100%;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
**Description**

The autocomplete options will only be called when the component has the
focus. It prevents calling the async options for nothing, like when
the user doesn't interact with the component.

I didn't manage to prevent calling autocomplete options after selecting
a value. In that case, the input loses the focus and re-gains it just after, triggering the call of autocomplete options


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.37.5-fix-gio-form-tags-input-fetch-on-focus-c34410c
```
```
yarn add @gravitee/ui-policy-studio-angular@7.37.5-fix-gio-form-tags-input-fetch-on-focus-c34410c
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.37.5-fix-gio-form-tags-input-fetch-on-focus-c34410c
```
```
yarn add @gravitee/ui-particles-angular@7.37.5-fix-gio-form-tags-input-fetch-on-focus-c34410c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-tjucadruyr.chromatic.com)
<!-- Storybook placeholder end -->
