### PR TITLE
Apim 4216 fix license expiration countdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,13 +223,15 @@ jobs:
 workflows:
   version: 2.1
   validate_build_branch:
-    # Trigger on all branches except `main` & `7.x`
+    # Trigger on all branches except `main` & `7.x` & `11.x`
     when:
       and:
         - not:
             equal: [main, << pipeline.git.branch >>]
         - not:
             equal: [7.x, << pipeline.git.branch >>]
+        - not:
+            equal: [11.x, << pipeline.git.branch >>]
     jobs:
       - lint-test:
           name: Lint & Test
@@ -310,11 +312,12 @@ workflows:
                 var-name: CHROMATIC_PROJECT_TOKEN
 
   release:
-    # Trigger only for `main` & `7.x` branch
+    # Trigger only for `main` & `7.x` & `11.x` branches
     when:
       or:
         - equal: [main, << pipeline.git.branch >>]
         - equal: [7.x, << pipeline.git.branch >>]
+        - equal: [11.x, << pipeline.git.branch >>]
         # TODO: Remove me. Used to test release
         - equal: [circleci, << pipeline.git.branch >>]
     jobs:

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.spec.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.spec.ts
@@ -109,6 +109,17 @@ describe('GioLicenseExpirationNotificationComponent', () => {
       expect(await harness.getTitleText()).toEqual('Your license will expire in 10 days');
     });
 
+    it('should display countdown message of whole number', async () => {
+      const expirationDate = new Date();
+      expirationDate.setDate(expirationDate.getDate() + 29);
+
+      component.expirationDate = expirationDate;
+      fixture.detectChanges();
+
+      const harness = await loader.getHarness(GioLicenseExpirationNotificationHarness);
+      expect(await harness.getTitleText()).toEqual('Your license will expire in 29 days');
+    });
+
     it('should display call to action', async () => {
       component.showCallToAction = true;
       fixture.detectChanges();

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.ts
@@ -52,7 +52,7 @@ export class GioLicenseExpirationNotificationComponent implements OnInit, OnChan
 
     const date = new Date();
     const timeRemaining = this.transformDateWithoutHours(this.expirationDate) - this.transformDateWithoutHours(date);
-    this.daysRemaining = timeRemaining / (1000 * 3600 * 24);
+    this.daysRemaining = Math.round(timeRemaining / (1000 * 3600 * 24));
 
     if (this.expirationDate.getTime() - date.getTime() < 0) {
       this.title = 'Your license has expired';


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4216

**Description**

Apply fix to support branch 11.x so that AM can use it. 

AM uses Angular 16 for the 4.3.0 release.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@11.3.0-apim-4216-fix-license-expiration-countdown-1b26cdc
```
```
yarn add @gravitee/ui-particles-angular@11.3.0-apim-4216-fix-license-expiration-countdown-1b26cdc
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@11.3.0-apim-4216-fix-license-expiration-countdown-1b26cdc
```
```
yarn add @gravitee/ui-policy-studio-angular@11.3.0-apim-4216-fix-license-expiration-countdown-1b26cdc
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-cxheomohlz.chromatic.com)
<!-- Storybook placeholder end -->
