### PR TITLE
Small improvements for form-file-picker & form-selection-inline

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.html
+++ b/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.html
@@ -72,6 +72,6 @@
 <ng-template #filePreview let-fileValue="fileValue">
   <div class="file-picker__preview__image" *ngIf="fileValue.isImage" [style.background-image]="'url(' + fileValue.dataUrl + ')'"></div>
   <div class="file-picker__preview__file" *ngIf="!fileValue.isImage">
-    <p>{{ fileValue.name }}</p>
+    <span class="file-picker__preview__file__name">{{ fileValue.name }}</span>
   </div>
 </ng-template>

--- a/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
+++ b/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
@@ -33,7 +33,8 @@ $typography: map.get(gio.$mat-theme, typography);
   flex: 1 1 auto;
   flex-flow: row wrap;
   justify-content: center;
-  padding: 4px;
+  padding: 4px 0;
+  gap: 8px;
 
   &__add-button {
     min-width: $card-size-default;
@@ -41,7 +42,7 @@ $typography: map.get(gio.$mat-theme, typography);
     flex: 1 1 auto;
     border: 2px dashed mat.get-color-from-palette(gio.$mat-space-palette, lighter40);
     border-radius: $radius;
-    margin: 4px;
+    margin: 4px 0;
     cursor: pointer;
 
     &:hover,
@@ -56,7 +57,7 @@ $typography: map.get(gio.$mat-theme, typography);
     }
 
     &.complete {
-      padding: 6px;
+      padding: 6px 0;
       border: none;
     }
 
@@ -74,10 +75,10 @@ $typography: map.get(gio.$mat-theme, typography);
     flex: 0 0 $card-size-default;
     flex-flow: column nowrap;
     justify-content: space-between;
-    padding: 6px;
+    padding: 6px 0;
     border: 2px solid mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
     border-radius: $radius;
-    margin: 4px;
+    margin: 4px 0;
     inline-size: fit-content;
 
     &.drag-hover {

--- a/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
+++ b/projects/ui-particles-angular/src/lib/gio-form-file-picker/gio-form-file-picker.component.scss
@@ -106,6 +106,12 @@ $typography: map.get(gio.$mat-theme, typography);
       code {
         @include mat.typography-level($typography, 'caption');
       }
+
+      &__name {
+        position: absolute;
+        padding: 4px;
+        overflow-wrap: anywhere;
+      }
     }
 
     &.disabled {

--- a/projects/ui-particles-angular/src/lib/gio-form-selection-inline/gio-form-selection-inline-card.component.scss
+++ b/projects/ui-particles-angular/src/lib/gio-form-selection-inline/gio-form-selection-inline-card.component.scss
@@ -31,7 +31,7 @@ $accent: map.get(gio.$mat-theme, accent);
   flex: 1 1 auto;
   border: 1px solid var(--mdc-outlined-text-field-outline-color);
   border-radius: 4px;
-  margin: 6px;
+  margin: 6px 0;
   cursor: pointer;
 
   .selection-icon {
@@ -58,7 +58,7 @@ $accent: map.get(gio.$mat-theme, accent);
 
   &.selected {
     border: 2px solid mat.get-color-from-palette($accent);
-    margin: 5px;
+    margin: 5px 0;
     color: mat.get-color-from-palette($accent);
 
     .selection-icon__radio-icon {

--- a/projects/ui-particles-angular/src/lib/gio-form-selection-inline/gio-form-selection-inline.component.scss
+++ b/projects/ui-particles-angular/src/lib/gio-form-selection-inline/gio-form-selection-inline.component.scss
@@ -16,5 +16,6 @@
 
 :host {
   display: grid;
+  gap: 6px;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5103

**Description**

fix: improve form-file-picker with long file name
fix: remove default fist left marring 

:p

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.11.2-apim-5103-e9d704d
```
```
yarn add @gravitee/ui-schematics@12.11.2-apim-5103-e9d704d
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.11.2-apim-5103-e9d704d
```
```
yarn add @gravitee/ui-policy-studio-angular@12.11.2-apim-5103-e9d704d
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.11.2-apim-5103-e9d704d
```
```
yarn add @gravitee/ui-particles-angular@12.11.2-apim-5103-e9d704d
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-veqphjfckr.chromatic.com)
<!-- Storybook placeholder end -->
