### PR TITLE
fix(gio-menu): remove disable state on selector when only one value

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.html
@@ -18,7 +18,7 @@
 <div class="gio-menu-selector">
   <mat-form-field class="gio-menu-selector__mat-form-field" appearance="legacy">
     <mat-label>{{ selectorTitle }}</mat-label>
-    <mat-select [tabIndex]="tabIndex" [value]="selectedItemValue" (selectionChange)="onSelectionChange($event)" [disabled]="isDisabled()">
+    <mat-select [tabIndex]="tabIndex" [value]="selectedItemValue" (selectionChange)="onSelectionChange($event)">
       <mat-option class="gio-menu-selector__mat-option" *ngFor="let item of selectorItems" [value]="item.value">
         {{ item.displayValue }}
       </mat-option>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.ts
@@ -45,8 +45,4 @@ export class GioMenuSelectorComponent {
   public onSelectionChange($event: MatSelectChange): void {
     this.selectChange.emit($event.value);
   }
-
-  public isDisabled(): boolean {
-    return this.selectorItems.length <= 1;
-  }
 }


### PR DESCRIPTION
**Issue**

N.A.

**Description**

Remove disabled state on env select when only one env exists

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.49.1-remove-disable-state-on-env-selection-21002c1
```
```
yarn add @gravitee/ui-policy-studio-angular@7.49.1-remove-disable-state-on-env-selection-21002c1
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.49.1-remove-disable-state-on-env-selection-21002c1
```
```
yarn add @gravitee/ui-particles-angular@7.49.1-remove-disable-state-on-env-selection-21002c1
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vphldmpgbz.chromatic.com)
<!-- Storybook placeholder end -->
