### PR TITLE
allow users to disable submit button in gio-save-bar

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
@@ -37,6 +37,7 @@
         mat-flat-button
         color="primary"
         [type]="form ? 'submit' : 'button'"
+        [disabled]="disableSaveButton"
         (click)="onSubmitClicked()"
       >
         {{ creationMode ? 'Create' : 'Save' }}

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
@@ -70,6 +70,9 @@ export class GioSaveBarComponent {
   @Input()
   public hideDiscardButton = false;
 
+  @Input()
+  public disableSaveButton = false;
+
   @Output()
   public resetClicked = new EventEmitter<void>();
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.harness.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.harness.ts
@@ -15,6 +15,7 @@
  */
 
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class GioSaveBarHarness extends ComponentHarness {
   public static hostSelector = 'gio-save-bar';
@@ -23,7 +24,7 @@ export class GioSaveBarHarness extends ComponentHarness {
   private readonly resetButtonSelector = '.save-bar__content__actions__reset-button';
   private readonly submitButtonSelector = '.save-bar__content__actions__submit-button';
 
-  protected getSubmitButton = this.locatorFor(this.submitButtonSelector);
+  protected getSubmitButton = this.locatorFor(MatButtonHarness.with({ selector: this.submitButtonSelector }));
   protected getResetButton = this.locatorFor(this.resetButtonSelector);
 
   public async isVisible(): Promise<boolean> {
@@ -40,7 +41,13 @@ export class GioSaveBarHarness extends ComponentHarness {
 
   public async isSubmitButtonInvalid(): Promise<boolean> {
     const submitButton = await this.getSubmitButton();
-    return submitButton.hasClass('invalid');
+    const submitButtonHost = await submitButton.host();
+    return submitButtonHost.hasClass('invalid');
+  }
+
+  public async isSubmitButtonDisabled(): Promise<boolean> {
+    const submitButton = await this.getSubmitButton();
+    return submitButton.isDisabled();
   }
 
   public async isSubmitButtonVisible(): Promise<boolean> {

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
@@ -183,3 +183,22 @@ export const CreationMode: Story = {
     },
   }),
 };
+
+export const SaveButtonDisabled: Story = {
+  name: 'Creation Mode / Save Button Disabled',
+  render: () => ({
+    template: `
+    <div style="padding-bottom: 400px">
+      <gio-save-bar
+        [creationMode]="true"
+        [disableSaveButton]="true"
+        (resetClicked)="onReset($event)"
+        (submitted)="onSubmit($event)"
+      ></gio-save-bar>
+    </div>
+    `,
+    props: {
+      onSubmit: (e: unknown) => action('Submit')(e),
+    },
+  }),
+};


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4691

**Description**

Allow users to disable submit button in gio-save-bar

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.60.0-apim-4691-disable-save-button-7x-8c3be91
```
```
yarn add @gravitee/ui-policy-studio-angular@7.60.0-apim-4691-disable-save-button-7x-8c3be91
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.60.0-apim-4691-disable-save-button-7x-8c3be91
```
```
yarn add @gravitee/ui-particles-angular@7.60.0-apim-4691-disable-save-button-7x-8c3be91
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-kaqmftiwjh.chromatic.com)
<!-- Storybook placeholder end -->
