### PR TITLE
fix: use type=btn on clipboard to prevent form submit

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-clipboard/gio-clipboard-copy-icon.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-clipboard/gio-clipboard-copy-icon.component.ts
@@ -23,6 +23,7 @@ import { GioClipboardComponent } from './gio-clipboard.base.component';
   template: `
     <button
       #tooltip="matTooltip"
+      type="button"
       class="btn"
       [attr.aria-label]="label"
       [class.clicked]="clicked"

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-clipboard/gio-clipboard-copy-wrapper.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-clipboard/gio-clipboard-copy-wrapper.component.ts
@@ -25,6 +25,7 @@ import { GioClipboardComponent } from './gio-clipboard.base.component';
     <ng-content></ng-content>
     <button
       #tooltip="matTooltip"
+      type="button"
       class="right"
       [attr.aria-label]="label"
       [class.clicked]="clicked"


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/COC-478

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.38.0-coc-478-sso-design-f9edfb4
```
```
yarn add @gravitee/ui-particles-angular@7.38.0-coc-478-sso-design-f9edfb4
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.38.0-coc-478-sso-design-f9edfb4
```
```
yarn add @gravitee/ui-policy-studio-angular@7.38.0-coc-478-sso-design-f9edfb4
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-yolvchuoyb.chromatic.com)
<!-- Storybook placeholder end -->
