### PR TITLE
Customize menu colors

### DIFF
--- a/ui-particles-angular/.stylelintrc.js
+++ b/ui-particles-angular/.stylelintrc.js
@@ -10,5 +10,6 @@ module.exports = {
         ignorePseudoElements: ['ng-deep'],
       },
     ],
+    'custom-property-pattern': ['-.*', '--.*'],
   },
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-footer/gio-menu-footer.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-footer/gio-menu-footer.component.scss
@@ -17,13 +17,17 @@
 @use '@angular/material' as mat;
 @use '../../../scss' as gio;
 
+$background: map.get(gio.$mat-oem-palette, background);
+$text: map.get(gio.$mat-oem-palette, background-contrast);
+$menu-border: color-mix(in srgb, $background 50%, $text);
+
 :host {
   flex-grow: 0;
 }
 
 .gio-menu-footer {
   padding: 16px;
-  border-top: 1px solid map.get(gio.$mat-space-palette, lighter40);
+  border-top: 1px solid $menu-border;
 }
 
 :host-context(.gio-menu__reduced) .gio-menu-footer {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-item/gio-menu-item.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-item/gio-menu-item.component.scss
@@ -18,10 +18,13 @@
 
 @use '../../../scss' as gio;
 
-$activeBackground: map.get(gio.$mat-space-palette, lighter30);
-$hoverBackground: map.get(gio.$mat-space-palette, lighter20);
-$background: map.get(gio.$mat-space-palette, lighter10);
-$text: map.get(gio.$mat-dove-palette, default);
+$activeBackground: map.get(gio.$mat-oem-palette, active);
+$activeText: map.get(gio.$mat-oem-palette, active-contrast);
+$hoverBackground: color-mix(in srgb, $activeBackground 50%, transparent);
+$hoverText: map.get(gio.$mat-oem-palette, active-contrast);
+$background: map.get(gio.$mat-oem-palette, background);
+$text: map.get(gio.$mat-oem-palette, background-contrast);
+$menu-border: color-mix(in srgb, $background 75%, $text);
 
 :host {
   display: block;
@@ -45,10 +48,11 @@ $text: map.get(gio.$mat-dove-palette, default);
 
   &__active {
     background: $activeBackground;
+    color: $activeText;
   }
 
   &__outlined {
-    border: 1px solid map.get(gio.$mat-space-palette, lighter40);
+    border: 1px solid $menu-border;
     border-radius: 4px;
   }
 
@@ -90,4 +94,5 @@ $text: map.get(gio.$mat-dove-palette, default);
 
 .gio-menu-item:hover:not(.gio-menu-item__active) {
   background: $hoverBackground;
+  color: $hoverText;
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.html
@@ -19,7 +19,7 @@
   <mat-form-field class="gio-menu-selector__mat-form-field" appearance="legacy">
     <mat-label>{{ selectorTitle }}</mat-label>
     <mat-select [tabIndex]="tabIndex" [value]="selectedItemValue" (selectionChange)="onSelectionChange($event)" [disabled]="isDisabled()">
-      <mat-option *ngFor="let item of selectorItems" [value]="item.value">
+      <mat-option class="gio-menu-selector__mat-option" *ngFor="let item of selectorItems" [value]="item.value">
         {{ item.displayValue }}
       </mat-option>
     </mat-select>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
@@ -17,14 +17,16 @@
 @use '@angular/material' as mat;
 @use '../../../scss' as gio;
 
-$background: map.get(gio.$mat-space-palette, lighter10);
-$text: map.get(gio.$mat-dove-palette, default);
+$background: map.get(gio.$mat-oem-palette, background);
+$text: map.get(gio.$mat-oem-palette, background-contrast);
+$menu-border: color-mix(in srgb, $background 75%, $text);
+$myActiveBackground: map.get(gio.$mat-oem-palette, active);
 
 .gio-menu-selector {
   width: 192px;
   padding: 10px 14px 0;
   border-style: solid;
-  border-color: map.get(gio.$mat-space-palette, lighter40);
+  border-color: $menu-border;
   border-radius: 4px;
   margin-bottom: 8px;
   color: $text;
@@ -34,16 +36,32 @@ $text: map.get(gio.$mat-dove-palette, default);
   }
 }
 
+.gio-menu-selector__mat-option.mat-option.mat-selected {
+  color: black; // select has white background so text should be dark
+}
+
 ::ng-deep {
   gio-menu-selector {
     .gio-menu-selector {
       > * {
         display: block;
       }
+    }
 
-      @include mat.select-color(gio.$mat-theme-dark);
-      @include mat.form-field-color(gio.$mat-theme-dark);
-      @include mat.core-color(gio.$mat-theme-dark);
+    .mat-form-field-label > mat-label {
+      color: $text;
+    }
+
+    .mat-select-min-line {
+      color: $text;
+    }
+
+    .gio-menu-selector .mat-form-field .mat-select-arrow {
+      color: $text;
+    }
+
+    .gio-menu-selector .mat-form-field.mat-focused.mat-primary .mat-select-arrow {
+      color: $text !important;
     }
   }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.component.scss
@@ -18,7 +18,7 @@
 
 @use '../../scss' as gio;
 
-$background: map.get(gio.$mat-space-palette, lighter10);
+$background: map.get(gio.$mat-oem-palette, background);
 
 .gio-menu {
   display: flex;

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-menu/gio-menu.stories.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { Args, Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { withDesign } from 'storybook-addon-designs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -54,27 +54,53 @@ const gioMenuContent = `
               <gio-menu-item tabindex="1" icon="gio:building" (click)="onClick('org')" [active]="isActive('org')">Organization settings</gio-menu-item>
             </gio-menu-footer>`;
 
+const colorArgTypes = {
+  darkMode: {
+    control: 'boolean',
+  },
+  menuBackground: {
+    control: 'color',
+  },
+  menuActive: {
+    control: 'color',
+  },
+};
+
+const computeStyle = (args: Args) => {
+  const darkMode = args.darkMode ?? true;
+  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, '#1c1e39', darkMode);
+  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, '#494b61', darkMode);
+  return backgroundStyle + activeStyle;
+};
+
+const computeStyleAndContrastByPrefix = (prefix: string, color: string, defaultColor: string, darkMode = true) => {
+  return `--gio-oem-palette--${prefix}:${color ?? defaultColor}; --gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
+};
+
 export const Default: Story = {
-  render: () => ({
-    template: `
-        <div id="sidenav">
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
+        <div id="sidenav" [style]="style">
           <gio-menu [reduced]="false">
             ${gioMenuContent}
           </gio-menu>
           <h1>Selected env: {{ selectedItemValue }}</h1>
         </div>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-      selectedItemValue: 'dev',
-      selectorItems: [
-        { value: 'prod', displayValue: '🚀 Prod' },
-        { value: 'dev', displayValue: '🧪 Development' },
-      ],
-    },
-    styles: [
-      ` 
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        selectedItemValue: 'dev',
+        selectorItems: [
+          { value: 'prod', displayValue: '🚀 Prod' },
+          { value: 'dev', displayValue: '🧪 Development' },
+        ],
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #sidenav {
             height: 956px;
             display: flex;
@@ -84,31 +110,35 @@ export const Default: Story = {
             margin-left: 12px
         };
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };
 
 export const Reduced: Story = {
-  render: () => ({
-    template: `
-        <div id="sidenav">
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
+        <div id="sidenav"  [style]="style">
           <gio-menu [reduced]="true">
             ${gioMenuContent}
           </gio-menu>
           <h1>Selected env: {{ selectedItemValue }}</h1>
         </div>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-      selectedItemValue: 'prod',
-      selectorItems: [
-        { value: 'prod', displayValue: '🚀 Prod' },
-        { value: 'dev', displayValue: '🧪 Development' },
-      ],
-    },
-    styles: [
-      ` 
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        selectedItemValue: 'prod',
+        selectorItems: [
+          { value: 'prod', displayValue: '🚀 Prod' },
+          { value: 'dev', displayValue: '🧪 Development' },
+        ],
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #sidenav {
             height: 956px;
             display: flex;
@@ -118,28 +148,32 @@ export const Reduced: Story = {
             margin-left: 12px
         };
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };
 
 export const WithOneItemInSelector: Story = {
-  render: () => ({
-    template: `
-        <div id="sidenav">
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
+        <div id="sidenav"  [style]="style">
           <gio-menu [reduced]="false">
             ${gioMenuContent}
           </gio-menu>
           <h1>Selected env: {{ selectedItemValue }}</h1>
         </div>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-      selectedItemValue: 'onlyOne',
-      selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-    },
-    styles: [
-      ` 
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        selectedItemValue: 'onlyOne',
+        selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #sidenav {
             height: 956px;
             display: flex;
@@ -149,14 +183,17 @@ export const WithOneItemInSelector: Story = {
             margin-left: 12px
         };
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };
 
 export const SmallMenu: Story = {
-  render: () => ({
-    template: `
-        <div id="sidenav">
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
+        <div id="sidenav"  [style]="style">
           <gio-menu>
             <gio-menu-header>    
               <gio-menu-selector tabindex="1" [selectedItemValue]="selectedItemValue" selectorTitle="Environment" [selectorItems]="selectorItems" (selectChange)="selectedItemValue=$event"></gio-menu-selector>
@@ -173,14 +210,15 @@ export const SmallMenu: Story = {
           <h1>Selected env: {{ selectedItemValue }}</h1>
         </div>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-      selectedItemValue: 'onlyOne',
-      selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-    },
-    styles: [
-      ` 
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        selectedItemValue: 'onlyOne',
+        selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #sidenav {
             height: 500px;
             display: flex;
@@ -190,8 +228,9 @@ export const SmallMenu: Story = {
             margin-left: 12px
         };
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };
 
 const gioSubmenuContent = `
@@ -221,9 +260,11 @@ const gioSubmenuContent = `
       <gio-submenu-item tabindex="1" (click)="onClick('audit')" [active]="isActive('audit')" iconRight="gio:lock">Audit</gio-submenu-item>`;
 
 export const WithSubMenu: Story = {
-  render: () => ({
-    template: `
-        <div id="sidenav">
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
+        <div id="sidenav"  [style]="style">
           <gio-menu [reduced]="false">
             ${gioMenuContent}
           </gio-menu>
@@ -233,16 +274,17 @@ export const WithSubMenu: Story = {
           <h1>Selected env: {{ selectedItemValue }}</h1>
         </div>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-      onSubClick: (target: string) => (subRoute = target),
-      isSubActive: (target: string) => (subRoute != target ? null : true),
-      selectedItemValue: 'onlyOne',
-      selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-    },
-    styles: [
-      ` 
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        onSubClick: (target: string) => (subRoute = target),
+        isSubActive: (target: string) => (subRoute != target ? null : true),
+        selectedItemValue: 'onlyOne',
+        selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #sidenav {
             height: 956px;
             display: flex;
@@ -252,14 +294,17 @@ export const WithSubMenu: Story = {
             margin-left: 12px
         };
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };
 
 export const ReducedWithSubMenu: Story = {
-  render: () => ({
-    template: `
-        <div id="sidenav">
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
+        <div id="sidenav" [style]="style">
           <gio-menu [reduced]="true">
             ${gioMenuContent}
           </gio-menu>
@@ -269,16 +314,17 @@ export const ReducedWithSubMenu: Story = {
           <h1>Selected env: {{ selectedItemValue }}</h1>
         </div>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-      onSubClick: (target: string) => (subRoute = target),
-      isSubActive: (target: string) => (subRoute != target ? null : true),
-      selectedItemValue: 'onlyOne',
-      selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-    },
-    styles: [
-      ` 
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        onSubClick: (target: string) => (subRoute = target),
+        isSubActive: (target: string) => (subRoute != target ? null : true),
+        selectedItemValue: 'onlyOne',
+        selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #sidenav {
             height: 956px;
             display: flex;
@@ -288,6 +334,7 @@ export const ReducedWithSubMenu: Story = {
             margin-left: 12px
         };
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-group/gio-submenu-group.component.scss
@@ -18,8 +18,10 @@
 
 @use '../../../scss' as gio;
 
-$text: map.get(gio.$mat-space-palette, lighter60);
-$text-light: mat.get-color-from-palette(gio.$mat-dove-palette, darker20);
+$menuText: map.get(gio.$mat-oem-palette, background-contrast);
+$text: color-mix(in srgb, $menuText 70%, black);
+$menuTextLight: map.get(gio.$mat-oem-palette-light, background-contrast);
+$textLight: color-mix(in srgb, $menuTextLight 70%, black);
 
 .gio-submenu-group {
   display: flex;
@@ -36,6 +38,6 @@ $text-light: mat.get-color-from-palette(gio.$mat-dove-palette, darker20);
   }
 
   &__title__light {
-    color: $text-light;
+    color: $textLight;
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-item/gio-submenu-item.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu-item/gio-submenu-item.component.scss
@@ -18,11 +18,17 @@
 
 @use '../../../scss' as gio;
 
-$activeBackground: map.get(gio.$mat-space-palette, lighter30);
-$hoverBackground: map.get(gio.$mat-space-palette, lighter20);
-$activeBackgroundLight: map.get(gio.$mat-accent-palette, default);
-$hoverBackgroundLight: map.get(gio.$mat-accent-palette, darker20);
-$textLight: map.get(gio.$mat-basic-palette, white);
+$activeBackground: map.get(gio.$mat-oem-palette, active);
+$activeText: map.get(gio.$mat-oem-palette, active-contrast);
+$hoverBackground: color-mix(in srgb, $activeBackground 50%, transparent);
+$hoverText: map.get(gio.$mat-oem-palette, active-contrast);
+$background: map.get(gio.$mat-oem-palette, background);
+$text: map.get(gio.$mat-oem-palette, background-contrast);
+$menu-border: color-mix(in srgb, $background 75%, $text);
+$activeBackgroundLight: map.get(gio.$mat-oem-palette-light, active);
+$activeTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
+$hoverBackgroundLight: color-mix(in srgb, $activeBackgroundLight 50%, transparent);
+$hoverTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
 
 :host {
   display: block;
@@ -48,14 +54,14 @@ $textLight: map.get(gio.$mat-basic-palette, white);
     height: 20px;
     flex: none;
     flex-grow: 0;
-    color: $textLight;
+    color: $text;
     letter-spacing: 0.4px;
   }
 
   &__icon-right {
     width: 20px;
     height: 20px;
-    color: $textLight;
+    color: $text;
     float: right;
   }
 }
@@ -66,12 +72,15 @@ $textLight: map.get(gio.$mat-basic-palette, white);
 
 :host-context(.gio-submenu__light) .gio-submenu-item__active {
   background: $activeBackgroundLight;
+  color: $activeTextLight;
 }
 
 .gio-submenu-item:hover:not(.gio-submenu-item__active) {
   background: $hoverBackground;
+  color: $hoverText;
 }
 
 :host-context(.gio-submenu__light) .gio-submenu-item:hover:not(.gio-submenu-item__active) {
   background: $hoverBackgroundLight;
+  color: $hoverTextLight;
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.component.scss
@@ -15,12 +15,13 @@
  */
 @use 'sass:map';
 @use '@angular/material' as mat;
-
 @use '../../scss' as gio;
 
-$background: map.get(gio.$mat-space-palette, default);
-$backgroundLight: map.get(gio.$mat-accent-palette, darker40);
-$textLight: map.get(gio.$mat-basic-palette, white);
+$menuBackground: map.get(gio.$mat-oem-palette, background);
+$background: color-mix(in srgb, $menuBackground 80%, black);
+$text: map.get(gio.$mat-oem-palette, background-contrast);
+$backgroundLight: map.get(gio.$mat-oem-palette-light, background);
+$textLight: map.get(gio.$mat-oem-palette-light, background-contrast);
 
 :host {
   z-index: 100;
@@ -63,7 +64,7 @@ $textLight: map.get(gio.$mat-basic-palette, white);
 
   &__title {
     padding-bottom: 8px;
-    color: $textLight;
+    color: $text;
   }
 
   .hide {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-submenu/gio-submenu.stories.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Meta, moduleMetadata } from '@storybook/angular';
+import { Args, Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { withDesign } from 'storybook-addon-designs';
 
@@ -33,9 +33,35 @@ export default {
 } as Meta;
 
 let route = 'plans';
+
+const colorArgTypes = {
+  darkMode: {
+    control: 'boolean',
+  },
+  menuBackground: {
+    control: 'color',
+  },
+  menuActive: {
+    control: 'color',
+  },
+};
+
+const computeStyle = (args: Args) => {
+  const darkMode = args.darkMode ?? true;
+  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, '#1c1e39', darkMode);
+  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, '#494b61', darkMode);
+  return backgroundStyle + activeStyle;
+};
+
+const computeStyleAndContrastByPrefix = (prefix: string, color: string, defaultColor: string, darkMode = true) => {
+  return `--gio-oem-palette--${prefix}:${color ?? defaultColor}; --gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
+};
+
 export const Default: Story = {
-  render: () => ({
-    template: `
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
         <gio-submenu [reduced]="false">
             <div gioSubmenuTitle>Submenu title</div>   
             <gio-submenu-item (click)="onClick('message')" [active]="isActive('message')">Message</gio-submenu-item>
@@ -63,16 +89,20 @@ export const Default: Story = {
             <gio-submenu-item (click)="onClick('audit')" [active]="isActive('audit')">Audit</gio-submenu-item>
         </gio-submenu>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-    },
-  }),
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        style: computeStyle(args),
+      },
+    };
+  },
 };
 
 export const Light: Story = {
-  render: () => ({
-    template: `
+  argTypes: colorArgTypes,
+  render: args => {
+    return {
+      template: `
         <gio-submenu theme="light" [reduced]="false">
             <div gioSubmenuTitle>Submenu title</div>   
             <gio-submenu-item (click)="onClick('message')" [active]="isActive('message')">Message</gio-submenu-item>
@@ -100,9 +130,11 @@ export const Light: Story = {
             <gio-submenu-item (click)="onClick('audit')" [active]="isActive('audit')">Audit</gio-submenu-item>
         </gio-submenu>
         `,
-    props: {
-      onClick: (target: string) => (route = target),
-      isActive: (target: string) => (route != target ? null : true),
-    },
-  }),
+      props: {
+        onClick: (target: string) => (route = target),
+        isActive: (target: string) => (route != target ? null : true),
+        style: computeStyle(args),
+      },
+    };
+  },
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette.scss
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '@angular/material' as mat;
+
+$mat-oem-palette: mat.define-palette(
+  (
+    // mat-space-palette lighter10
+    background: var(--gio-oem-palette--background, #1c1e39),
+    // mat-space-palette lighter30
+    active: var(--gio-oem-palette--active, #494b61),
+    contrast: (
+      background: var(--gio-oem-palette--background-contrast, #fff),
+      active: var(--gio-oem-palette--active-contrast, #fff),
+    )
+  ),
+  background,
+  background,
+  background
+);
+
+// palette used for gio-submenu (Organization menu in APIM) and is not customizable for now.
+$mat-oem-palette-light: mat.define-palette(
+  (
+    // mat-accent-palette darker40
+    background: #51438e,
+    // mat-accent-palette default
+    active: #876fec,
+    contrast: (
+      background: #fff,
+      active: #fff,
+    )
+  ),
+  background,
+  background,
+  background
+);

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/index.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/index.scss
@@ -17,6 +17,8 @@
 @forward './gio-mat-palettes' show $mat-primary-palette, $mat-accent-palette, $mat-success-palette, $mat-warning-palette, $mat-error-palette,
   $mat-method-palette, $mat-basic-palette, $mat-blue-palette, $mat-cyan-palette, $mat-space-palette, $mat-dove-palette;
 
+@forward './gio-oem-palette' show $mat-oem-palette, $mat-oem-palette-light;
+
 @forward './theme/typography/gio-typography' show subtitle-typography, code-typography, link-typography, caption-2;
 
 @forward './gio-mat-theme-variable' show $mat-theme, $mat-typography, $mat-theme-dark;


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3109

**Description**

Customize menu colors.

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.38.0-menu-customization-976b00f
```
```
yarn add @gravitee/ui-particles-angular@7.38.0-menu-customization-976b00f
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.38.0-menu-customization-976b00f
```
```
yarn add @gravitee/ui-policy-studio-angular@7.38.0-menu-customization-976b00f
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-zspivoyelw.chromatic.com)
<!-- Storybook placeholder end -->
