### PR TITLE
fix: remove unnecessary HttpClientModule

### DIFF
--- a/ui-particles-angular/.storybook/preview.ts
+++ b/ui-particles-angular/.storybook/preview.ts
@@ -1,6 +1,7 @@
 // Set material classes to the Storybook body
 import { moduleMetadata } from '@storybook/angular';
 import { GioMatConfigModule } from '../projects/ui-particles-angular/src/lib/gio-mat-config';
+import { HttpClientModule } from '@angular/common/http';
 
 window.document.body?.classList.add('mat-app-background');
 window.document.body?.classList.add('mat-typography');
@@ -31,4 +32,4 @@ export const parameters = {
   },
 };
 
-export const decorators = [moduleMetadata({ imports: [GioMatConfigModule] })];
+export const decorators = [moduleMetadata({ imports: [GioMatConfigModule, HttpClientModule] })];

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-asciidoctor/gio-asciidoctor.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-asciidoctor/gio-asciidoctor.module.ts
@@ -15,12 +15,11 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
 
 import { GioAsciidoctorComponent } from './gio-asciidoctor.component';
 
 @NgModule({
-  imports: [CommonModule, HttpClientModule],
+  imports: [CommonModule],
   declarations: [GioAsciidoctorComponent],
   exports: [GioAsciidoctorComponent],
 })

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.module.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-banner/gio-banner.module.spec.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { GioBannerComponent } from './gio-banner.component';
 import { GioBannerModule } from './gio-banner.module';
@@ -24,7 +25,7 @@ describe('GioBannerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioBannerModule],
+      imports: [NoopAnimationsModule, HttpClientTestingModule, GioBannerModule],
     });
     fixture = TestBed.createComponent(GioBannerComponent);
   });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-icons/gio-icons.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-icons/gio-icons.module.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @NgModule({
-  imports: [CommonModule, HttpClientModule, MatIconModule],
+  imports: [CommonModule, MatIconModule],
   exports: [MatIconModule],
 })
 export class GioIconsModule {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-icons/gio-icons.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-icons/gio-icons.stories.ts
@@ -21,6 +21,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/types-7-0';
 import { MatButtonModule } from '@angular/material/button';
+import { HttpClientModule } from '@angular/common/http';
 
 import { GioBannerModule } from '../gio-banner/gio-banner.module';
 import { GioClipboardModule } from '../gio-clipboard/gio-clipboard.module';
@@ -42,6 +43,7 @@ export default {
         MatInputModule,
         GioBannerModule,
         GioClipboardModule,
+        HttpClientModule,
       ],
       declarations: [SbGetIconsListPipe],
     }),

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.module.ts
@@ -18,13 +18,11 @@ import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 
 import { GioLicenseDirective } from './gio-license.directive';
-import { GioLicenseService } from './gio-license.service';
 import { GioLicenseDialogModule } from './gio-license-dialog/gio-license-dialog.module';
 
 @NgModule({
   imports: [CommonModule, MatDialogModule, GioLicenseDialogModule],
   declarations: [GioLicenseDirective],
   exports: [GioLicenseDirective],
-  providers: [GioLicenseService],
 })
 export class GioLicenseModule {}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.spec.ts
@@ -19,6 +19,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { GioMonacoEditorHarness, ConfigureTestingGioMonacoEditor } from './gio-monaco-editor.harness';
 import { GioMonacoEditorModule } from './gio-monaco-editor.module';
@@ -40,7 +41,7 @@ describe('GioMonacoEditorModule', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [NoopAnimationsModule, GioMonacoEditorModule, ReactiveFormsModule],
+      imports: [NoopAnimationsModule, HttpClientTestingModule, GioMonacoEditorModule, ReactiveFormsModule],
     });
     ConfigureTestingGioMonacoEditor();
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
@@ -23,7 +22,7 @@ import { GioMonacoEditorComponent } from './gio-monaco-editor.component';
 import { GioMonacoEditorConfig, GIO_MONACO_EDITOR_CONFIG } from './models/GioMonacoEditorConfig';
 
 @NgModule({
-  imports: [CommonModule, HttpClientModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule],
   declarations: [GioMonacoEditorComponent, GioMonacoEditorFormFieldDirective],
   exports: [GioMonacoEditorComponent, GioMonacoEditorFormFieldDirective],
   providers: [

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.spec.ts
@@ -24,6 +24,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { of } from 'rxjs';
 import { MatInputHarness } from '@angular/material/input/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { fakeAllPolicies } from '../../models/index-testing';
 import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
@@ -73,7 +74,7 @@ describe('GioPolicyStudioPoliciesCatalogDialogComponent', () => {
   const createTestingComponent = (apiType: ApiType, executionPhase: ExecutionPhase) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [GioPolicyStudioModule, MatDialogModule, NoopAnimationsModule, MatIconTestingModule],
+      imports: [GioPolicyStudioModule, HttpClientTestingModule, MatDialogModule, NoopAnimationsModule, MatIconTestingModule],
       providers: [
         {
           provide: GioPolicyStudioService,

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.spec.ts
@@ -24,6 +24,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { of } from 'rxjs';
 import { MatInputHarness } from '@angular/material/input/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { fakeTestPolicyStep, fakeTestPolicy } from '../../models/index-testing';
 import { GioPolicyStudioModule } from '../../gio-policy-studio.module';
@@ -72,7 +73,7 @@ describe('GioPolicyStudioStepEditDialogComponent', () => {
   const createTestingComponent = (policy: Policy, step: Step) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [GioPolicyStudioModule, MatDialogModule, NoopAnimationsModule, MatIconTestingModule],
+      imports: [GioPolicyStudioModule, HttpClientTestingModule, MatDialogModule, NoopAnimationsModule, MatIconTestingModule],
       providers: [
         {
           provide: GioPolicyStudioService,

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -24,6 +24,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { of } from 'rxjs';
 import { MatInputHarness } from '@angular/material/input/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import {
   fakeAllPolicies,
@@ -58,7 +59,7 @@ describe('GioPolicyStudioModule', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioPolicyStudioModule, MatIconTestingModule],
+      imports: [NoopAnimationsModule, HttpClientTestingModule, GioPolicyStudioModule, MatIconTestingModule],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {


### PR DESCRIPTION
**Issue**

n/a 

**Description**

/!\ This module `HttpClientModule` must only be loaded once by the main application.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.45.0-fix-httpclientmodule-055dc04
```
```
yarn add @gravitee/ui-particles-angular@7.45.0-fix-httpclientmodule-055dc04
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.45.0-fix-httpclientmodule-055dc04
```
```
yarn add @gravitee/ui-policy-studio-angular@7.45.0-fix-httpclientmodule-055dc04
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-ikgiopyxnj.chromatic.com)
<!-- Storybook placeholder end -->
