### PR TITLE
fix: prefer use padding to add default mat-mdc-form-field top/bottom space

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/scss/mat-override/mat-form-field.scss
@@ -53,7 +53,7 @@
   // MDC mat-form-field
 
   .mat-mdc-form-field {
-    margin: 0.45em 0;
+    padding: 0.45em 0;
   }
 
   .mat-mdc-form-field.mat-form-field-disabled {


### PR DESCRIPTION
**Issue**
n/a

**Description**

Prefer use padding to add default mat-mdc-form-field top/bottom space

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@9.4.0-fix-mat-mdc-form-field-0cb32e3
```
```
yarn add @gravitee/ui-policy-studio-angular@9.4.0-fix-mat-mdc-form-field-0cb32e3
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@9.4.0-fix-mat-mdc-form-field-0cb32e3
```
```
yarn add @gravitee/ui-particles-angular@9.4.0-fix-mat-mdc-form-field-0cb32e3
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-rzcpzockxt.chromatic.com)
<!-- Storybook placeholder end -->
