### PR TITLE
refactor: remove `for await` use parallel instead

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-form-dialog/flow-proxy-form-dialog/gio-ps-flow-proxy-form-dialog.harness.ts
@@ -68,7 +68,7 @@ export class GioPolicyStudioFlowProxyFormDialogHarness extends ComponentHarness 
     if (flow.methods) {
       const methodsInput = await this.methodsInput();
       await methodsInput.removeTag('ALL');
-      for await (const method of flow.methods) {
+      for (const method of flow.methods) {
         await methodsInput.addTag(method);
       }
     }


### PR DESCRIPTION
**Issue**

n/a

**Description**

Needed for apim wih angular-cli and angular 14 
Fix this error : 
```
...node_modules/@gravitee/ui-policy-studio-angular/fesm2020/gravitee-ui-policy-studio-angular-testing.mjs:820:16: ERROR: Transforming for-await loops to the configured target environment ("es2015") is not supported yet

```

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.51.0-fix-2542a1e
```
```
yarn add @gravitee/ui-policy-studio-angular@7.51.0-fix-2542a1e
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.51.0-fix-ebe667c
```
```
yarn add @gravitee/ui-particles-angular@7.51.0-fix-ebe667c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-swoatrynon.chromatic.com)
<!-- Storybook placeholder end -->
