### PR TITLE
feat: send policy default values on init

### DIFF
--- a/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
+++ b/ui-particles-angular/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
@@ -83,12 +83,7 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
     });
 
     this.stepForm.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
-      this.stepChange.emit({
-        ...this.step,
-        description: this.stepForm?.get('description')?.value,
-        condition: this.stepForm?.get('condition')?.value ?? undefined,
-        configuration: this.stepForm?.get('configuration')?.value,
-      });
+      this.emitStepChange();
     });
 
     this.stepForm.statusChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(valid => {
@@ -98,8 +93,21 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
 
   public onJsonSchemaReady(isReady: boolean) {
     // When ready and if the form is valid, emit
-    if (isReady && this.stepForm?.status === 'VALID') {
-      this.isValid.emit(true);
+    if (isReady) {
+      this.emitStepChange();
+
+      if (this.stepForm?.status === 'VALID') {
+        this.isValid.emit(true);
+      }
     }
+  }
+
+  public emitStepChange(): void {
+    this.stepChange.emit({
+      ...this.step,
+      description: this.stepForm?.get('description')?.value,
+      condition: this.stepForm?.get('condition')?.value ?? undefined,
+      configuration: this.stepForm?.get('configuration')?.value,
+    });
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5654

**Description**

Send  send policy default values on init when json schema form component is ready

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.59.1-apim-5654-cherry-pick-48e5f86
```
```
yarn add @gravitee/ui-particles-angular@7.59.1-apim-5654-cherry-pick-48e5f86
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.59.1-apim-5654-cherry-pick-48e5f86
```
```
yarn add @gravitee/ui-policy-studio-angular@7.59.1-apim-5654-cherry-pick-48e5f86
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-kcgxvhfrqx.chromatic.com)
<!-- Storybook placeholder end -->
