### PR TITLE
fix: increase search border size

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-search/gio-menu-search.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-search/gio-menu-search.component.scss
@@ -24,7 +24,7 @@ $typography: map.get(gio.$mat-theme, typography);
 .gio-menu-search {
   display: flex;
   flex-direction: row;
-  border: 1px solid oem.$oem-menu-border;
+  border: 3px solid oem.$oem-menu-border;
   border-radius: 4px;
   margin-bottom: 16px;
 


### PR DESCRIPTION


**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

This reverts commit 6737b84300eb854cbc987b25fd451863aaa3fb38.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@9.5.0-revert-search-border-size-ad3fb1f
```
```
yarn add @gravitee/ui-particles-angular@9.5.0-revert-search-border-size-ad3fb1f
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@9.5.0-revert-search-border-size-ad3fb1f
```
```
yarn add @gravitee/ui-policy-studio-angular@9.5.0-revert-search-border-size-ad3fb1f
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vrglqdlgwi.chromatic.com)
<!-- Storybook placeholder end -->
