### PR TITLE
fix: json-schema - Set initial control value when fomly has more stable

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.component.ts
@@ -15,6 +15,7 @@
  */
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -31,7 +32,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, FormGroup, NgControl } from '@angular/forms';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
-import { cloneDeep, isEmpty, isObject } from 'lodash';
+import { cloneDeep, isEmpty, isEqual, isObject } from 'lodash';
 import { debounceTime, delay, distinctUntilChanged, filter, map, startWith, take, takeUntil, tap } from 'rxjs/operators';
 import { merge, ReplaySubject, Subject } from 'rxjs';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -45,6 +46,7 @@ import { GioFormlyJsonSchemaService } from './gio-formly-json-schema.service';
   selector: 'gio-form-json-schema',
   template: `<formly-form *ngIf="formGroup" [fields]="fields" [options]="options" [form]="formGroup" [model]="model"></formly-form>`,
   styleUrls: ['./gio-form-json-schema.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GioFormJsonSchemaComponent implements ControlValueAccessor, OnChanges, OnInit, AfterViewInit, OnDestroy {
   public static isDisplayable(jsonSchema: GioJsonSchema): boolean {
@@ -150,12 +152,20 @@ export class GioFormJsonSchemaComponent implements ControlValueAccessor, OnChang
       );
     });
 
-    // Init control value with default value without emit event
-    this.formGroup.valueChanges.pipe(take(1), takeUntil(this.unsubscribe$)).subscribe(value => {
-      this.ngControl?.control?.reset(value, { emitEvent: false });
-      this.changeDetectorRef.markForCheck();
-      this.changeDetectorRef.detectChanges();
-    });
+    // Sync control value with default value (without emit event) as long as the component is not ready
+    // When formly is initialised, it emits several values as it builds up step by step.
+    this.formGroup.valueChanges
+      .pipe(
+        distinctUntilChanged(isEqual),
+        tap(value => {
+          this.ngControl?.control?.reset(value, { emitEvent: false });
+        }),
+        takeUntil(this.ready),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+
+    // Avoid ExpressionChangedAfterItHasBeenCheckedError on project
     this.changeDetectorRef.markForCheck();
     this.changeDetectorRef.detectChanges();
 


### PR DESCRIPTION
**Issue**

part of https://gravitee.atlassian.net/browse/APIM-3969

**Description**

When formly is initialised, it emits several values as it builds up little by little. The control value must therefore be kept synchronised. Sync is stopped when the component is ready.

**Additional context**

cherry pick of : https://github.com/gravitee-io/gravitee-ui-particles/pull/381


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.57.0-7-x-fix-json-schema-a925b63
```
```
yarn add @gravitee/ui-particles-angular@7.57.0-7-x-fix-json-schema-a925b63
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.57.0-7-x-fix-json-schema-a925b63
```
```
yarn add @gravitee/ui-policy-studio-angular@7.57.0-7-x-fix-json-schema-a925b63
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-nxwcgubkqg.chromatic.com)
<!-- Storybook placeholder end -->
