### PR TITLE
fix(gio-menu): apply color to arrow in Organization select

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
@@ -52,7 +52,7 @@
     }
 
     .gio-menu-selector .mat-form-field .mat-select-arrow {
-      color: oem.$oem-menu-text;
+      color: oem.$oem-menu-text !important;
     }
 
     .gio-menu-selector .mat-form-field.mat-focused.mat-primary .mat-select-arrow {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3270

**Description**

Fix arrow color in gio-menu-selector
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.49.0-fix-arrow-color-in-gio-menu-selector-c621ed5
```
```
yarn add @gravitee/ui-particles-angular@7.49.0-fix-arrow-color-in-gio-menu-selector-c621ed5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.49.0-fix-arrow-color-in-gio-menu-selector-c621ed5
```
```
yarn add @gravitee/ui-policy-studio-angular@7.49.0-fix-arrow-color-in-gio-menu-selector-c621ed5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-kuhkpezayf.chromatic.com)
<!-- Storybook placeholder end -->
