### PR TITLE
feat: change signature of isMissingFeature$ in license service

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.directive.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.directive.ts
@@ -61,7 +61,7 @@ export class GioLicenseDirective implements OnInit, OnDestroy {
     if (isLicensePluginOptions(this.gioLicense)) {
       return of(!this.gioLicense.deployed);
     }
-    return this.licenseService.isMissingFeature$(this.gioLicense);
+    return this.licenseService.isMissingFeature$(this.gioLicense.feature);
   }
 
   public ngOnDestroy(): void {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
@@ -89,7 +89,7 @@ describe('GioLicenseService', () => {
 
       it('should check if feature is not missing', done => {
         gioLicenseService
-          .isMissingFeature$({ feature: 'foobar' })
+          .isMissingFeature$('foobar')
           .pipe(
             tap(isMissing => {
               expect(isMissing).toBeFalsy();
@@ -108,7 +108,7 @@ describe('GioLicenseService', () => {
 
       it('should check if feature is missing', done => {
         gioLicenseService
-          .isMissingFeature$({ feature: 'missing' })
+          .isMissingFeature$('missing')
           .pipe(
             tap(isMissing => {
               expect(isMissing).toBeTruthy();
@@ -331,7 +331,7 @@ describe('GioLicenseService', () => {
       };
 
       it('should declare feature missing if license is expired', done => {
-        gioLicenseService.isMissingFeature$({ feature: 'foobar' }).subscribe(isMissing => {
+        gioLicenseService.isMissingFeature$('foobar').subscribe(isMissing => {
           expect(isMissing).toEqual(true);
           done();
         });

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -89,8 +89,8 @@ export class GioLicenseService {
     return this.loadLicense$;
   }
 
-  public isMissingFeature$(licenseOptions: LicenseOptions | undefined): Observable<boolean> {
-    if (licenseOptions?.feature == null || !licenseOptions?.feature) {
+  public isMissingFeature$(feature: string | undefined): Observable<boolean> {
+    if (feature == null) {
       return of(false);
     }
     return this.isExpired$().pipe(
@@ -98,7 +98,7 @@ export class GioLicenseService {
         if (isExpired) {
           return of(isExpired);
         }
-        return this.getLicense$().pipe(map(license => license == null || !license.features.some(feat => feat === licenseOptions.feature)));
+        return this.getLicense$().pipe(map(license => license == null || !license.features.some(feat => feat === feature)));
       }),
     );
   }


### PR DESCRIPTION
BREAKING CHANGE: The GioLicenseService+isMissingFeature$ signature is modified to accept the feature as a string parameter instead of LicenseOptions object.

**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@10.2.0-change-license-service-08f7b10
```
```
yarn add @gravitee/ui-particles-angular@10.2.0-change-license-service-08f7b10
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@10.2.0-change-license-service-08f7b10
```
```
yarn add @gravitee/ui-policy-studio-angular@10.2.0-change-license-service-08f7b10
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-qzsbvigckr.chromatic.com)
<!-- Storybook placeholder end -->
