### PR TITLE
fix: gio menu selector drop-down + license notif formatting

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.scss
@@ -115,10 +115,9 @@ $expiration-notification-container-height: 152px;
 
     display: flex;
     width: 100%;
-    height: 100%;
     align-items: center;
     justify-content: space-between;
-    padding: 0 12px;
+    padding: 20px 12px;
     color: mat.get-color-from-palette(gio.$mat-space-palette, lighter10);
     font-weight: 700;
     text-decoration: none;

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.stories.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 import { moduleMetadata, Meta, Args, StoryObj } from '@storybook/angular';
-import { computeStylesForStory, GioMenuModule } from '@gravitee/ui-particles-angular';
+import { GioMenuModule } from '@gravitee/ui-particles-angular';
+
+import { computeStylesForStory, resetStoryStyleInjection } from '../oem-theme/oem-theme.service';
 
 import { GioLicenseExpirationNotificationComponent } from './gio-license-expiration-notification.component';
 import { GioLicenseExpirationNotificationModule } from './gio-license-expiration-notification.module';
@@ -92,6 +94,7 @@ const gioMenuContent = `
 
 export const InMenu: StoryObj = {
   render: args => {
+    resetStoryStyleInjection(args);
     return {
       template: `
         <div id="sidenav"  [style]="style">

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
@@ -51,5 +51,15 @@
   .mdc-menu-surface.mat-mdc-select-panel.gio-menu-selector-custom-width {
     width: 192px;
     margin: 10px -16px 0;
+
+    mat-option[aria-selected='true'] {
+      > span {
+        color: oem.$oem-menu-environment-selected;
+      }
+
+      .mat-pseudo-checkbox-checked.mat-pseudo-checkbox-minimal::after {
+        color: oem.$oem-menu-environment-selected;
+      }
+    }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu.stories.ts
@@ -16,7 +16,7 @@
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 
 import { GioSubmenuModule } from '../gio-submenu';
-import { OEM_THEME_ARG_TYPES, computeStylesForStory, OEM_DEFAULT_LOGO } from '../oem-theme.service';
+import { OEM_THEME_ARG_TYPES, OEM_DEFAULT_LOGO, computeAndInjectStylesForStory } from '../oem-theme.service';
 
 import { GioMenuModule } from './gio-menu.module';
 import { GioMenuItemComponent } from './gio-menu-item/gio-menu-item.component';
@@ -57,9 +57,10 @@ export const Default: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-        <div id="sidenav" [style]="style">
+        <div id="sidenav">
           <gio-menu [reduced]="false">
             ${gioMenuContent}
           </gio-menu>
@@ -74,7 +75,6 @@ export const Default: StoryObj = {
           { value: 'prod', displayValue: '🚀 Prod' },
           { value: 'dev', displayValue: '🧪 Development' },
         ],
-        style: computeStylesForStory(args),
       },
       styles: [
         ` 
@@ -98,9 +98,10 @@ export const Reduced: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-        <div id="sidenav"  [style]="style">
+        <div id="sidenav">
           <gio-menu [reduced]="true">
             ${gioMenuContent}
           </gio-menu>
@@ -115,7 +116,6 @@ export const Reduced: StoryObj = {
           { value: 'prod', displayValue: '🚀 Prod' },
           { value: 'dev', displayValue: '🧪 Development' },
         ],
-        style: computeStylesForStory(args),
       },
       styles: [
         ` 
@@ -139,9 +139,10 @@ export const WithOneItemInSelector: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-        <div id="sidenav"  [style]="style">
+        <div id="sidenav">
           <gio-menu [reduced]="false">
             ${gioMenuContent}
           </gio-menu>
@@ -153,7 +154,6 @@ export const WithOneItemInSelector: StoryObj = {
         isActive: (target: string) => (route != target ? null : true),
         selectedItemValue: 'onlyOne',
         selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-        style: computeStylesForStory(args),
       },
       styles: [
         ` 
@@ -177,9 +177,10 @@ export const SmallMenu: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-        <div id="sidenav"  [style]="style">
+        <div id="sidenav">
           <gio-menu>
             <gio-menu-header>    
               <gio-menu-selector tabindex="1" [selectedItemValue]="selectedItemValue" selectorTitle="Environment" [selectorItems]="selectorItems" (selectChange)="selectedItemValue=$event"></gio-menu-selector>
@@ -201,7 +202,6 @@ export const SmallMenu: StoryObj = {
         isActive: (target: string) => (route != target ? null : true),
         selectedItemValue: 'onlyOne',
         selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-        style: computeStylesForStory(args),
       },
       styles: [
         ` 
@@ -251,9 +251,10 @@ export const WithSubMenu: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-        <div id="sidenav"  [style]="style">
+        <div id="sidenav">
           <gio-menu [reduced]="false">
             ${gioMenuContent}
           </gio-menu>
@@ -270,7 +271,6 @@ export const WithSubMenu: StoryObj = {
         isSubActive: (target: string) => (subRoute != target ? null : true),
         selectedItemValue: 'onlyOne',
         selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-        style: computeStylesForStory(args),
       },
       styles: [
         ` 
@@ -294,9 +294,10 @@ export const ReducedWithSubMenu: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-        <div id="sidenav" [style]="style">
+        <div id="sidenav">
           <gio-menu [reduced]="true">
             ${gioMenuContent}
           </gio-menu>
@@ -313,7 +314,6 @@ export const ReducedWithSubMenu: StoryObj = {
         isSubActive: (target: string) => (subRoute != target ? null : true),
         selectedItemValue: 'onlyOne',
         selectorItems: [{ value: 'onlyOne', displayValue: '🧪 Only Env' }],
-        style: computeStylesForStory(args),
       },
       styles: [
         ` 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.stories.ts
@@ -16,7 +16,7 @@
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { GioSubmenuGroupComponent } from '@gravitee/ui-particles-angular';
 
-import { OEM_THEME_ARG_TYPES, computeStylesForStory, OEM_DEFAULT_LOGO } from '../oem-theme.service';
+import { OEM_THEME_ARG_TYPES, computeStylesForStory, OEM_DEFAULT_LOGO, resetStoryStyleInjection } from '../oem-theme.service';
 
 import { GioSubmenuModule } from './gio-submenu.module';
 
@@ -39,6 +39,8 @@ export const Default: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    resetStoryStyleInjection(args);
+
     return {
       template: `
 <div [style]="style">
@@ -85,6 +87,8 @@ export const Light: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    resetStoryStyleInjection(args);
+
     return {
       template: `
 <div [style]="style">

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-top-bar/gio-top-bar.stories.ts
@@ -18,7 +18,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 
 import { GioIconsModule } from '../../gio-icons/gio-icons.module';
-import { OEM_THEME_ARG_TYPES, computeStylesForStory, OEM_DEFAULT_LOGO } from '../oem-theme.service';
+import { OEM_THEME_ARG_TYPES, computeStylesForStory, OEM_DEFAULT_LOGO, resetStoryStyleInjection } from '../oem-theme.service';
 
 import { GioTopBarComponent } from './gio-top-bar.component';
 import { GioTopBarModule } from './gio-top-bar.module';
@@ -42,6 +42,8 @@ export const Default: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    resetStoryStyleInjection(args);
+
     return {
       template: `
         <div id="main" [style]="style">

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-menu-and-top-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme-menu-and-top-bar.stories.ts
@@ -22,7 +22,7 @@ import { GioSubmenuModule } from './gio-submenu';
 import { GioMenuModule } from './gio-menu';
 import { GioMenuItemComponent } from './gio-menu/gio-menu-item/gio-menu-item.component';
 import { GioTopBarLinkModule, GioTopBarMenuModule, GioTopBarModule } from './gio-top-bar';
-import { OEM_THEME_ARG_TYPES, computeStylesForStory, OEM_DEFAULT_LOGO } from './oem-theme.service';
+import { OEM_THEME_ARG_TYPES, OEM_DEFAULT_LOGO, computeAndInjectStylesForStory } from './oem-theme.service';
 
 export default {
   title: 'OEM Theme / Menu + Top Bar',
@@ -118,9 +118,11 @@ export const Default: StoryObj = {
     logo: OEM_DEFAULT_LOGO,
   },
   render: args => {
+    computeAndInjectStylesForStory(args, document);
     return {
       template: `
-<div [style]="style">
+
+<div>
         ${gioTopBarContent(args)}
     <div id="sidenav" >
         <gio-menu [reduced]="false">
@@ -144,10 +146,9 @@ export const Default: StoryObj = {
           { value: 'prod', displayValue: '🚀 Prod' },
           { value: 'dev', displayValue: '🧪 Development' },
         ],
-        style: computeStylesForStory(args),
       },
       styles: [
-        ` 
+        `         
         #sidenav {
             height: 956px;
             display: flex;
@@ -191,6 +192,8 @@ export const Default: StoryObj = {
           border-left: 1px solid var(--gio-oem-palette--background-contrast, #fff); 
           padding-left: 12px;
         }
+        
+       
         `,
       ],
     };

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/oem-theme.service.ts
@@ -42,6 +42,41 @@ const computeStylesForStory = (args: Args): string => {
     .join(' ');
 };
 
+/**
+ * Mimics how styles are injected in Console.
+ * It is necessary in order to apply styles to gio-menu-selector drop-down overlay.
+ * @param args
+ * @param document
+ */
+const computeAndInjectStylesForStory = (args: Args, document: Document): void => {
+  if (!document) {
+    return;
+  }
+
+  resetStoryStyleInjection(args);
+
+  const styles = computeStyles({
+    menuBackground: args.menuBackground,
+    menuActive: args.menuActive,
+  });
+  styles.forEach(style => {
+    document.documentElement.style.setProperty(style.key, style.value);
+  });
+};
+
+const resetStoryStyleInjection = (args: Args): void => {
+  if (!args?.menuBackground) {
+    document.documentElement.style.removeProperty('--gio-oem-palette--background');
+    document.documentElement.style.removeProperty('--gio-oem-palette--background-contrast');
+    document.documentElement.style.removeProperty('--gio-oem-palette--sub-menu');
+  }
+
+  if (!args?.menuActive) {
+    document.documentElement.style.removeProperty('--gio-oem-palette--active');
+    document.documentElement.style.removeProperty('--gio-oem-palette--active-contrast');
+  }
+};
+
 const computeStyles = (theme: OemTheme): { key: string; value: string }[] => {
   const backgroundStyle = computeStyleAndContrastByPrefix('background', theme.menuBackground);
   const activeStyle = computeStyleAndContrastByPrefix('active', theme.menuActive);
@@ -61,4 +96,4 @@ const computeStyleAndContrastByPrefix = (prefix: string, color: string): { key: 
   const paletteColorContrast = { key: `--gio-oem-palette--${prefix}-contrast`, value: '#fff' };
   return [paletteColor, paletteColorContrast];
 };
-export { computeStyles, computeStylesForStory };
+export { computeStyles, computeStylesForStory, computeAndInjectStylesForStory, resetStoryStyleInjection };

--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette-variable.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/gio-oem-palette-variable.scss
@@ -27,6 +27,7 @@ $oem-menu-hover-text: map.get(palette.$mat-oem-palette, active-contrast);
 $oem-menu-background: map.get(palette.$mat-oem-palette, background);
 $oem-menu-text: map.get(palette.$mat-oem-palette, background-contrast);
 $oem-menu-border: color-mix(in srgb, $oem-menu-background 75%, $oem-menu-text);
+$oem-menu-environment-selected: var(--gio-oem-palette--active, map.get(gio.$mat-primary-palette, default));
 
 // Sub Menu
 $oem-sub-menu-background: var(--gio-oem-palette--sub-menu, map.get(gio.$mat-space-palette, default));


### PR DESCRIPTION
**Issues**

https://gravitee.atlassian.net/browse/APIM-3784
https://gravitee.atlassian.net/browse/APIM-3783

**Description**

- Drop-down menu for gio-menu-selector using primary colors for the default version and personalized with `menuActive` for oem customers

![Screenshot 2024-02-01 at 09 40 28](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/b07309c8-7162-462b-a345-1e889feec53a)
![Screenshot 2024-02-01 at 09 41 57](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/71e4fc01-37a1-4264-b622-ceb9e0069c42)


- Touching up gio license expiration notification styling after angular migration

![Screenshot 2024-02-01 at 10 25 31](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/6472fcd8-f578-441e-ae88-9a2bfa4fdf84)
![Screenshot 2024-02-01 at 10 25 54](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/128f9105-af64-4767-bd6e-ffadb3455b59)
![Screenshot 2024-02-01 at 10 26 02](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/cbccc59b-86b7-4120-88a2-60e988e4feb1)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

