### PR TITLE
feat: send policy default values on init

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
@@ -88,12 +88,7 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
     });
 
     this.stepForm.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
-      this.stepChange.emit({
-        ...this.step,
-        description: this.stepForm?.get('description')?.value,
-        condition: this.stepForm?.get('condition')?.value ?? undefined,
-        configuration: this.stepForm?.get('configuration')?.value,
-      });
+      this.emitStepChange();
     });
 
     this.stepForm.statusChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(valid => {
@@ -107,8 +102,21 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
 
   public onJsonSchemaReady(isReady: boolean) {
     // When ready and if the form is valid, emit
-    if (isReady && this.stepForm?.status === 'VALID') {
-      this.isValid.emit(true);
+    if (isReady) {
+      this.emitStepChange();
+
+      if (this.stepForm?.status === 'VALID') {
+        this.isValid.emit(true);
+      }
     }
+  }
+
+  public emitStepChange(): void {
+    this.stepChange.emit({
+      ...this.step,
+      description: this.stepForm?.get('description')?.value,
+      condition: this.stepForm?.get('condition')?.value ?? undefined,
+      configuration: this.stepForm?.get('configuration')?.value,
+    });
   }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5654

**Description**

Init the form with default configuration's values.

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.11.4-apim-5654-ps-default-values-398653c
```
```
yarn add @gravitee/ui-schematics@12.11.4-apim-5654-ps-default-values-398653c
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.11.4-apim-5654-ps-default-values-398653c
```
```
yarn add @gravitee/ui-policy-studio-angular@12.11.4-apim-5654-ps-default-values-398653c
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.11.4-apim-5654-ps-default-values-398653c
```
```
yarn add @gravitee/ui-particles-angular@12.11.4-apim-5654-ps-default-values-398653c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-vilbqmvgdw.chromatic.com)
<!-- Storybook placeholder end -->
