### PR TITLE
feat: make utm parameters optional in CTA URLs

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
@@ -18,188 +18,246 @@ import { TestBed } from '@angular/core/testing';
 import { switchMap, tap } from 'rxjs/operators';
 import { MatDialogModule } from '@angular/material/dialog';
 
-import { LICENSE_CONFIGURATION_TESTING } from './gio-license.testing.module';
+import { LICENSE_CONFIGURATION_TESTING, OEM_LICENSE_CONFIGURATION_TESTING } from './gio-license.testing.module';
 import { GioLicenseService, License } from './gio-license.service';
 
 describe('GioLicenseService', () => {
   let httpTestingController: HttpTestingController;
   let gioLicenseService: GioLicenseService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MatDialogModule],
-      providers: [
-        {
-          provide: 'LicenseConfiguration',
-          useValue: LICENSE_CONFIGURATION_TESTING,
-        },
-      ],
+  describe('With standard license', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule, MatDialogModule],
+        providers: [
+          {
+            provide: 'LicenseConfiguration',
+            useValue: LICENSE_CONFIGURATION_TESTING,
+          },
+        ],
+      });
+
+      httpTestingController = TestBed.inject(HttpTestingController);
+      gioLicenseService = TestBed.inject<GioLicenseService>(GioLicenseService);
     });
 
