### PR TITLE
fix: add pattern error message in json schema form component

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
@@ -43,6 +43,7 @@ import {
   minItemsValidationMessage,
   maxItemsValidationMessage,
   constValidationMessage,
+  patternValidationMessage,
 } from './util/validation-message.util';
 import { GioFormJsonSchemaComponent } from './gio-form-json-schema.component';
 import { GioBannerWrapperComponent as GioBannerWrapperComponent } from './wrappers/gio-banner-wrapper.component';
@@ -87,6 +88,7 @@ import { GioFjsCodeEditorTypeComponent } from './type-component/code-editor-type
         { name: 'maxItems', message: maxItemsValidationMessage },
         { name: 'uniqueItems', message: 'Should NOT have duplicate items' },
         { name: 'const', message: constValidationMessage },
+        { name: 'pattern', message: patternValidationMessage },
       ],
       wrappers: [
         { name: 'gio-with-banner', component: GioBannerWrapperComponent },

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/string.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/string.ts
@@ -59,6 +59,12 @@ export const stringExample: GioJsonSchema = {
       type: 'string',
       format: 'gio-code-editor',
     },
+    pattern: {
+      title: 'A string with a pattern validator',
+      description: 'Should not contains or ends with spaces',
+      type: 'string',
+      pattern: '^\\S+$',
+    },
   },
   required: ['requiredString'],
 };

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/util/validation-message.util.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-json-schema/util/validation-message.util.ts
@@ -58,3 +58,8 @@ export function constValidationMessage(error: unknown, field: FormlyFieldConfig)
 export function typeValidationMessage({ schemaType }: { schemaType: unknown[] }): string {
   return `Should be "${schemaType[0]}".`;
 }
+
+export function patternValidationMessage(error: unknown, field: FormlyFieldConfig): string {
+  const key = field?.key?.toString() ?? 'Field';
+  return `${key.charAt(0).toUpperCase() + key.slice(1)} value does not respect the pattern: ${field?.props?.pattern}`;
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5436

**Description**

add pattern error message in json schema form component

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.59.0-apim-5436-pattern-error-message-580f329
```
```
yarn add @gravitee/ui-particles-angular@7.59.0-apim-5436-pattern-error-message-580f329
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-jruivxckne.chromatic.com)
<!-- Storybook placeholder end -->
