### PR TITLE
fix(angular): round license expiration countdown number

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.spec.ts
@@ -109,6 +109,17 @@ describe('GioLicenseExpirationNotificationComponent', () => {
       expect(await harness.getTitleText()).toEqual('Your license will expire in 10 days');
     });
 
+    it('should display countdown message of whole number', async () => {
+      const expirationDate = new Date();
+      expirationDate.setDate(expirationDate.getDate() + 29);
+
+      component.expirationDate = expirationDate;
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(GioLicenseExpirationNotificationHarness);
+      expect(await harness.getTitleText()).toEqual('Your license will expire in 29 days');
+    });
+
     it('should display call to action', async () => {
       component.showCallToAction = true;
       fixture.detectChanges();

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.ts
@@ -52,7 +52,7 @@ export class GioLicenseExpirationNotificationComponent implements OnInit, OnChan
 
     const date = new Date();
     const timeRemaining = this.transformDateWithoutHours(this.expirationDate) - this.transformDateWithoutHours(date);
-    this.daysRemaining = timeRemaining / (1000 * 3600 * 24);
+    this.daysRemaining = Math.round(timeRemaining / (1000 * 3600 * 24));
 
     if (this.expirationDate.getTime() - date.getTime() < 0) {
       this.title = 'Your license has expired';


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4216

**Description**

Round the countdown number for the license expiration countdown.

![Screenshot 2024-03-15 at 17 30 37](https://github.com/gravitee-io/gravitee-ui-particles/assets/42294616/aa918fc9-d1bc-4c27-85c0-b8ad212425d8)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.0.0-apim-4216-fix-decimal-license-countdown-ce4e059
```
```
yarn add @gravitee/ui-policy-studio-angular@12.0.0-apim-4216-fix-decimal-license-countdown-ce4e059
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.0.0-apim-4216-fix-decimal-license-countdown-ce4e059
```
```
yarn add @gravitee/ui-particles-angular@12.0.0-apim-4216-fix-decimal-license-countdown-ce4e059
```
<!-- Prerelease placeholder ui-particles-angular end -->
