### PR TITLE
feat: add init event emitter on monaco editor

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -19,11 +19,13 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   Inject,
   Input,
   NgZone,
   OnDestroy,
   Optional,
+  Output,
   Self,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
@@ -57,6 +59,9 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
 
   @Input()
   public options: editor.IStandaloneEditorConstructionOptions = {};
+
+  @Output()
+  public editorInit = new EventEmitter<editor.IStandaloneCodeEditor>();
 
   public loaded$ = new ReplaySubject<boolean>(1);
 
@@ -187,6 +192,7 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
     });
 
     this.setupLanguage(settings.uri, this.languageConfig);
+    this.editorInit.emit(this.standaloneCodeEditor);
   }
 
   private setupLanguage(uri: string, languageConfig?: MonacoEditorLanguageConfig) {


### PR DESCRIPTION
**Issue**

N.A. 

**Description**

Add output on monaco editor in order to be able to perform some actions when editor is loaded (for instance, setting focus in the text area).


<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.38.0-add-oninit-monaco-editor-3bf618b
```
```
yarn add @gravitee/ui-policy-studio-angular@7.38.0-add-oninit-monaco-editor-3bf618b
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-txcqtiianb.chromatic.com)
<!-- Storybook placeholder end -->
