### PR TITLE
Apim 2952 add doc and remove dark mode

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/README.stories.mdx
@@ -1,15 +1,31 @@
-import { Meta, Story } from '@storybook/addon-docs';
+import { Meta } from '@storybook/addon-docs';
 
 <Meta title="OEM Theme / README" />
 
 # OEM Theme
 
-TODO: Fill out documentation to inform the user how to use the OEM Theme Customization.
+## Overview
 
-New stories to add:
-- logo
-- favicon
-- `<head>` title text
-- newsletter
-- loading icon
-- disable documentation
+With an OEM License, the user can customize the theme of the APIM Console.
+
+🚧 Coming soon: Find out more about the OEM License and how to integrate the license into your current Gravitee environment 🚧
+
+## Menu + Top Bar
+
+The color of the Menu + Top Bar is customizable with two specifications: `menuBackground` and `menuActive`.
+
+The `menuBackground` property designates the color of the main panel and top bar of the component. This is also the color that the sub-menu is based upon.
+
+The `menuActive` is the color of the active menu item as well as the notification color in the top bar. Hovers over menu items are also calculated from the `menuActive` value.
+
+You can test color combinations in the [ Menu + Top Bar](../?path=/story/oem-theme-menu-top-bar--default) with the Controls included in the story.
+
+🚧 For now, only white text is possible for menu customization. 🚧
+
+
+## Logo
+## Favicon
+## `<head>` Title Text
+## Newsletter
+## Loading Icon
+## Disable Gravitee Documentation

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-menu-and-top-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-menu-and-top-bar.stories.ts
@@ -28,7 +28,7 @@ import { GioTopBarLinkModule, GioTopBarMenuModule, GioTopBarModule } from './gio
 import { COLOR_ARG_TYPES, computeStyle } from './oem-theme-shared';
 
 export default {
-  title: 'OEM Theme',
+  title: 'OEM Theme / Menu + Top Bar',
   component: GioMenuItemComponent,
   decorators: [
     moduleMetadata({
@@ -118,7 +118,6 @@ const gioSubmenuContent = `
 `;
 
 export const Default: Story = {
-  name: 'Menu and Top Bar',
   argTypes: COLOR_ARG_TYPES,
   render: args => {
     return {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-shared.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-shared.ts
@@ -16,9 +16,6 @@
 import { Args } from '@storybook/angular';
 
 const COLOR_ARG_TYPES = {
-  darkMode: {
-    control: 'boolean',
-  },
   menuBackground: {
     control: 'color',
   },
@@ -28,9 +25,8 @@ const COLOR_ARG_TYPES = {
 };
 
 const computeStyle = (args: Args) => {
-  const darkMode = args.darkMode ?? true;
-  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground, darkMode);
-  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive, darkMode);
+  const backgroundStyle = computeStyleAndContrastByPrefix('background', args.menuBackground);
+  const activeStyle = computeStyleAndContrastByPrefix('active', args.menuActive);
   let subMenu = '';
   // If the menu background is defined, then define the sub-menu color
   if (args.menuBackground) {
@@ -39,12 +35,12 @@ const computeStyle = (args: Args) => {
   return backgroundStyle + activeStyle + subMenu;
 };
 
-const computeStyleAndContrastByPrefix = (prefix: string, color: string, darkMode = true) => {
+const computeStyleAndContrastByPrefix = (prefix: string, color: string) => {
   if (!color) {
     return '';
   }
   const paletteColor = `--gio-oem-palette--${prefix}:${color}; `;
-  const paletteColorContrast = `--gio-oem-palette--${prefix}-contrast:${darkMode ? '#fff' : '#100c27'}; `;
+  const paletteColorContrast = `--gio-oem-palette--${prefix}-contrast: #fff; `;
   return paletteColor + paletteColorContrast;
 };
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2952

**Description**

Remove dark mode option for now for OEM menu.
Add documentation for color customization of OEM menu.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.43.0-apim-2952-add-doc-and-remove-dark-mode-6ef480b
```
```
yarn add @gravitee/ui-particles-angular@7.43.0-apim-2952-add-doc-and-remove-dark-mode-6ef480b
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.43.0-apim-2952-add-doc-and-remove-dark-mode-6ef480b
```
```
yarn add @gravitee/ui-policy-studio-angular@7.43.0-apim-2952-add-doc-and-remove-dark-mode-6ef480b
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-yrbkqudipu.chromatic.com)
<!-- Storybook placeholder end -->
