### PR TITLE
feat: add expiration date to license + service

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
@@ -267,6 +267,32 @@ describe('GioLicenseService', () => {
         )
         .subscribe();
     });
+
+    it('should return license expiration date', done => {
+      const expiringLicense: License = {
+        tier: '',
+        packs: [],
+        features: [],
+        expiresAt: new Date(),
+      };
+
+      gioLicenseService
+        .getExpirationDate$()
+        .pipe(
+          tap(expirationDate => {
+            expect(expirationDate).toEqual(expiringLicense.expiresAt);
+            done();
+          }),
+        )
+        .subscribe();
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/license`,
+      });
+
+      req.flush(expiringLicense);
+    });
   });
 
   describe('With OEM license', () => {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -25,6 +25,7 @@ export type License = {
   tier: string;
   packs: Array<string>;
   features: Array<string>;
+  expiresAt?: Date;
 };
 
 export interface LicenseConfiguration {
@@ -145,5 +146,9 @@ export class GioLicenseService {
       })
       .afterClosed()
       .subscribe();
+  }
+
+  public getExpirationDate$(): Observable<Date | undefined> {
+    return this.getLicense$().pipe(map(license => license.expiresAt));
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3664

**Description**

Add expiration date to license for UI

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.55.0-apim-3664-add-exp-date-to-license-fc57e0c
```
```
yarn add @gravitee/ui-particles-angular@7.55.0-apim-3664-add-exp-date-to-license-fc57e0c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.55.0-apim-3664-add-exp-date-to-license-fc57e0c
```
```
yarn add @gravitee/ui-policy-studio-angular@7.55.0-apim-3664-add-exp-date-to-license-fc57e0c
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-weylpohene.chromatic.com)
<!-- Storybook placeholder end -->
