### PR TITLE
feat: add read only option to policy studio

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.html
@@ -29,17 +29,17 @@
 <button class="menuBtn" mat-icon-button [matMenuTriggerFor]="policyMenu"><mat-icon svgIcon="gio:more-vertical"></mat-icon></button>
 
 <mat-menu #policyMenu="matMenu">
-  <button mat-menu-item (click)="onEdit()">
-    <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-    <span>Edit</span>
+  <button mat-menu-item (click)="onEditOrView()">
+    <mat-icon [svgIcon]="readOnly ? 'gio:eye-empty' : 'gio:edit-pencil'"></mat-icon>
+    <span>{{ readOnly ? 'View' : 'Edit' }}</span>
   </button>
 
-  <button mat-menu-item (click)="onDisable()">
+  <button [disabled]="readOnly" mat-menu-item (click)="onDisable()">
     <mat-icon [svgIcon]="step.enabled ? 'gio:prohibition' : 'gio:check-circled-outline'"></mat-icon>
     <span>{{ step.enabled ? 'Disable' : 'Enable' }}</span>
   </button>
 
-  <button mat-menu-item (click)="onDelete()">
+  <button [disabled]="readOnly" mat-menu-item (click)="onDelete()">
     <mat-icon svgIcon="gio:trash"></mat-icon>
     <span>Delete</span>
   </button>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.ts
@@ -31,6 +31,9 @@ import {
 })
 export class GioPolicyStudioDetailsPhaseStepComponent implements OnChanges {
   @Input()
+  public readOnly = false;
+
+  @Input()
   public step!: Step;
 
   @Input()
@@ -55,7 +58,7 @@ export class GioPolicyStudioDetailsPhaseStepComponent implements OnChanges {
     }
   }
 