-    httpTestingController = TestBed.inject(HttpTestingController);
-    gioLicenseService = TestBed.inject<GioLicenseService>(GioLicenseService);
-  });
-
-  afterEach(() => {
-    httpTestingController.verify();
-  });
-
-  const mockLicense: License = {
-    tier: 'tier',
-    packs: [],
-    features: ['foobar'],
-  };
-
-  it('should call the API', done => {
-    gioLicenseService.getLicense$().subscribe(response => {
-      expect(response).toMatchObject(mockLicense);
-      done();
+    afterEach(() => {
+      httpTestingController.verify();
     });
 
-    const req = httpTestingController.expectOne({
-      method: 'GET',
-      url: `https://url.test:3000/license`,
-    });
-
-    req.flush(mockLicense);
-  });
-
-  it('should get license', done => {
-    gioLicenseService
-      .getLicense$()
-      .pipe(
-        switchMap(() => gioLicenseService.getLicense$()),
-        tap(license => {
-          expect(license).toMatchObject(mockLicense);
-          done();
-        }),
-      )
-      .subscribe();
-
-    const req = httpTestingController.expectOne({
-      method: 'GET',
-      url: `https://url.test:3000/license`,
-    });
-
-    req.flush(mockLicense);
-  });
-
-  it('should check if feature is not missing', done => {
-    gioLicenseService
-      .isMissingFeature$({ feature: 'foobar' })
-      .pipe(
-        tap(isMissing => {
-          expect(isMissing).toBeFalsy();
-          done();
-        }),
-      )
-      .subscribe();
-
-    const req = httpTestingController.expectOne({
-      method: 'GET',
-      url: `https://url.test:3000/license`,
-    });
-
-    req.flush(mockLicense);
-  });
-
-  it('should check if feature is not missing with deployed plugin', done => {
-    gioLicenseService
-      .isMissingFeature$({ deployed: true })
-      .pipe(
-        tap(isMissing => {
-          expect(isMissing).toBeFalsy();
-          done();
-        }),
-      )
-      .subscribe();
-  });
-
-  it('should check if feature is missing with deployed plugin', done => {
-    gioLicenseService
-      .isMissingFeature$({ deployed: false })
-      .pipe(
-        tap(isMissing => {
-          expect(isMissing).toBeTruthy();
-          done();
-        }),
-      )
-      .subscribe();
-  });
-
-  it('should check if feature is missing', done => {
-    gioLicenseService
-      .isMissingFeature$({ feature: 'missing' })
-      .pipe(
-        tap(isMissing => {
-          expect(isMissing).toBeTruthy();
-          done();
-        }),
-      )
-      .subscribe();
-
-    const req = httpTestingController.expectOne({
-      method: 'GET',
-      url: `https://url.test:3000/license`,
-    });
-
-    req.flush(mockLicense);
-  });
-
-  it('should use isMissingFeature$ with undefined options', done => {
-    gioLicenseService
-      .isMissingFeature$(undefined)
-      .pipe(
-        tap(isMissing => {
-          expect(isMissing).toBeFalsy();
-          done();
-        }),
-      )
-      .subscribe();
-  });
-
-  it('should get feature more information', () => {
-    expect(gioLicenseService.getFeatureInfo({ feature: 'foobar' })).not.toBeNull();
-  });
-
-  it('should throw error when get more information with wrong feature', () => {
-    expect(() => gioLicenseService.getFeatureInfo({ feature: 'bad' })).toThrow();
-  });
-
-  it('should return trial URL from UTM medium', () => {
-    const expected =
-      'https://url.test:3000/trial?utm_source=oss_utm_source_test&utm_medium=feature_debugmode_v2&utm_campaign=oss_utm_campaign_test';
-    expect(gioLicenseService.getTrialURL({ feature: 'feature_debugmode_v2' })).toEqual(expected);
-  });
-
-  it('should return trial URL from UTM medium and UTM content', () => {
-    const expected =
-      'https://url.test:3000/trial?utm_source=oss_utm_source_test&utm_medium=feature_debugmode_v2&utm_campaign=oss_utm_campaign_test&utm_content=organization';
-    expect(gioLicenseService.getTrialURL({ feature: 'feature_debugmode_v2', context: 'organization' })).toEqual(expected);
-  });
-
-  it('should check if license is OEM', done => {
-    const oemLicense: License = {
-      tier: '',
+    const mockLicense: License = {
+      tier: 'tier',
       packs: [],
-      features: ['oem-customization'],
+      features: ['foobar'],
     };
 
-    gioLicenseService
-      .isOEM$()
-      .pipe(
-        tap(isOEM => {
-          expect(isOEM).toEqual(true);
-          done();
-        }),
-      )
-      .subscribe();
+    it('should call the API', done => {
+      gioLicenseService.getLicense$().subscribe(response => {
+        expect(response).toMatchObject(mockLicense);
+        done();
+      });
 
-    const req = httpTestingController.expectOne({
-      method: 'GET',
-      url: `https://url.test:3000/license`,
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/license`,
+      });
+
+      req.flush(mockLicense);
     });
 
-    req.flush(oemLicense);
+    it('should get license', done => {
+      gioLicenseService
+        .getLicense$()
+        .pipe(
+          switchMap(() => gioLicenseService.getLicense$()),
+          tap(license => {
+            expect(license).toMatchObject(mockLicense);
+            done();
+          }),
+        )
+        .subscribe();
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/license`,
+      });
+
+      req.flush(mockLicense);
+    });
+
+    it('should check if feature is not missing', done => {
+      gioLicenseService
+        .isMissingFeature$({ feature: 'foobar' })
+        .pipe(
+          tap(isMissing => {
+            expect(isMissing).toBeFalsy();
+            done();
+          }),
+        )
+        .subscribe();
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/license`,
+      });
+
+      req.flush(mockLicense);
+    });
+
+    it('should check if feature is not missing with deployed plugin', done => {
+      gioLicenseService
+        .isMissingFeature$({ deployed: true })
+        .pipe(
+          tap(isMissing => {
+            expect(isMissing).toBeFalsy();
+            done();
+          }),
+        )
+        .subscribe();
+    });
+
+    it('should check if feature is missing with deployed plugin', done => {
+      gioLicenseService
+        .isMissingFeature$({ deployed: false })
+        .pipe(
+          tap(isMissing => {
+            expect(isMissing).toBeTruthy();
+            done();
+          }),
+        )
+        .subscribe();
+    });
+
+    it('should check if feature is missing', done => {
+      gioLicenseService
+        .isMissingFeature$({ feature: 'missing' })
+        .pipe(
+          tap(isMissing => {
+            expect(isMissing).toBeTruthy();
+            done();
+          }),
+        )
+        .subscribe();
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/license`,
+      });
+
+      req.flush(mockLicense);
+    });
+
+    it('should use isMissingFeature$ with undefined options', done => {
+      gioLicenseService
+        .isMissingFeature$(undefined)
+        .pipe(
+          tap(isMissing => {
+            expect(isMissing).toBeFalsy();
+            done();
+          }),
+        )
+        .subscribe();
+    });
+
+    it('should get feature more information', () => {
+      expect(gioLicenseService.getFeatureInfo({ feature: 'foobar' })).not.toBeNull();
+    });
+
+    it('should throw error when get more information with wrong feature', () => {
+      expect(() => gioLicenseService.getFeatureInfo({ feature: 'bad' })).toThrow();
+    });
+
+    it('should return trial URL from UTM medium', () => {
+      const expected =
+        'https://url.test:3000/trial?utm_source=oss_utm_source_test&utm_medium=feature_debugmode_v2&utm_campaign=oss_utm_campaign_test';
+      expect(gioLicenseService.getTrialURL({ feature: 'feature_debugmode_v2' })).toEqual(expected);
+    });
+
+    it('should return trial URL from UTM medium and UTM content', () => {
+      const expected =
+        'https://url.test:3000/trial?utm_source=oss_utm_source_test&utm_medium=feature_debugmode_v2&utm_campaign=oss_utm_campaign_test&utm_content=organization';
+      expect(
+        gioLicenseService.getTrialURL({
+          feature: 'feature_debugmode_v2',
+          context: 'organization',
+        }),
+      ).toEqual(expected);
+    });
+
+    it('should check if license is OEM', done => {
+      const oemLicense: License = {
+        tier: '',
+        packs: [],
+        features: ['not-oem'],
+      };
+
+      gioLicenseService
+        .isOEM$()
+        .pipe(
+          tap(isOEM => {
+            expect(isOEM).toEqual(false);
+            done();
+          }),
+        )
+        .subscribe();
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/license`,
+      });
+
+      req.flush(oemLicense);
+    });
+  });
+
+  describe('With OEM license', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule, MatDialogModule],
+        providers: [
+          {
+            provide: 'LicenseConfiguration',
+            useValue: OEM_LICENSE_CONFIGURATION_TESTING,
+          },
+        ],
+      });
+
+      httpTestingController = TestBed.inject(HttpTestingController);
+      gioLicenseService = TestBed.inject<GioLicenseService>(GioLicenseService);
+    });
+
+    afterEach(() => {
+      httpTestingController.verify();
+    });
+
+    it('should not append UTM params if utm_source and utm_campaigns are not defined', () => {
+      const expected = 'https://oem.test:3000/trial';
+      expect(gioLicenseService.getTrialURL({ feature: 'feature_debugmode_v2', context: 'organization' })).toEqual(expected);
+    });
+
+    it('should check if license is OEM', done => {
+      const oemLicense: License = {
+        tier: '',
+        packs: [],
+        features: ['oem-customization'],
+      };
+
+      gioLicenseService
+        .isOEM$()
+        .pipe(
+          tap(isOEM => {
+            expect(isOEM).toEqual(true);
+            done();
+          }),
+        )
+        .subscribe();
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://oem.test:3000/license`,
+      });
+
+      req.flush(oemLicense);
+    });
   });
 });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -31,8 +31,8 @@ export interface LicenseConfiguration {
   resourceURL: string;
   featureInfoData: Record<string, FeatureInfo>;
   trialResourceURL: string;
-  utmSource: string;
-  utmCampaign: string;
+  utmSource?: string;
+  utmCampaign?: string;
 }
 
 export interface UTM {
@@ -105,11 +105,12 @@ export class GioLicenseService {
     if (!licenseOptions.feature) {
       throw new Error(`feature is undefined`);
     }
-    let url = `${this.licenseConfiguration.trialResourceURL}?utm_source=${this.licenseConfiguration.utmSource}&utm_medium=${licenseOptions.feature}&utm_campaign=${this.licenseConfiguration.utmCampaign}`;
-    if (licenseOptions.context) {
-      url += `&utm_content=${licenseOptions.context}`;
-    }
-    return url;
+    const urlParams =
+      this.licenseConfiguration.utmSource || this.licenseConfiguration.utmCampaign
+        ? `?utm_source=${this.licenseConfiguration.utmSource}&utm_medium=${licenseOptions.feature}&utm_campaign=${this.licenseConfiguration.utmCampaign}`
+        : '';
+    const context = urlParams.length > 0 && licenseOptions.context ? `&utm_content=${licenseOptions.context}` : '';
+    return `${this.licenseConfiguration.trialResourceURL}${urlParams}${context}`;
   }
 
   public isOEM$(): Observable<boolean> {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.testing.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.testing.module.ts
@@ -31,6 +31,17 @@ export const LICENSE_CONFIGURATION_TESTING: LicenseConfiguration = {
     },
   },
 };
+export const OEM_LICENSE_CONFIGURATION_TESTING: LicenseConfiguration = {
+  resourceURL: 'https://oem.test:3000/license',
+  trialResourceURL: 'https://oem.test:3000/trial',
+  featureInfoData: {
+    foobar: {
+      image: 'assets/gio-icons.svg',
+      description: 'Foobar feature description',
+      title: 'FOOBAR',
+    },
+  },
+};
 
 @NgModule({
   imports: [],


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2966

**Description**

UTM parameters should be appended to CTA URL only for non OEM usage
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.48.0-optional-utm-params-in-cta-url-23f2c73
```
```
yarn add @gravitee/ui-policy-studio-angular@7.48.0-optional-utm-params-in-cta-url-23f2c73
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.48.0-optional-utm-params-in-cta-url-23f2c73
```
```
yarn add @gravitee/ui-particles-angular@7.48.0-optional-utm-params-in-cta-url-23f2c73
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-mxnjbqmyoe.chromatic.com)
<!-- Storybook placeholder end -->
