### PR TITLE
Apim 3111 adapt gio top bar

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-badge/gio-badge.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-badge/gio-badge.scss
@@ -18,6 +18,7 @@
 
 @use '../../scss/gio-mat-palettes.scss' as palettes;
 @use '../../scss/gio-mat-theme-variable' as theme;
+@use '../../scss/gio-oem-palette-variable' as oem;
 
 /**
  * Gravitee.io version of bootstrap "badge" element
@@ -111,5 +112,14 @@
 
     background-color: mat.get-color-from-palette(palettes.$mat-warning-palette, lighter);
     color: mat.get-color-from-palette(palettes.$mat-warning-palette, lighter-contrast);
+  }
+}
+
+// OEM Theme
+
+.gio-top-bar-menu {
+  .gio-badge-accent {
+    background-color: oem.$oem-top-bar-notification;
+    color: oem.$oem-top-bar-notification-contrast;
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-footer/gio-menu-footer.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-footer/gio-menu-footer.component.scss
@@ -15,10 +15,7 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$background: map.get(gio.$mat-oem-palette, background);
-$text: map.get(gio.$mat-oem-palette, background-contrast);
-$menu-border: color-mix(in srgb, $background 50%, $text);
+@use '../../../../scss/gio-oem-palette-variable' as oem;
 
 :host {
   flex-grow: 0;
@@ -26,7 +23,7 @@ $menu-border: color-mix(in srgb, $background 50%, $text);
 
 .gio-menu-footer {
   padding: 16px;
-  border-top: 1px solid $menu-border;
+  border-top: 1px solid oem.$oem-menu-border;
 }
 
 :host-context(.gio-menu__reduced) .gio-menu-footer {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-item/gio-menu-item.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-item/gio-menu-item.component.scss
@@ -15,14 +15,7 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$activeBackground: map.get(gio.$mat-oem-palette, active);
-$activeText: map.get(gio.$mat-oem-palette, active-contrast);
-$hoverBackground: color-mix(in srgb, $activeBackground 50%, transparent);
-$hoverText: map.get(gio.$mat-oem-palette, active-contrast);
-$background: map.get(gio.$mat-oem-palette, background);
-$text: map.get(gio.$mat-oem-palette, background-contrast);
-$menu-border: color-mix(in srgb, $background 75%, $text);
+@use '../../../../scss/gio-oem-palette-variable' as oem;
 
 :host {
   display: block;
@@ -40,17 +33,17 @@ $menu-border: color-mix(in srgb, $background 75%, $text);
   padding: 16px;
   border-radius: 4px;
   margin: 4px 0;
-  background: $background;
-  color: $text;
+  background: oem.$oem-menu-background;
+  color: oem.$oem-menu-text;
   cursor: pointer;
 
   &__active {
-    background: $activeBackground;
-    color: $activeText;
+    background: oem.$oem-menu-active;
+    color: oem.$oem-menu-active-text;
   }
 
   &__outlined {
-    border: 1px solid $menu-border;
+    border: 1px solid oem.$oem-menu-border;
     border-radius: 4px;
   }
 
@@ -91,6 +84,6 @@ $menu-border: color-mix(in srgb, $background 75%, $text);
 }
 
 .gio-menu-item:hover:not(.gio-menu-item__active) {
-  background: $hoverBackground;
-  color: $hoverText;
+  background: oem.$oem-menu-hover;
+  color: oem.$oem-menu-hover-text;
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
@@ -15,20 +15,16 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$background: map.get(gio.$mat-oem-palette, background);
-$text: map.get(gio.$mat-oem-palette, background-contrast);
-$menu-border: color-mix(in srgb, $background 75%, $text);
-$myActiveBackground: map.get(gio.$mat-oem-palette, active);
+@use '../../../../scss/gio-oem-palette-variable' as oem;
 
 .gio-menu-selector {
   width: 192px;
   padding: 10px 14px 0;
   border-style: solid;
-  border-color: $menu-border;
+  border-color: oem.$oem-menu-border;
   border-radius: 4px;
   margin-bottom: 8px;
-  color: $text;
+  color: oem.$oem-menu-text;
 
   &__mat-form-field {
     padding-bottom: 0;
@@ -48,19 +44,19 @@ $myActiveBackground: map.get(gio.$mat-oem-palette, active);
     }
 
     .mat-form-field-label > mat-label {
-      color: $text;
+      color: oem.$oem-menu-text;
     }
 
     .mat-select-min-line {
-      color: $text;
+      color: oem.$oem-menu-text;
     }
 
     .gio-menu-selector .mat-form-field .mat-select-arrow {
-      color: $text;
+      color: oem.$oem-menu-text;
     }
 
     .gio-menu-selector .mat-form-field.mat-focused.mat-primary .mat-select-arrow {
-      color: $text !important;
+      color: oem.$oem-menu-text !important;
     }
   }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu.component.scss
@@ -15,8 +15,7 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$background: map.get(gio.$mat-oem-palette, background);
+@use '../../../scss/gio-oem-palette-variable' as oem;
 
 .gio-menu {
   display: flex;
@@ -25,7 +24,7 @@ $background: map.get(gio.$mat-oem-palette, background);
   flex-direction: column;
   justify-content: flex-start;
   padding: 16px 0 0;
-  background: $background;
+  background: oem.$oem-menu-background;
 
   &__reduced {
     width: 76px;

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu.stories.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Args, Meta, moduleMetadata } from '@storybook/angular';
+import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { withDesign } from 'storybook-addon-designs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { GioSubmenuModule } from '../gio-submenu';
+import { COLOR_ARG_TYPES, computeStyle } from '../oem-theme-shared';
 
 import { GioMenuModule } from './gio-menu.module';
 import { GioMenuItemComponent } from './gio-menu-item/gio-menu-item.component';
@@ -28,7 +29,7 @@ export default {
   component: GioMenuItemComponent,
   decorators: [
     moduleMetadata({
-      imports: [GioMenuModule, NoopAnimationsModule, GioSubmenuModule],
+      imports: [GioMenuModule, GioSubmenuModule, NoopAnimationsModule],
     }),
     withDesign,
   ],
@@ -54,31 +55,8 @@ const gioMenuContent = `
               <gio-menu-item tabindex="1" icon="gio:building" (click)="onClick('org')" [active]="isActive('org')">Organization settings</gio-menu-item>
             </gio-menu-footer>`;
 
-const colorArgTypes = {
-  darkMode: {
-    control: 'boolean',
-  },
-  menuBackground: {
-    control: 'color',
-  },
-  menuActive: {
-    control: 'color',
-  },
-};
-
-const computeStyle = (args: Args) => {
-  const darkMode = args.darkMode ?? true;
-  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, '#1c1e39', darkMode);
-  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, '#494b61', darkMode);
-  return backgroundStyle + activeStyle;
-};
-
-const computeStyleAndContrastByPrefix = (prefix: string, color: string, defaultColor: string, darkMode = true) => {
-  return `--gio-oem-palette--${prefix}:${color ?? defaultColor}; --gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
-};
-
 export const Default: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
@@ -116,7 +94,7 @@ export const Default: Story = {
 };
 
 export const Reduced: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
@@ -154,7 +132,7 @@ export const Reduced: Story = {
 };
 
 export const WithOneItemInSelector: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
@@ -189,7 +167,7 @@ export const WithOneItemInSelector: Story = {
 };
 
 export const SmallMenu: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
@@ -260,7 +238,7 @@ const gioSubmenuContent = `
       <gio-submenu-item tabindex="1" (click)="onClick('audit')" [active]="isActive('audit')" iconRight="gio:lock">Audit</gio-submenu-item>`;
 
 export const WithSubMenu: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
@@ -300,7 +278,7 @@ export const WithSubMenu: Story = {
 };
 
 export const ReducedWithSubMenu: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu-group/gio-submenu-group.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu-group/gio-submenu-group.component.scss
@@ -15,11 +15,7 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$menuText: map.get(gio.$mat-oem-palette, background-contrast);
-$text: color-mix(in srgb, $menuText 70%, black);
-$menuTextLight: map.get(gio.$mat-oem-palette-light, background-contrast);
-$textLight: color-mix(in srgb, $menuTextLight 70%, black);
+@use '../../../../scss/gio-oem-palette-variable' as oem;
 
 .gio-submenu-group {
   display: flex;
@@ -31,11 +27,11 @@ $textLight: color-mix(in srgb, $menuTextLight 70%, black);
     padding: 8px 12px;
     border-radius: 4px;
     margin: 1px 0;
-    color: $text;
+    color: oem.$oem-sub-menu-title;
     letter-spacing: 0.4px;
   }
 
   &__title__light {
-    color: $textLight;
+    color: oem.$oem-light-sub-menu-title;
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu-item/gio-submenu-item.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu-item/gio-submenu-item.component.scss
@@ -15,18 +15,7 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$activeBackground: map.get(gio.$mat-oem-palette, active);
-$activeText: map.get(gio.$mat-oem-palette, active-contrast);
-$hoverBackground: color-mix(in srgb, $activeBackground 50%, transparent);
-$hoverText: map.get(gio.$mat-oem-palette, active-contrast);
-$background: map.get(gio.$mat-oem-palette, background);
-$text: map.get(gio.$mat-oem-palette, background-contrast);
-$menu-border: color-mix(in srgb, $background 75%, $text);
-$activeBackgroundLight: map.get(gio.$mat-oem-palette-light, active);
-$activeTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
-$hoverBackgroundLight: color-mix(in srgb, $activeBackgroundLight 50%, transparent);
-$hoverTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
+@use '../../../../scss/gio-oem-palette-variable' as oem;
 
 :host {
   display: block;
@@ -44,7 +33,7 @@ $hoverTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
   cursor: pointer;
 
   &__active {
-    background: $activeBackground;
+    background: oem.$oem-menu-active;
   }
 
   &__title {
@@ -52,14 +41,14 @@ $hoverTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
     height: 20px;
     flex: none;
     flex-grow: 0;
-    color: $text;
+    color: oem.$oem-menu-text;
     letter-spacing: 0.4px;
   }
 
   &__icon-right {
     width: 20px;
     height: 20px;
-    color: $text;
+    color: oem.$oem-menu-text;
     float: right;
   }
 }
@@ -68,17 +57,19 @@ $hoverTextLight: map.get(gio.$mat-oem-palette-light, active-contrast);
   padding: 8px 20px;
 }
 
-:host-context(.gio-submenu__light) .gio-submenu-item__active {
-  background: $activeBackgroundLight;
-  color: $activeTextLight;
-}
-
 .gio-submenu-item:hover:not(.gio-submenu-item__active) {
-  background: $hoverBackground;
-  color: $hoverText;
+  background: oem.$oem-menu-hover;
+  color: oem.$oem-menu-hover-text;
 }
 
-:host-context(.gio-submenu__light) .gio-submenu-item:hover:not(.gio-submenu-item__active) {
-  background: $hoverBackgroundLight;
-  color: $hoverTextLight;
+:host-context(.gio-submenu__light) {
+  .gio-submenu-item__active {
+    background: oem.$oem-light-menu-selected;
+    color: oem.$oem-light-menu-text;
+  }
+
+  .gio-submenu-item:hover:not(.gio-submenu-item__active) {
+    background: oem.$oem-light-menu-hover;
+    color: oem.$oem-light-menu-text;
+  }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.component.scss
@@ -15,12 +15,7 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
-
-$menuBackground: map.get(gio.$mat-oem-palette, background);
-$background: color-mix(in srgb, $menuBackground 80%, black);
-$text: map.get(gio.$mat-oem-palette, background-contrast);
-$backgroundLight: map.get(gio.$mat-oem-palette-light, background);
-$textLight: map.get(gio.$mat-oem-palette-light, background-contrast);
+@use '../../../scss/gio-oem-palette-variable' as oem;
 
 :host {
   z-index: 100;
@@ -35,10 +30,10 @@ $textLight: map.get(gio.$mat-oem-palette-light, background-contrast);
   flex-grow: 0;
   justify-content: flex-start;
   padding: 16px;
-  background: $background;
+  background: oem.$oem-sub-menu-background;
 
   &__light {
-    background: $backgroundLight;
+    background: oem.$oem-light-menu-background;
   }
 
   &__reduced {
@@ -63,7 +58,7 @@ $textLight: map.get(gio.$mat-oem-palette-light, background-contrast);
 
   &__title {
     padding-bottom: 8px;
-    color: $text;
+    color: oem.$oem-menu-text;
   }
 
   .hide {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.stories.ts
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Args, Meta, moduleMetadata } from '@storybook/angular';
+import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { withDesign } from 'storybook-addon-designs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { GioSubmenuGroupComponent } from '@gravitee/ui-particles-angular';
 
-import { GioSubmenuGroupComponent } from './gio-submenu-group/gio-submenu-group.component';
+import { COLOR_ARG_TYPES, computeStyle } from '../oem-theme-shared';
+
 import { GioSubmenuModule } from './gio-submenu.module';
 
 export default {
@@ -25,7 +28,7 @@ export default {
   component: GioSubmenuGroupComponent,
   decorators: [
     moduleMetadata({
-      imports: [GioSubmenuModule],
+      imports: [GioSubmenuModule, NoopAnimationsModule],
     }),
     withDesign,
   ],
@@ -34,35 +37,13 @@ export default {
 
 let route = 'plans';
 
-const colorArgTypes = {
-  darkMode: {
-    control: 'boolean',
-  },
-  menuBackground: {
-    control: 'color',
-  },
-  menuActive: {
-    control: 'color',
-  },
-};
-
-const computeStyle = (args: Args) => {
-  const darkMode = args.darkMode ?? true;
-  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, '#1c1e39', darkMode);
-  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, '#494b61', darkMode);
-  return backgroundStyle + activeStyle;
-};
-
-const computeStyleAndContrastByPrefix = (prefix: string, color: string, defaultColor: string, darkMode = true) => {
-  return `--gio-oem-palette--${prefix}:${color ?? defaultColor}; --gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
-};
-
 export const Default: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
-        <gio-submenu [reduced]="false">
+<div [style]="style">
+        <gio-submenu >
             <div gioSubmenuTitle>Submenu title</div>   
             <gio-submenu-item (click)="onClick('message')" [active]="isActive('message')">Message</gio-submenu-item>
             <gio-submenu-group title="Portal">
@@ -88,6 +69,7 @@ export const Default: Story = {
             </gio-submenu-group>
             <gio-submenu-item (click)="onClick('audit')" [active]="isActive('audit')">Audit</gio-submenu-item>
         </gio-submenu>
+        </div>
         `,
       props: {
         onClick: (target: string) => (route = target),
@@ -99,11 +81,12 @@ export const Default: Story = {
 };
 
 export const Light: Story = {
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
-        <gio-submenu theme="light" [reduced]="false">
+<div [style]="style">
+        <gio-submenu theme="light" >
             <div gioSubmenuTitle>Submenu title</div>   
             <gio-submenu-item (click)="onClick('message')" [active]="isActive('message')">Message</gio-submenu-item>
             <gio-submenu-group title="Portal" theme="light">
@@ -129,6 +112,7 @@ export const Light: Story = {
             </gio-submenu-group>
             <gio-submenu-item (click)="onClick('audit')" [active]="isActive('audit')">Audit</gio-submenu-item>
         </gio-submenu>
+        </div>
         `,
       props: {
         onClick: (target: string) => (route = target),

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar-content/gio-top-bar-content.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar-content/gio-top-bar-content.component.scss
@@ -18,7 +18,8 @@
 
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
 
-$background: map.get(gio.$mat-theme, background);
+@use '../../../../scss/gio-oem-palette-variable' as oem;
+
 $typography: map.get(gio.$mat-theme, typography);
 
 .gio-top-bar-content {
@@ -37,8 +38,8 @@ $typography: map.get(gio.$mat-theme, typography);
   }
 
   &.apim {
-    background: rgb(0 111 185 / 50%);
-    color: map.get(gio.$mat-cyan-palette, default-contrast);
+    background: oem.$oem-top-bar-apim-button-background;
+    color: oem.$oem-menu-text;
   }
 
   &.cockpit {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar-link/gio-top-bar-link.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar-link/gio-top-bar-link.component.scss
@@ -16,6 +16,7 @@
 @use 'sass:map';
 @use '@angular/material' as mat;
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
+@use '../../../../scss/gio-oem-palette-variable' as oem;
 
 $typography: map.get(gio.$mat-theme, typography);
 
@@ -27,7 +28,7 @@ $typography: map.get(gio.$mat-theme, typography);
   @include mat.typography-level($typography, body-2);
 
   height: 20px;
-  color: map.get(gio.$mat-dove-palette, default);
+  color: oem.$oem-menu-text;
   letter-spacing: 0.4px;
   text-decoration: none;
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar-menu/gio-top-bar-menu.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar-menu/gio-top-bar-menu.component.scss
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@use '../../../../scss/gio-oem-palette-variable' as oem;
+
 :host {
   flex-grow: 1;
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar.component.scss
@@ -15,8 +15,8 @@
  */
 @use 'sass:map';
 @use 'ui-particles-angular/projects/ui-particles-angular/index' as gio;
