### PR TITLE
fix: allow license directive input with undefined license

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.directive.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license/gio-license.directive.spec.ts
@@ -24,7 +24,7 @@ import { GioLicenseModule } from './gio-license.module';
 @Component({ template: `<div [gioLicense]="license" (click)="onClick()">A Content</div>` })
 class TestLicenseComponent {
   @Input()
-  public license: LicenseOptions = {};
+  public license?: LicenseOptions = {};
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   public onClick() {}
@@ -33,7 +33,7 @@ class TestLicenseComponent {
 describe('GioLicenseDirective', () => {
   let fixture: ComponentFixture<TestLicenseComponent>;
   let component: TestLicenseComponent;
-  function prepareTestLicenseComponent(licenseOptions: LicenseOptions, license: boolean) {
+  function prepareTestLicenseComponent(licenseOptions: LicenseOptions | undefined, license: boolean) {
     fixture = TestBed.configureTestingModule({
       declarations: [TestLicenseComponent],
       imports: [HttpClientTestingModule, GioLicenseModule, GioLicenseTestingModule.with(license)],
@@ -81,6 +81,17 @@ describe('GioLicenseDirective', () => {
 
     it('should not override click if plugin is deployed', () => {
       prepareTestLicenseComponent({ feature: 'foobar', deployed: true }, false);
+      const onClickSpy = jest.spyOn(component, 'onClick');
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement.querySelector('div');
+      element.click();
+
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not override click if no license defined', () => {
+      prepareTestLicenseComponent(undefined, false);
       const onClickSpy = jest.spyOn(component, 'onClick');
       fixture.detectChanges();
 


### PR DESCRIPTION
**Issue**
n/a

**Description**

allow license directive input with undefined license

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@11.0.0-fix-license-b4189bf
```
```
yarn add @gravitee/ui-policy-studio-angular@11.0.0-fix-license-b4189bf
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@11.0.0-fix-license-b4189bf
```
```
yarn add @gravitee/ui-particles-angular@11.0.0-fix-license-b4189bf
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-mhemfqfbuk.chromatic.com)
<!-- Storybook placeholder end -->
