### PR TITLE
fix: isReadOnly method from policy studio harness

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.harness.ts
@@ -36,6 +36,14 @@ export class GioPolicyStudioDetailsHarness extends ComponentHarness {
     return matcher.test(hostText);
   }
 
+  public async isReadOnly(): Promise<boolean> {
+    const editFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__edit' }))();
+    const editBtnDisabled = await editFlowBtn.isDisabled();
+    const deleteFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__delete' }))();
+    const deleteBtnDisabled = await deleteFlowBtn.isDisabled();
+    return editBtnDisabled && deleteBtnDisabled;
+  }
+
   public async clickEditFlowBtn(): Promise<void> {
     const editFlowBtn = await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn__edit' }))();
     await editFlowBtn.click();

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
@@ -93,6 +93,17 @@ export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
     }
   }
 
+  public async isReadOnly(): Promise<boolean> {
+    const flowsGroups = await this.locateFlowsGroups();
+    const flowGroup = flowsGroups.pop();
+    if (!flowGroup) {
+      throw new Error('A flow group is required to test that menu is readonly');
+    }
+    const addBtn = await flowGroup.childLocatorFor(MatButtonHarness.with({ ancestor: '.list__flowsGroup__header__addBtn' }))();
+
+    return await addBtn.isDisabled();
+  }
+
   public async openFlowExecutionConfig(): Promise<void> {
     await (await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn_edit' }))())?.click();
   }

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.harness.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.harness.ts
@@ -36,8 +36,21 @@ export class GioPolicyStudioHarness extends ComponentHarness {
   private phaseHarness = (phaseType: PhaseType) => this.locatorFor(GioPolicyStudioDetailsPhaseHarness.with({ type: phaseType }))();
 
   public async isReadOnly(): Promise<boolean> {
-    const host = await this.host();
-    return Boolean(host.getAttribute('readOnly'));
+    const menu = await this.menuHarness();
+    const readOnlyMenu = await menu.isReadOnly();
+
+    await this.selectFlowInMenu('.+');
+
+    const details = await this.detailsHarness();
+    const emptyDetails = await details.isDisplayEmptyFlow();
+
+    if (!emptyDetails) {
+      await this.selectFlowInMenu('.+');
+      const readOnlyDetails = await details.isReadOnly();
+      return readOnlyMenu && readOnlyDetails;
+    }
+
+    return readOnlyMenu;
   }
 
   /**

--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/gio-policy-studio.spec.ts
@@ -31,9 +31,9 @@ import {
   fakeChannelFlow,
   fakeConditionedChannelFlow,
   fakeDefaultFlowExecution,
+  fakeHttpFlow,
   fakeHTTPProxyEndpoint,
   fakeHTTPProxyEntrypoint,
-  fakeHttpFlow,
   fakeKafkaMessageEndpoint,
   fakePlan,
   fakeRateLimitStep,
@@ -92,17 +92,24 @@ describe('GioPolicyStudioModule', () => {
 
     describe('with readOnly mode', () => {
       beforeEach(() => {
+        component.flowsGroups = [
+          {
+            name: 'main flows',
+            _id: 'main-flow',
+            flows: [
+              {
+                ...fakeChannelFlow({ name: 'flow1' }),
+                _id: 'flow',
+                _hasChanged: false,
+              },
+            ],
+          },
+        ];
         component.readOnly = true;
       });
 
-      it('should have readOnly attribute', async () => {
-        const attribute = await policyStudioHarness.isReadOnly();
-        expect(attribute).toBe(true);
-      });
-
-      it('should disable save button', async () => {
-        const state = await policyStudioHarness.getSaveButtonState();
-        expect(state).toBe('DISABLED');
+      it('should make studio read only', async () => {
+        expect(await policyStudioHarness.isReadOnly()).toBe(true);
       });
     });
 


### PR DESCRIPTION
This property can be access from the component and the method was flawed.
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.4.0-fix-studio-harness-a2e6885
```
```
yarn add @gravitee/ui-schematics@12.4.0-fix-studio-harness-a2e6885
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.4.0-fix-studio-harness-a2e6885
```
```
yarn add @gravitee/ui-particles-angular@12.4.0-fix-studio-harness-a2e6885
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.4.0-fix-studio-harness-a2e6885
```
```
yarn add @gravitee/ui-policy-studio-angular@12.4.0-fix-studio-harness-a2e6885
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xxsvmsxyat.chromatic.com)
<!-- Storybook placeholder end -->