+@use '../../../scss/gio-oem-palette-variable' as oem;
 
-$background: map.get(gio.$mat-theme, background);
 $typography: map.get(gio.$mat-theme, typography);
 
 :host {
@@ -32,7 +32,7 @@ $typography: map.get(gio.$mat-theme, typography);
       line-height: 36px;
 
       &:hover {
-        background: map.get(gio.$mat-space-palette, lighter20);
+        background: oem.$oem-menu-hover;
       }
     }
   }
@@ -42,7 +42,8 @@ $typography: map.get(gio.$mat-theme, typography);
   display: flex;
   align-items: center;
   padding: 16px;
-  background: map.get(gio.$mat-space-palette, lighter10);
-  color: map.get(gio.$mat-dove-palette, default);
+  border-bottom: 1px solid oem.$oem-menu-border;
+  background: oem.$oem-menu-background;
+  color: oem.$oem-menu-text;
   gap: 18px;
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar.stories.ts
@@ -20,6 +20,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 
 import { GioIconsModule } from '../../gio-icons/gio-icons.module';
+import { COLOR_ARG_TYPES, computeStyle } from '../oem-theme-shared';
 
 import { GioTopBarComponent } from './gio-top-bar.component';
 import { GioTopBarModule } from './gio-top-bar.module';
