### PR TITLE
feat(oem): customize light submenu

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/README.stories.mdx
@@ -14,9 +14,10 @@ With an OEM License, the user can customize the theme of the APIM Console.
 
 The color of the Menu + Top Bar is customizable with two specifications: `menuBackground` and `menuActive`.
 
-The `menuBackground` property designates the color of the main panel and top bar of the component. This is also the color that the sub-menu is based upon.
+The `menuBackground` property designates the color of the main panel and top bar of the component. This is also the color that the main sub-menu is based upon.
 
 The `menuActive` is the color of the active menu item as well as the notification color in the top bar. Hovers over menu items are also calculated from the `menuActive` value.
+This value is also used as the basis for the [Light Submenu](../?path=/story/oem-theme-submenu--light).
 
 You can test color combinations in the [ Menu + Top Bar](../?path=/story/oem-theme-menu-top-bar--default) with the Controls included in the story.
 
@@ -26,6 +27,4 @@ You can test color combinations in the [ Menu + Top Bar](../?path=/story/oem-the
 ## Logo
 ## Favicon
 ## `<head>` Title Text
-## Newsletter
-## Loading Icon
 ## Disable Gravitee Documentation

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette-variable.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette-variable.scss
@@ -38,8 +38,8 @@ $oem-top-bar-notification-contrast: var(--gio-oem-palette--active-contrast, map.
 $oem-top-bar-apim-button-background: var(--gio-oem-palette--sub-menu, rgb(0 111 185 / 50%));
 
 // Light
-$oem-light-menu-background: map.get(palette.$mat-oem-palette-light, background);
-$oem-light-menu-selected: map.get(palette.$mat-oem-palette-light, active);
-$oem-light-menu-text: map.get(palette.$mat-oem-palette-light, active-contrast);
-$oem-light-menu-hover: color-mix(in srgb, $oem-light-menu-selected 50%, transparent);
+$oem-light-menu-selected: var(--gio-oem-palette--active, map.get(gio.$mat-accent-palette, default));
+$oem-light-menu-background: color-mix(in srgb, $oem-light-menu-selected 60%, black);
+$oem-light-menu-text: map.get(palette.$mat-oem-palette, active-contrast);
+$oem-light-menu-hover: color-mix(in srgb, $oem-light-menu-selected 80%, black);
 $oem-light-sub-menu-title: color-mix(in srgb, $oem-light-menu-text 70%, black);

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette.scss
@@ -30,20 +30,3 @@ $mat-oem-palette: mat.define-palette(
   background,
   background
 );
-
-// palette used for gio-submenu (Organization menu in APIM) and is not customizable for now.
-$mat-oem-palette-light: mat.define-palette(
-  (
-    // mat-accent-palette darker40
-    background: #51438e,
-    // mat-accent-palette default
-    active: #876fec,
-    contrast: (
-      background: #fff,
-      active: #fff,
-    )
-  ),
-  background,
-  background,
-  background
-);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3236

**Description**

Customize light sub-menu for oem 

Default: 

![Screenshot 2023-11-07 at 09 51 37](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/aba2f86a-bd15-46c9-8600-d2c2d69dc4f8)

Customized:

![Screenshot 2023-11-07 at 09 51 17](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/354e8b14-0153-46ea-83e4-e5bda5b32ae3)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.44.0-apim-3236-customize-light-sub-menu-05df2e9
```
```
yarn add @gravitee/ui-policy-studio-angular@7.44.0-apim-3236-customize-light-sub-menu-05df2e9
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-junvfyrfap.chromatic.com)
<!-- Storybook placeholder end -->