-  public onEdit() {
+  public onEditOrView() {
     if (!this.policy) {
       // TODO: Handle UseCase when policy is not found. (Like if the plugin is removed from the BackEnd)
       return;
@@ -66,6 +69,7 @@ export class GioPolicyStudioDetailsPhaseStepComponent implements OnChanges {
         GioPolicyStudioStepEditDialogComponent,
         {
           data: {
+            readOnly: this.readOnly,
             policy: this.policy,
             step: this.step,
           },

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.html
@@ -44,7 +44,7 @@
         <!-- Add policy button after first connector -->
         <ng-container *ngIf="isFirst">
           <mat-icon class="content__step__rightArrow" svgIcon="gio:arrow-right"></mat-icon>
-          <button class="content__step__addBtn" mat-button (click)="onAddPolicy(-1)">
+          <button [disabled]="readOnly" class="content__step__addBtn" mat-button (click)="onAddPolicy(-1)">
             <mat-icon svgIcon="gio:plus"></mat-icon>
           </button>
           <mat-icon class="content__step__rightArrow" svgIcon="gio:arrow-right"></mat-icon>
@@ -61,7 +61,8 @@
           </div>
           <gio-ps-flow-details-phase-step
             class="content__step__step"
-            [class.disabled]="!stepVM.step.enabled"
+            [readOnly]="readOnly"
+            [class.disabled]="readOnly || !stepVM.step.enabled"
             [policies]="policies"
             [step]="stepVM.step"
             (stepChange)="onStepChange(stepVM.index, $event)"
@@ -72,7 +73,7 @@
 
         <!-- Add policy button -->
         <mat-icon class="content__step__rightArrow" svgIcon="gio:arrow-right"></mat-icon>
-        <button class="content__step__addBtn" mat-button (click)="onAddPolicy(stepVM.index)">
+        <button [disabled]="readOnly" class="content__step__addBtn" mat-button (click)="onAddPolicy(stepVM.index)">
           <mat-icon svgIcon="gio:plus"></mat-icon>
         </button>
         <mat-icon class="content__step__rightArrow" svgIcon="gio:arrow-right"></mat-icon>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.ts
@@ -46,6 +46,9 @@ type StepVM =
 })
 export class GioPolicyStudioDetailsPhaseComponent implements OnChanges {
   @Input()
+  public readOnly = false;
+
+  @Input()
   public steps: Step[] = [];
 
   @Input()

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -23,10 +23,10 @@
     <div class="header">
       <div class="header__label">Flow details</div>
       <div class="header__configBtn">
-        <button class="header__configBtn__edit" mat-stroked-button (click)="onEditFlow()">
+        <button [disabled]="readOnly" class="header__configBtn__edit" mat-stroked-button (click)="onEditFlow()">
           <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
         </button>
-        <button class="header__configBtn__delete" mat-stroked-button (click)="onDeleteFlow()">
+        <button [disabled]="readOnly" class="header__configBtn__delete" mat-stroked-button (click)="onDeleteFlow()">
           <mat-icon svgIcon="gio:trash"></mat-icon>
         </button>
       </div>
@@ -40,6 +40,7 @@
             class="content__phase"
             name="Request phase"
             description="Policies will be applied during the connection establishment"
+            [readOnly]="readOnly"
             [startConnector]="messageFlowEntrypointsInfo"
             [endConnector]="endpointsInfo"
             [steps]="flow.request ?? []"
@@ -53,6 +54,7 @@
             class="content__phase"
             name="Response phase"
             description="Policies will be applied to the response from the initial connection"
+            [readOnly]="readOnly"
             [startConnector]="endpointsInfo"
             [endConnector]="messageFlowEntrypointsInfo"
             [steps]="flow.response ?? []"
@@ -68,6 +70,7 @@
             class="content__phase"
             name="Publish phase"
             description="Policies will be applied on messages sent to the endpoint"
+            [readOnly]="readOnly"
             [startConnector]="messageFlowEntrypointsInfo | gioFilterConnectorsByMode: 'PUBLISH' : operations"
             [endConnector]="endpointsInfo | gioFilterConnectorsByMode: 'PUBLISH' : operations"
             [steps]="flow.publish ?? []"
@@ -81,6 +84,7 @@
             class="content__phase"
             name="Subscribe phase"
             description="Policies will be applied on messages received by the entrypoint"
+            [readOnly]="readOnly"
             [startConnector]="endpointsInfo | gioFilterConnectorsByMode: 'SUBSCRIBE' : operations"
             [endConnector]="messageFlowEntrypointsInfo | gioFilterConnectorsByMode: 'SUBSCRIBE' : operations"
             [steps]="flow.subscribe ?? []"
@@ -98,6 +102,7 @@
           class="content__phase"
           name="Request phase"
           description="Policies will be applied during the connection establishment"
+          [readOnly]="readOnly"
           [startConnector]="entrypointsInfo | gioFilterConnectorsByMode: 'REQUEST_RESPONSE'"
           [endConnector]="endpointsInfo | gioFilterConnectorsByMode: 'REQUEST_RESPONSE'"
           [steps]="flow.request ?? []"
@@ -111,6 +116,7 @@
           class="content__phase"
           name="Response phase"
           description="Policies will be applied during the connection termination"
+          [readOnly]="readOnly"
           [startConnector]="endpointsInfo | gioFilterConnectorsByMode: 'REQUEST_RESPONSE'"
           [endConnector]="entrypointsInfo | gioFilterConnectorsByMode: 'REQUEST_RESPONSE'"
           [steps]="flow.response ?? []"

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -38,6 +38,9 @@ import { GioPolicyStudioFlowFormDialogResult } from '../flow-form-dialog/gio-ps-
 })
 export class GioPolicyStudioDetailsComponent implements OnChanges {
   @Input()
+  public readOnly = false;
+
+  @Input()
   public loading = false;
 
   @Input()

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.html
@@ -51,6 +51,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions class="actions" align="end">
-  <button class="actions__cancelBtn" mat-button [mat-dialog-close]="">Cancel</button>
-  <button class="actions__saveBtn" color="primary" mat-flat-button role="dialog" (click)="onSubmit()">Save</button>
+  <button [disabled]="readOnly" class="actions__cancelBtn" mat-button [mat-dialog-close]="">Cancel</button>
+  <button [disabled]="readOnly" class="actions__saveBtn" color="primary" mat-flat-button role="dialog" (click)="onSubmit()">Save</button>
 </mat-dialog-actions>

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-execution-form-dialog/gio-ps-flow-execution-form-dialog.component.ts
@@ -22,6 +22,7 @@ import { FlowExecution } from '../../models';
 
 export type GioPolicyStudioFlowExecutionFormDialogData = {
   flowExecution?: FlowExecution;
+  readOnly?: boolean;
 };
 
 @Component({
@@ -34,6 +35,8 @@ export class GioPolicyStudioFlowExecutionFormDialogComponent {
 
   public existingFlowExecution?: FlowExecution;
 
+  public readOnly = false;
+
   constructor(
     public dialogRef: MatDialogRef<GioPolicyStudioFlowExecutionFormDialogComponent, FlowExecution | undefined>,
     @Inject(MAT_DIALOG_DATA) flowDialogData: GioPolicyStudioFlowExecutionFormDialogData,
@@ -44,6 +47,12 @@ export class GioPolicyStudioFlowExecutionFormDialogComponent {
       mode: new UntypedFormControl(flowDialogData?.flowExecution?.mode ?? 'DEFAULT'),
       matchRequired: new UntypedFormControl(flowDialogData?.flowExecution?.matchRequired ?? false),
     });
+
+    this.readOnly = Boolean(flowDialogData.readOnly);
+
+    if (this.readOnly) {
+      this.flowExecutionFormGroup.disable({ emitEvent: false });
+    }
   }
 
   public onSubmit(): void {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
@@ -22,7 +22,7 @@
   </div>
   <div class="header__configBtn">
     <button class="header__configBtn_edit" mat-stroked-button [disabled]="loading" (click)="onConfigureExecution(flowExecution)">
-      <mat-icon svgIcon="gio:settings"></mat-icon>
+      <mat-icon [svgIcon]="readOnly ? 'gio:eye-empty' : 'gio:settings'"></mat-icon>
     </button>
   </div>
 </div>
@@ -35,7 +35,9 @@
         <span>{{ flowsGroup.name }}</span>
       </div>
       <div class="list__flowsGroup__header__addBtn">
-        <button mat-button (click)="onAddFlow(flowsGroup)"><mat-icon svgIcon="gio:plus" matTooltip="New flow"></mat-icon></button>
+        <button mat-button [disabled]="readOnly" (click)="onAddFlow(flowsGroup)">
+          <mat-icon svgIcon="gio:plus" matTooltip="New flow"></mat-icon>
+        </button>
       </div>
     </div>
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -57,6 +57,9 @@ interface FlowMenuVM extends FlowVM {
 })
 export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
   @Input()
+  public readOnly = false;
+
+  @Input()
   public loading = false;
 
   @Input()
@@ -229,6 +232,7 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
         {
           data: {
             flowExecution,
+            readOnly: this.readOnly,
           },
           role: 'alertdialog',
           id: 'gioPsFlowExecutionFormDialog',

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.html
@@ -30,7 +30,7 @@
 </h2>
 
 <mat-dialog-content class="content">
-  <gio-ps-step-form [policy]="policy" [(step)]="step" (isValid)="isValid = $event"></gio-ps-step-form>
+  <gio-ps-step-form [readOnly]="readOnly" [policy]="policy" [(step)]="step" (isValid)="isValid = $event"></gio-ps-step-form>
 </mat-dialog-content>
 
 <mat-dialog-actions class="actions" align="end">

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-edit-dialog/gio-ps-step-edit-dialog.component.ts
@@ -21,6 +21,7 @@ import { Policy, Step } from '../../models';
 export type GioPolicyStudioStepEditDialogData = {
   policy: Policy;
   step: Step;
+  readOnly?: boolean;
 };
 
 export type GioPolicyStudioStepEditDialogResult = undefined | Step;
@@ -35,6 +36,7 @@ export class GioPolicyStudioStepEditDialogComponent {
   public step!: Step;
 
   public isValid = false;
+  public readOnly = false;
 
   constructor(
     public dialogRef: MatDialogRef<GioPolicyStudioStepEditDialogComponent, GioPolicyStudioStepEditDialogResult>,
@@ -42,6 +44,7 @@ export class GioPolicyStudioStepEditDialogComponent {
   ) {
     this.policy = flowDialogData.policy;
     this.step = flowDialogData.step;
+    this.readOnly = Boolean(flowDialogData.readOnly);
   }
 
   public onSave(): void {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.html
@@ -23,13 +23,13 @@
     <ng-container *ngIf="stepForm && (policySchema$ | async) as policySchema; else loadingTmpl" [formGroup]="stepForm">
       <mat-form-field>
         <mat-label>Description</mat-label>
-        <textarea matInput formControlName="description" cdkFocusInitial></textarea>
+        <textarea [disabled]="readOnly" matInput formControlName="description" cdkFocusInitial></textarea>
         <mat-hint>Describe how your policy works.</mat-hint>
       </mat-form-field>
 
       <mat-form-field>
         <mat-label>Trigger condition</mat-label>
-        <input matInput formControlName="condition" />
+        <input [disabled]="readOnly" matInput formControlName="condition" />
         <mat-hint>The condition to execute this policy. Supports Expression Language.</mat-hint>
       </mat-form-field>
 

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
@@ -30,6 +30,9 @@ import { Policy, Step } from '../../models';
 })
 export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDestroy {
   @Input()
+  public readOnly = false;
+
+  @Input()
   public step?: Step;
 
   @Input()
@@ -54,7 +57,9 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
       this.policySchema$ = this.policyStudioService.getPolicySchema(this.policy).pipe(
         map(schema => {
           if (GioFormJsonSchemaComponent.isDisplayable(schema as GioJsonSchema)) {
-            return schema as GioJsonSchema;
+            const gioJsonSchema = schema as GioJsonSchema;
+            gioJsonSchema.readOnly = this.readOnly;
+            return gioJsonSchema;
           }
           return {};
         }),
@@ -94,6 +99,10 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
     this.stepForm.statusChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(valid => {
       this.isValid.emit(valid === 'VALID');
     });
+
+    if (this.readOnly) {
+      this.stepForm.disable({ emitEvent: false });
+    }
   }
 
   public onJsonSchemaReady(isReady: boolean) {

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.apim.stories.ts
@@ -58,6 +58,7 @@ export default {
 
   render: props => ({
     template: `<div style="height:calc(100vh - 2rem);"><gio-policy-studio
+    [readOnly]="readOnly"
     [loading]="loading"
     [apiType]="apiType"
     [flowExecution]="flowExecution"
@@ -231,6 +232,39 @@ export const MessageWithAllPhases: StoryObj = {
   },
 };
 
+export const ReadonlyMessageWithAllPhases: StoryObj = {
+  name: 'Read only message API with All phases',
+  args: {
+    readOnly: true,
+    apiType: 'MESSAGE',
+    entrypointsInfo: [
+      fakeSSEMessageEntrypoint(),
+      fakeSSEMessageEntrypoint(),
+      fakeWebsocketMessageEntrypoint(),
+      fakeHTTPPostMessageEntrypoint(),
+      fakeHTTPGetMessageEntrypoint(),
+      fakeWebhookMessageEntrypoint(),
+    ],
+    endpointsInfo: [fakeMockMessageEndpoint(), fakeKafkaMessageEndpoint()],
+    commonFlows: [
+      fakeChannelFlow(base => {
+        const channelSelector = base.selectors?.find(selector => selector.type === 'CHANNEL') as ChannelSelector;
+        channelSelector.entrypoints = [];
+        channelSelector.operations = [];
+        return {
+          ...base,
+          name: 'Flow',
+          request: [fakeTestPolicyStep()],
+          response: [fakeTestPolicyStep()],
+          publish: [fakeTestPolicyStep()],
+          subscribe: [fakeTestPolicyStep()],
+        };
+      }),
+    ],
+    plans: [],
+  },
+};
+
 export const MessageWithDisabledPhase: StoryObj = {
   name: 'Message API with disabled phase',
   args: {
@@ -324,6 +358,81 @@ export const MessageWithConditionalExpressionLanguageStep: StoryObj = {
 export const ProxyWithFlowsAndPlans: StoryObj = {
   name: 'Proxy API with flows & plans',
   args: {
+    apiType: 'PROXY',
+    flowExecution: {
+      mode: 'BEST_MATCH',
+      matchRequired: false,
+    },
+    entrypointsInfo: [fakeHTTPProxyEntrypoint()],
+    endpointsInfo: [fakeHTTPProxyEndpoint()],
+    commonFlows: [
+      fakeHttpFlow(),
+      fakeHttpFlow({
+        name: 'Extra long flow name to test overflow Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      }),
+      fakeHttpFlow({
+        name: '',
+      }),
+    ],
+    plans: [
+      fakePlan({
+        name: 'Plan without flow and with a very long name to test overflow Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        flows: [
+          fakeHttpFlow({
+            name: '',
+          }),
+
+          fakeHttpFlow({
+            name: 'plan flow 1',
+          }),
+        ],
+      }),
+      fakePlan({
+        name: 'Second plan',
+        flows: [
+          fakeHttpFlow({
+            name: 'Flow 1',
+            selectors: [
+              {
+                type: 'HTTP',
+                methods: ['GET'],
+                path: '/path1',
+                pathOperator: 'EQUALS',
+              },
+            ],
+          }),
+          fakeHttpFlow({
+            name: 'Flow 2',
+            selectors: [
+              {
+                type: 'HTTP',
+                methods: ['GET', 'PUT', 'POST', 'DELETE'],
+                path: '/path1',
+                pathOperator: 'STARTS_WITH',
+              },
+            ],
+          }),
+          fakeHttpFlow({
+            name: 'Flow 3',
+            selectors: [
+              {
+                type: 'HTTP',
+                methods: [],
+                path: '/path3',
+                pathOperator: 'EQUALS',
+              },
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+};
+
+export const ReadOnlyProxyWithFlowsAndPlans: StoryObj = {
+  name: 'Read only proxy API with flows & plans',
+  args: {
+    readOnly: true,
     apiType: 'PROXY',
     flowExecution: {
       mode: 'BEST_MATCH',

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.html
@@ -47,6 +47,7 @@
 <div class="wrapper">
   <div class="wrapper__flowsMenu">
     <gio-ps-flows-menu
+      [readOnly]="readOnly"
       [loading]="loading"
       [apiType]="apiType"
       [flowExecution]="flowExecution"
@@ -60,6 +61,7 @@
 
   <div class="wrapper__flowDetails">
     <gio-ps-flow-details
+      [readOnly]="readOnly"
       [loading]="loading"
       [apiType]="apiType"
       [flow]="selectedFlow"

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.component.ts
@@ -38,6 +38,12 @@ import { GioPolicyStudioService } from './gio-policy-studio.service';
 })
 export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
   /**
+   * May be set to `true` if the API is not manageable from the UI (e.g. kubernetes operator APIs)
+   */
+  @Input()
+  public readOnly = false;
+
+  /**
    * API type (required)
    */
   @Input()

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.harness.ts
@@ -35,6 +35,11 @@ export class GioPolicyStudioHarness extends ComponentHarness {
 
   private phaseHarness = (phaseType: PhaseType) => this.locatorFor(GioPolicyStudioDetailsPhaseHarness.with({ type: phaseType }))();
 
+  public async isReadOnly(): Promise<boolean> {
+    const host = await this.host();
+    return Boolean(host.getAttribute('readOnly'));
+  }
+
   /**
    * Add a flow to a plan or to "Common flows"
    *

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -90,6 +90,22 @@ describe('GioPolicyStudioModule', () => {
       fixture.detectChanges();
     });
 
+    describe('with readOnly mode', () => {
+      beforeEach(() => {
+        component.readOnly = true;
+      });
+
+      it('should have readOnly attribute', async () => {
+        const attribute = await policyStudioHarness.isReadOnly();
+        expect(attribute).toBe(true);
+      });
+
+      it('should disable save button', async () => {
+        const state = await policyStudioHarness.getSaveButtonState();
+        expect(state).toBe('DISABLED');
+      });
+    });
+
     describe('with entrypointsInfo & endpointsInfo', () => {
       beforeEach(() => {
         component.entrypointsInfo = [fakeWebhookMessageEntrypoint()];


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-21

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.3.0-feat-read-only-policy-studio-fe5e3b5
```
```
yarn add @gravitee/ui-particles-angular@12.3.0-feat-read-only-policy-studio-fe5e3b5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.3.0-feat-read-only-policy-studio-fe5e3b5
```
```
yarn add @gravitee/ui-schematics@12.3.0-feat-read-only-policy-studio-fe5e3b5
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.3.0-feat-read-only-policy-studio-fe5e3b5
```
```
yarn add @gravitee/ui-policy-studio-angular@12.3.0-feat-read-only-policy-studio-fe5e3b5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-pdifcnogcs.chromatic.com)
<!-- Storybook placeholder end -->