@@ -39,11 +40,13 @@ export default {
 } as Meta;
 
 export const Default: Story = {
-  render: () => ({
-    template: `
-        <div id="main">
+  argTypes: COLOR_ARG_TYPES,
+  render: args => {
+    return {
+      template: `
+        <div id="main" [style]="style">
           <gio-top-bar>
-            <button mat-icon-button gioTopBarHome>
+            <button mat-icon-button>
               <mat-icon svgIcon="gio:gravitee" (click)="click('am')"></mat-icon>
             </button>
             <gio-top-bar-content type="am" productName="Access Management"></gio-top-bar-content>
@@ -58,7 +61,7 @@ export const Default: Story = {
             </gio-top-bar-menu>
           </gio-top-bar>
           <gio-top-bar>
-            <button mat-icon-button gioTopBarHome>
+            <button mat-icon-button>
               <mat-icon svgIcon="gio:gravitee" (click)="click('apim')"></mat-icon>
             </button>
             <gio-top-bar-content type="apim" productName="API Management"></gio-top-bar-content>
@@ -74,7 +77,7 @@ export const Default: Story = {
             </gio-top-bar-menu>
           </gio-top-bar>
           <gio-top-bar>
-            <button mat-icon-button gioTopBarHome>
+            <button mat-icon-button>
               <mat-icon svgIcon="gio:gravitee" (click)="click('cockpit')"></mat-icon>
             </button>
             <gio-top-bar-content type="cockpit" productName="Cockpit"></gio-top-bar-content>
@@ -90,11 +93,12 @@ export const Default: Story = {
           </gio-top-bar>
         </div>
         `,
-    props: {
-      click: (product: string) => alert('click on ' + product),
-    },
-    styles: [
-      ` 
+      props: {
+        click: (product: string) => alert('click on ' + product),
+        style: computeStyle(args),
+      },
+      styles: [
+        ` 
         #main {
             padding: 16px;
             display: flex;
@@ -115,6 +119,7 @@ export const Default: Story = {
         }
 
         `,
-    ],
-  }),
+      ],
+    };
+  },
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-menu-and-top-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-menu-and-top-bar.stories.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Args, Meta, moduleMetadata } from '@storybook/angular';
+import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { withDesign } from 'storybook-addon-designs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -25,6 +25,7 @@ import { GioSubmenuModule } from './gio-submenu';
 import { GioMenuModule } from './gio-menu';
 import { GioMenuItemComponent } from './gio-menu/gio-menu-item/gio-menu-item.component';
 import { GioTopBarLinkModule, GioTopBarMenuModule, GioTopBarModule } from './gio-top-bar';
