### PR TITLE
feat(policy-studio): keep original text formatting for flow conditions

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-info-bar/gio-ps-flow-details-info-bar.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-info-bar/gio-ps-flow-details-info-bar.component.html
@@ -66,5 +66,5 @@
 
 <div *ngIf="condition" class="info">
   <span class="info__label">Condition</span>
-  <span class="info__value gio-badge-neutral">{{ condition }}</span>
+  <span class="info__value gio-badge-neutral condition">{{ condition }}</span>
 </div>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-info-bar/gio-ps-flow-details-info-bar.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-info-bar/gio-ps-flow-details-info-bar.component.scss
@@ -48,5 +48,9 @@ $typography: map.get(gio.$mat-theme, typography);
         margin-right: 4px;
       }
     }
+
+    &.condition {
+      text-transform: none;
+    }
   }
 }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.scss
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.scss
@@ -106,6 +106,7 @@ $typography: map.get(gio.$mat-theme, typography);
           display: inline-block;
           overflow: hidden;
           text-overflow: ellipsis;
+          text-transform: none;
           white-space: nowrap;
 
           mat-icon {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -291,6 +291,37 @@ export const MessageWithConditionalStep: Story = {
     plans: [],
   },
 };
+export const MessageWithConditionalExpressionLanguageStep: Story = {
+  name: 'Message API with conditional expression language step',
+  args: {
+    apiType: 'MESSAGE',
+    entrypointsInfo: [fakeWebhookMessageEntrypoint()],
+    endpointsInfo: [fakeKafkaMessageEndpoint()],
+    commonFlows: [
+      fakeChannelFlow({
+        name: 'Flow',
+        request: [],
+        response: [fakeTestPolicyStep()],
+        selectors: [
+          {
+            type: 'CHANNEL',
+            operations: ['PUBLISH', 'SUBSCRIBE'],
+            channel: 'boop',
+            channelOperator: 'EQUALS',
+            entrypoints: ['sse'],
+          },
+          {
+            type: 'CONDITION',
+            condition: "{#request.params['includeheaders'] == null}",
+          },
+        ],
+        publish: [],
+        subscribe: [],
+      }),
+    ],
+    plans: [],
+  },
+};
 
 export const ProxyWithFlowsAndPlans: Story = {
   name: 'Proxy API with flows & plans',


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3026

**Description**

Do not transform text for flow condition badges

![Screenshot 2024-01-02 at 10 11 52](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/6da92475-a7e5-483e-808e-4e2e89cdedbc)
![Screenshot 2024-01-02 at 10 13 45](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/a4d17e45-3ccc-4076-9889-e49143c025ea)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.51.1-apim-3026-keep-text-formatting-for-flow-conditions-95c46c7
```
```
yarn add @gravitee/ui-policy-studio-angular@7.51.1-apim-3026-keep-text-formatting-for-flow-conditions-95c46c7
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.51.1-apim-3026-keep-text-formatting-for-flow-conditions-95c46c7
```
```
yarn add @gravitee/ui-particles-angular@7.51.1-apim-3026-keep-text-formatting-for-flow-conditions-95c46c7
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-ovmuscwage.chromatic.com)
<!-- Storybook placeholder end -->
