### PR TITLE
fix: use same border for env selector and search in menu

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/oem-theme/gio-menu/gio-menu-selector/gio-menu-selector.component.scss
@@ -20,8 +20,7 @@
 .gio-menu-selector {
   width: 192px;
   padding: 4px 14px 10px;
-  border-style: solid;
-  border-color: oem.$oem-menu-border;
+  border: 3px solid oem.$oem-menu-border;
   border-radius: 4px;
   margin-bottom: 8px;
   color: oem.$oem-menu-text;


### PR DESCRIPTION
**Description**

use same border for env selector and search in menu

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@9.5.1-apim-3442-fix-background-color-4dc8af2
```
```
yarn add @gravitee/ui-particles-angular@9.5.1-apim-3442-fix-background-color-4dc8af2
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@9.5.1-apim-3442-fix-background-color-4dc8af2
```
```
yarn add @gravitee/ui-policy-studio-angular@9.5.1-apim-3442-fix-background-color-4dc8af2
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-abmagoqcow.chromatic.com)
<!-- Storybook placeholder end -->