+import { COLOR_ARG_TYPES, computeStyle } from './oem-theme-shared';
 
 export default {
   title: 'OEM Theme',
@@ -116,40 +117,15 @@ const gioSubmenuContent = `
             <gio-submenu-item (click)="onSubClick('audit')" [active]="isActive('audit')">Audit</gio-submenu-item>
 `;
 
-const colorArgTypes = {
-  darkMode: {
-    control: 'boolean',
-  },
-  menuBackground: {
-    control: 'color',
-  },
-  menuActive: {
-    control: 'color',
-  },
-};
-
-const computeStyle = (args: Args) => {
-  const darkMode = args.darkMode ?? true;
-  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, '#1c1e39', darkMode);
-  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, '#494b61', darkMode);
-  return backgroundStyle + activeStyle;
-};
-
-const computeStyleAndContrastByPrefix = (prefix: string, color: string, defaultColor: string, darkMode = true) => {
-  return `--gio-oem-palette--${prefix}:${color ?? defaultColor}; --gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
-};
-
 export const Default: Story = {
   name: 'Menu and Top Bar',
-  argTypes: colorArgTypes,
+  argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {
       template: `
-<div>
-    <div>
+<div [style]="style">
         ${gioTopBarContent}
-    </div>
-    <div id="sidenav" [style]="style">
+    <div id="sidenav" >
         <gio-menu [reduced]="false">
           ${gioMenuContent}
         </gio-menu>
@@ -215,7 +191,7 @@ export const Default: Story = {
         }
         
         .api-name {
-          border-left: 1px solid var(--gio-oem-palette--background-contrast); 
+          border-left: 1px solid var(--gio-oem-palette--background-contrast, #fff); 
           padding-left: 12px;
         }
         `,

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-shared.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-shared.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Args } from '@storybook/angular';
+
+const COLOR_ARG_TYPES = {
+  darkMode: {
+    control: 'boolean',
+  },
+  menuBackground: {
+    control: 'color',
+  },
+  menuActive: {
+    control: 'color',
+  },
+};
+
+const computeStyle = (args: Args) => {
+  const darkMode = args.darkMode ?? true;
+  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, darkMode);
+  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, darkMode);
+  let subMenu = '';
+  // If the menu background is defined, then define the sub-menu color
+  if (args.menuBackground) {
+    subMenu = `--gio-oem-palette--sub-menu:color-mix(in srgb, ${args.menuBackground} 80%, black); `;
+  }
+  return backgroundStyle + activeStyle + subMenu;
+};
+
+const computeStyleAndContrastByPrefix = (prefix: string, color: string, darkMode = true) => {
+  if (!color) {
+    return '';
+  }
+  const paletteColor = `--gio-oem-palette--${prefix}:${color}; `;
+  const paletteColorContrast = `--gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
+  return paletteColor + paletteColorContrast;
+};
+
+export { computeStyle, COLOR_ARG_TYPES };

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette-variable.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette-variable.scss
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@use './gio-oem-palette' as palette;
+@use './gio-mat-palettes' as gio;
+
+// Menu
+$oem-menu-active: map.get(palette.$mat-oem-palette, active);
+$oem-menu-active-text: map.get(palette.$mat-oem-palette, active-contrast);
+$oem-menu-hover: color-mix(in srgb, $oem-menu-active 50%, transparent);
+$oem-menu-hover-text: map.get(palette.$mat-oem-palette, active-contrast);
+$oem-menu-background: map.get(palette.$mat-oem-palette, background);
+$oem-menu-text: map.get(palette.$mat-oem-palette, background-contrast);
+$oem-menu-border: color-mix(in srgb, $oem-menu-background 75%, $oem-menu-text);
+
+// Sub Menu
+$oem-sub-menu-background: var(--gio-oem-palette--sub-menu, map.get(gio.$mat-space-palette, default));
+$oem-sub-menu-title: color-mix(in srgb, $oem-menu-text 70%, black);
+
+// Top Bar
+$oem-top-bar-notification: var(--gio-oem-palette--active, map.get(gio.$mat-accent-palette, lighter80));
+$oem-top-bar-notification-contrast: var(--gio-oem-palette--active-contrast, map.get(gio.$mat-space-palette, default));
+$oem-top-bar-apim-button-background: var(--gio-oem-palette--sub-menu, rgb(0 111 185 / 50%));
+
+// Light
+$oem-light-menu-background: map.get(palette.$mat-oem-palette-light, background);
+$oem-light-menu-selected: map.get(palette.$mat-oem-palette-light, active);
+$oem-light-menu-text: map.get(palette.$mat-oem-palette-light, active-contrast);
+$oem-light-menu-hover: color-mix(in srgb, $oem-light-menu-selected 50%, transparent);
+$oem-light-sub-menu-title: color-mix(in srgb, $oem-light-menu-text 70%, black);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/3111

**Description**

- Refactoring to centralize shared content / standardize variables
- Add oem customization to top bar 

Default: 

![Screenshot 2023-11-02 at 16 55 26](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/9243e76c-b520-4e13-8365-7d6be080c8ca)

Dark mode:

![Screenshot 2023-11-02 at 16 56 02](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/11960a80-f7b9-475e-82d5-8f1ff26562c8)

Light mode:

![Screenshot 2023-11-02 at 16 56 53](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/37989044-de04-4cd0-8648-cee26d6dfbfe)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.42.0-apim-3111-adapt-gio-top-bar-4c8bd1b
```
```
yarn add @gravitee/ui-policy-studio-angular@7.42.0-apim-3111-adapt-gio-top-bar-4c8bd1b
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.42.0-apim-3111-adapt-gio-top-bar-4c8bd1b
```
```
yarn add @gravitee/ui-particles-angular@7.42.0-apim-3111-adapt-gio-top-bar-4c8bd1b
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-yzpzomcrvx.chromatic.com)
<!-- Storybook placeholder end -->
