### PR TITLE
fix: error on load plugin's doc with policy studio

### DIFF
--- a/projects/ui-particles-angular/gio-asciidoctor/gio-asciidoctor.service.ts
+++ b/projects/ui-particles-angular/gio-asciidoctor/gio-asciidoctor.service.ts
@@ -20,7 +20,7 @@ import asciidoctor, { Asciidoctor } from '@asciidoctor/core';
 
 declare global {
   interface Window {
-    Asciidoctor: Asciidoctor;
+    _gioAsciidoctor: Asciidoctor;
   }
 }
 
@@ -36,15 +36,15 @@ export class GioAsciidoctorService {
   }
 
   private loadAsciidoctor(): Observable<Asciidoctor> {
-    if (!window.Asciidoctor) {
+    if (!window._gioAsciidoctor) {
       const loadAsciidoctor = async () => {
-        window.Asciidoctor = asciidoctor();
-        return window.Asciidoctor;
+        window._gioAsciidoctor = asciidoctor();
+        return window._gioAsciidoctor;
       };
 
       return from(loadAsciidoctor());
     } else {
-      return of(window.Asciidoctor);
+      return of(window._gioAsciidoctor);
     }
   }
 }


### PR DESCRIPTION
**Issue**

n/A

**Description**

This fix error on load plugin's doc with policy studio inside APIM since 4.3


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.11.0-fix-9dcc649
```
```
yarn add @gravitee/ui-particles-angular@12.11.0-fix-9dcc649
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.11.0-fix-9dcc649
```
```
yarn add @gravitee/ui-schematics@12.11.0-fix-9dcc649
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-aztoaoxgcw.chromatic.com)
<!-- Storybook placeholder end -->
