### PR TITLE
feat: change method name to match `expiresAt` returned by /license

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
@@ -268,30 +268,67 @@ describe('GioLicenseService', () => {
         .subscribe();
     });
 
-    it('should return license expiration date', done => {
-      const expiringLicense: License = {
-        tier: '',
-        packs: [],
-        features: [],
-        expiresAt: new Date(),
-      };
+    describe('getExpiresAt$', () => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      it.each<any>([[1706092042001], ['2023-03-14T12:55:39.954Z']] as [any][])(
+        'Check date is returned when expiration date is truthy',
+        (date: any, done: jest.DoneCallback) => {
+          const expiringLicense = {
+            tier: '',
+            packs: [],
+            features: [],
+            expiresAt: date,
+          };
 
-      gioLicenseService
-        .getExpirationDate$()
-        .pipe(
-          tap(expirationDate => {
-            expect(expirationDate).toEqual(expiringLicense.expiresAt);
-            done();
-          }),
-        )
-        .subscribe();
+          gioLicenseService
+            .getExpiresAt$()
+            .pipe(
+              tap(expirationDate => {
+                expect(expirationDate instanceof Date).toEqual(true);
+                expect(expirationDate).toEqual(new Date(expiringLicense.expiresAt));
+                done();
+              }),
+            )
+            .subscribe();
 
-      const req = httpTestingController.expectOne({
-        method: 'GET',
-        url: `https://url.test:3000/license`,
-      });
+          const req = httpTestingController.expectOne({
+            method: 'GET',
+            url: `https://url.test:3000/license`,
+          });
 
-      req.flush(expiringLicense);
+          req.flush(expiringLicense);
+        },
+      );
+
+      it.each<any>([[undefined], [null]] as [any][])(
+        'Check undefined is returned when expiration date is falsy',
+        (date: any, done: jest.DoneCallback) => {
+          const expiringLicense = {
+            tier: '',
+            packs: [],
+            features: [],
+            expiresAt: date,
+          };
+
+          gioLicenseService
+            .getExpiresAt$()
+            .pipe(
+              tap(expirationDate => {
+                expect(expirationDate).toEqual(undefined);
+                done();
+              }),
+            )
+            .subscribe();
+
+          const req = httpTestingController.expectOne({
+            method: 'GET',
+            url: `https://url.test:3000/license`,
+          });
+
+          req.flush(expiringLicense);
+        },
+      );
+      /* eslint-enable @typescript-eslint/no-explicit-any */
     });
   });
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -148,7 +148,7 @@ export class GioLicenseService {
       .subscribe();
   }
 
-  public getExpirationDate$(): Observable<Date | undefined> {
-    return this.getLicense$().pipe(map(license => license.expiresAt));
+  public getExpiresAt$(): Observable<Date | undefined> {
+    return this.getLicense$().pipe(map(license => (license.expiresAt ? new Date(license.expiresAt) : undefined)));
   }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Change method name to match `expiresAt`. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.56.1-apim-3670-update-license-service-expires-at-afbfef9
```
```
yarn add @gravitee/ui-particles-angular@7.56.1-apim-3670-update-license-service-expires-at-afbfef9
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.56.1-apim-3670-update-license-service-expires-at-092fe5f
```
```
yarn add @gravitee/ui-policy-studio-angular@7.56.1-apim-3670-update-license-service-expires-at-092fe5f
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-arkoxrpmxf.chromatic.com)
<!-- Storybook placeholder end -->
