### PR TITLE
feat: improve confirm dialog with last angular 16 feature

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.html
@@ -22,7 +22,7 @@
   <p class="confirm-dialog__body__content" *ngIf="content" [innerHTML]="content"></p>
 
   <div class="confirm-dialog__body__content" *ngIf="contentComponentOutlet">
-    <ng-container *ngComponentOutlet="contentComponentOutlet; injector: contentComponentInjector"></ng-container>
+    <ng-container *ngComponentOutlet="contentComponentOutlet; inputs: contentComponentInputs"></ng-container>
   </div>
 
   <p class="confirm-dialog__body__validate-message" [innerHTML]="validationMessage"></p>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.component.ts
@@ -61,11 +61,7 @@ export class GioConfirmAndValidateDialogComponent {
       this.content = confirmDialogData?.content as string;
     } else if (isObject(confirmDialogData?.content)) {
       this.contentComponentOutlet = confirmDialogData?.content.componentOutlet;
-      // TODO: When Angular 16 ready use ngComponentOutletInputs
-      this.contentComponentInjector = Injector.create({
-        providers: [{ provide: 'contentComponentInputs', useValue: confirmDialogData?.content.componentInputs }],
-        parent: parentInjector,
-      });
+      this.contentComponentInputs = confirmDialogData?.content.componentInputs;
     }
 
     this.validationMessage = extendValidationMessage(

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.stories.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-confirm-and-validate-dialog/gio-confirm-and-validate-dialog.stories.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, Input, Type } from '@angular/core';
+import { Component, Input, Type } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { tap } from 'rxjs/operators';
 import { action } from '@storybook/addon-actions';
@@ -70,9 +70,6 @@ export class ConfirmAndValidateDialogStoryComponent {
   template: ` <div>{{ title }}</div> `,
 })
 export class ConfirmAndValidateContentDialogStoryComponent {
-  public title: string;
-
-  constructor(@Inject('contentComponentInputs') contentComponentInputs: { title: string }) {
-    this.title = contentComponentInputs.title;
-  }
+  @Input()
+  public title?: string;
 }


### PR DESCRIPTION
**Issue**
n/a

**Description**

Simple BC for this component :
- Replace 'contentComponentInputs' with direct @Input property

Only one change near to this component https://github.com/gravitee-io/gravitee-cockpit/blob/394f796e429abc9103837c012b188f9650b480af/gravitee-cockpit-ui/src/app/topology/pages/account-settings/account-tokens/account-tokens.component.ts#L98

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@9.6.0-confirm-dialog-e0200c9
```
```
yarn add @gravitee/ui-policy-studio-angular@9.6.0-confirm-dialog-e0200c9
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@9.6.0-confirm-dialog-e0200c9
```
```
yarn add @gravitee/ui-particles-angular@9.6.0-confirm-dialog-e0200c9
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-bbuseztana.chromatic.com)
<!-- Storybook placeholder end -->
