### PR TITLE
feat: add isOEM method in license service

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
@@ -177,4 +177,29 @@ describe('GioLicenseService', () => {
       'https://url.test:3000/trial?utm_source=oss_utm_source_test&utm_medium=feature_debugmode_v2&utm_campaign=oss_utm_campaign_test&utm_content=organization';
     expect(gioLicenseService.getTrialURL({ feature: 'feature_debugmode_v2', context: 'organization' })).toEqual(expected);
   });
+
+  it('should check if license is OEM', done => {
+    const oemLicense: License = {
+      tier: '',
+      packs: [],
+      features: ['oem-customization'],
+    };
+
+    gioLicenseService
+      .isOEM$()
+      .pipe(
+        tap(isOEM => {
+          expect(isOEM).toEqual(true);
+          done();
+        }),
+      )
+      .subscribe();
+
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `https://url.test:3000/license`,
+    });
+
+    req.flush(oemLicense);
+  });
 });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -112,6 +112,10 @@ export class GioLicenseService {
     return url;
   }
 
+  public isOEM$(): Observable<boolean> {
+    return this.getLicense$().pipe(map(license => license !== null && license.features.includes('oem-customization')));
+  }
+
   public openDialog(licenseOptions: LicenseOptions, event?: Event) {
     event?.stopPropagation();
     event?.preventDefault();


### PR DESCRIPTION
**Issue**

N.A.

**Description**

Add new service to check if license has the OEM feature
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.47.0-add-method-to-license-service-068d4d6
```
```
yarn add @gravitee/ui-policy-studio-angular@7.47.0-add-method-to-license-service-068d4d6
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.47.0-add-method-to-license-service-068d4d6
```
```
yarn add @gravitee/ui-particles-angular@7.47.0-add-method-to-license-service-068d4d6
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hqhydtlcuj.chromatic.com)
<!-- Storybook placeholder end -->
