### PR TITLE
fix: add pattern default error message

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
@@ -44,6 +44,7 @@ import {
   minItemsValidationMessage,
   maxItemsValidationMessage,
   constValidationMessage,
+  patternValidationMessage,
 } from './util/validation-message.util';
 import { GioFormJsonSchemaComponent } from './gio-form-json-schema.component';
 import { GioBannerWrapperComponent as GioBannerWrapperComponent } from './wrappers/gio-banner-wrapper.component';
@@ -90,6 +91,7 @@ import { GioFjsCronTypeComponent } from './type-component/cron-type.component';
         { name: 'maxItems', message: maxItemsValidationMessage },
         { name: 'uniqueItems', message: 'Should NOT have duplicate items' },
         { name: 'const', message: constValidationMessage },
+        { name: 'pattern', message: patternValidationMessage },
       ],
       wrappers: [
         { name: 'gio-with-banner', component: GioBannerWrapperComponent },

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/string.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/string.ts
@@ -65,6 +65,12 @@ export const stringExample: GioJsonSchema = {
       type: 'string',
       format: 'gio-cron',
     },
+    pattern: {
+      title: 'A string with a pattern validator',
+      description: 'Should not contains or ends with spaces',
+      type: 'string',
+      pattern: '^\\S+$',
+    },
   },
   required: ['requiredString', 'cron'],
 };

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/util/validation-message.util.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/util/validation-message.util.ts
@@ -58,3 +58,8 @@ export function constValidationMessage(error: unknown, field: FormlyFieldConfig)
 export function typeValidationMessage({ schemaType }: { schemaType: unknown[] }): string {
   return `Should be "${schemaType[0]}".`;
 }
+
+export function patternValidationMessage(error: unknown, field: FormlyFieldConfig): string {
+  const key = field?.key?.toString() ?? 'Field';
+  return `${key.charAt(0).toUpperCase() + key.slice(1)} value does not respect the pattern: ${field?.props?.pattern}`;
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5436

**Description**

Cherry pick of https://github.com/gravitee-io/gravitee-ui-particles/pull/400

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.11.3-apim-5436-pattern-error-message-main-f042a78
```
```
yarn add @gravitee/ui-policy-studio-angular@12.11.3-apim-5436-pattern-error-message-main-f042a78
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.11.3-apim-5436-pattern-error-message-main-f042a78
```
```
yarn add @gravitee/ui-particles-angular@12.11.3-apim-5436-pattern-error-message-main-f042a78
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-ijeabjbztn.chromatic.com)
<!-- Storybook placeholder end -->
