### PR TITLE
Add support for html language into MonacoEditor

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.scss
@@ -17,6 +17,7 @@
   display: block;
   height: 100%;
   min-height: 150px;
+  pointer-events: auto;
   transition: opacity 0.2s ease-out;
 }
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -38,11 +38,14 @@ import { GioMonacoEditorService } from './services/gio-monaco-editor.service';
 
 export type MonacoEditorLanguageConfig =
   | {
-      language: 'json' | 'markdown';
+      language: 'json';
       schemas: { uri: string; schema: unknown }[];
     }
   | {
       language: 'markdown';
+    }
+  | {
+      language: 'html';
     };
 
 @Component({

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -194,6 +194,28 @@ export const LanguageMarkdown: StoryObj = {
   },
 };
 
+export const LanguageHTML: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'html',
+    },
+    value: `<html>
+  <body style="text-align: center;">
+    <header>
+      <#include "header.html" />
+    </header>
+    <div style="margin-top: 50px; color: #424e5a;">
+      <h3>Hi,</h3>
+      <p>
+        The API <b><code>{api.name}</code></b> was updated by {user.displayName}.
+      </p>
+    </div>
+  </body>
+</html>`,
+    disableMiniMap: true,
+  },
+};
+
 export const DisableMiniMap: StoryObj = {
   args: {
     languageConfig: {


### PR DESCRIPTION
**Issue**
n/a

**Description**

![image](https://github.com/gravitee-io/gravitee-ui-particles/assets/4974420/38c9b4dc-f200-414b-a4d3-cc941c43c74c)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@9.0.3-html-monacoeditor-afa8d1e
```
```
yarn add @gravitee/ui-particles-angular@9.0.3-html-monacoeditor-afa8d1e
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-tsasthnxgm.chromatic.com)
<!-- Storybook placeholder end -->
