### PR TITLE
chore: disable turbosnap on chromatic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           # TODO:
           #  - Handle npx chromatic command failure, make the job fails
           command: |
-            SB_URL=$(npx chromatic --only-changed --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=<< parameters.package_name >>/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=<< parameters.package_name >>/storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
             echo "export SB_URL=$SB_URL" >> $BASH_ENV
       - gh/setup
       - run:


### PR DESCRIPTION
**Description**

Remove only-changed turbosnap option

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.0.0-disable-chromatic-turbosnap-636dfd5
```
```
yarn add @gravitee/ui-policy-studio-angular@12.0.0-disable-chromatic-turbosnap-636dfd5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.0.0-disable-chromatic-turbosnap-636dfd5
```
```
yarn add @gravitee/ui-particles-angular@12.0.0-disable-chromatic-turbosnap-636dfd5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-znlwogxdmo.chromatic.com)
<!-- Storybook placeholder end -->
