### PR TITLE
feat(ui-angular): add scope to License object

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -26,6 +26,7 @@ export type License = {
   packs: Array<string>;
   features: Array<string>;
   expiresAt?: Date;
+  scope?: string;
 };
 
 export interface LicenseConfiguration {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3856

**Description**

Add scope to the license object so that it can be used in APIM

Added from backend with: https://github.com/gravitee-io/gravitee-api-management/pull/6560

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@9.0.3-apim-2856-add-scope-to-license-4110426
```
```
yarn add @gravitee/ui-policy-studio-angular@9.0.3-apim-2856-add-scope-to-license-4110426
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@9.0.3-apim-2856-add-scope-to-license-4110426
```
```
yarn add @gravitee/ui-particles-angular@9.0.3-apim-2856-add-scope-to-license-4110426
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-tljxqncllt.chromatic.com)
<!-- Storybook placeholder end -->
