### PR TITLE
feat(monaco-editor): add CSS language

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -55,6 +55,9 @@ export type MonacoEditorLanguageConfig =
   | {
       language: 'spel';
       schema?: JSONSchema;
+    }
+  | {
+      language: 'css';
     };
 
 @Component({

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -96,6 +96,17 @@ export const LanguageJson: StoryObj = {
   },
 };
 
+export const LanguageCss: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'css',
+    },
+    value: `.style {
+  border: 1px solid black;
+}`,
+  },
+};
+
 export const LanguageEL: StoryObj = {
   args: {
     languageConfig: {


### PR DESCRIPTION
**Issue**

N/A

**Description**

Allow CSS edition in monaco editor.

<img width="646" alt="image" src="https://github.com/user-attachments/assets/10237b92-08e8-4f6b-abd0-79c73204d25c">
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.13.1-add-css-in-monaco-editor-ca83b42
```
```
yarn add @gravitee/ui-particles-angular@12.13.1-add-css-in-monaco-editor-ca83b42
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.13.1-add-css-in-monaco-editor-ca83b42
```
```
yarn add @gravitee/ui-policy-studio-angular@12.13.1-add-css-in-monaco-editor-ca83b42
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.13.1-add-css-in-monaco-editor-ca83b42
```
```
yarn add @gravitee/ui-schematics@12.13.1-add-css-in-monaco-editor-ca83b42
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-pyocathhcy.chromatic.com)
<!-- Storybook placeholder end -->
