### PR TITLE
feat(monaco-editor): add option to disable minimap

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/README.stories.mdx
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/README.stories.mdx
@@ -56,11 +56,12 @@ GioMonacoEditorModule.forRoot({
 - `formControl` - form control to bind to. Work with ReactiveFormsModule.
 - `languageConfig`: `object` - language configuration of the editor.
 - `options`: `IStandaloneEditorConstructionOptions` - options of the editor.
+- `disableMiniMap`: `boolean` - option to disable the minimap (mini view of the document displayed on the right)
 
 Example:
 
 ```html
-<gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig"></gio-monaco-editor>
+<gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig" [disableMiniMap]="disbaleMiniMap"></gio-monaco-editor>
 ```
 
 ## Testing

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -58,6 +58,9 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
   @Input()
   public options: editor.IStandaloneEditorConstructionOptions = {};
 
+  @Input()
+  public disableMiniMap = false;
+
   public loaded$ = new ReplaySubject<boolean>(1);
 
   private defaultOptions: editor.IStandaloneEditorConstructionOptions = {
@@ -174,6 +177,9 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
       readOnly: this.readOnly,
       theme: this.config.theme ?? 'vs',
       model: this.textModel,
+      minimap: {
+        enabled: !this.disableMiniMap,
+      },
     });
 
     this.standaloneCodeEditor = monaco.editor.create(domElement, {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.spec.ts
@@ -20,6 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MonacoEditorLanguageConfig } from '@gravitee/ui-particles-angular';
 
 import { GioMonacoEditorHarness, ConfigureTestingGioMonacoEditor } from './gio-monaco-editor.harness';
 import { GioMonacoEditorModule } from './gio-monaco-editor.module';
@@ -28,7 +29,7 @@ import { GioMonacoEditorModule } from './gio-monaco-editor.module';
   template: `<gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig"></gio-monaco-editor> `,
 })
 class TestComponent {
-  public languageConfig = false;
+  public languageConfig: MonacoEditorLanguageConfig = { language: 'markdown' };
 
   public control = new FormControl('InitialValue');
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -49,8 +49,11 @@ export default {
     value: {
       control: { type: 'object' },
     },
+    disableMiniMap: {
+      control: { type: 'boolean' },
+    },
   },
-  render: ({ value, disabled, languageConfig }) => {
+  render: ({ value, disabled, languageConfig, disableMiniMap }) => {
     const control = new FormControl({ value, disabled });
     control.valueChanges.subscribe(value => {
       action('valueChanges')(value);
@@ -60,7 +63,7 @@ export default {
     });
     return {
       template: `
-      <gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig"></gio-monaco-editor>
+      <gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig" [disableMiniMap]="disableMiniMap"></gio-monaco-editor>
       <br>
       <pre>{{ control.status }}</pre>
       <pre>{{ control.dirty ? 'DIRTY' : 'PRISTINE' }}</pre>
@@ -70,6 +73,7 @@ export default {
       props: {
         control,
         languageConfig,
+        disableMiniMap,
       },
     };
   },
@@ -188,5 +192,29 @@ export const LanguageMarkdown: Story = {
 ## Markdown plus h2 with a custom ID ##   {#id-goes-here}
 [Link back to H2](#id-goes-here)
 `,
+    disableMiniMap: true,
+  },
+};
+
+export const DisableMiniMap: Story = {
+  args: {
+    languageConfig: {
+      language: 'json',
+      schemas: [
+        {
+          uri: 'http://myserver/foo-schema.json',
+          schema: GioJsonSchema,
+        },
+      ],
+    },
+    value: `{
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string"
+    },
+  },
+    }`,
+    disableMiniMap: true,
   },
 };


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3395

**Description**

Add option to disable minimap view on the monaco editor
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.49.2-apim-3395-disable-minimap-3cc8744
```
```
yarn add @gravitee/ui-policy-studio-angular@7.49.2-apim-3395-disable-minimap-3cc8744
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-uvfiwkuqxj.chromatic.com)
<!-- Storybook placeholder end -->
