### PR TITLE
fix: avoid double-clicking and disable the save/create button during lock time

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
@@ -37,9 +37,10 @@
         mat-flat-button
         color="primary"
         [type]="form ? 'submit' : 'button'"
+        [disabled]="isSubmitted"
         (click)="onSubmitClicked()"
       >
-        {{ creationMode ? 'Create' : 'Save' }}
+        {{ creationMode ? 'Create' : 'Save' }}{{ isSubmitted ? '...' : '' }}
       </button>
     </div>
   </mat-card>

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 import { animate, style, transition, trigger } from '@angular/animations';
-import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { Component, EventEmitter, HostBinding, HostListener, Input, OnDestroy, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { timer } from 'rxjs';
+import { of, Subscription } from 'rxjs';
+import { delay, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'gio-save-bar',
@@ -35,7 +36,7 @@ import { timer } from 'rxjs';
     ]),
   ],
 })
-export class GioSaveBarComponent {
+export class GioSaveBarComponent implements OnDestroy {
   public isSubmitted = false;
 
   @HostBinding('class.save-bar-sticky')
@@ -60,6 +61,7 @@ export class GioSaveBarComponent {
   public form?: FormGroup;
 
   private hasSubmitLock = true;
+  private submitLockSubscription?: Subscription;
 
   @Input()
   public formInitialValues?: unknown;
@@ -91,6 +93,10 @@ export class GioSaveBarComponent {
     return this.opened;
   }
 
+  public ngOnDestroy() {
+    this.submitLockSubscription?.unsubscribe();
+  }
+
   public onResetClicked(): void {
     if (this.form) {
       this.form.reset(this.formInitialValues);
@@ -117,8 +123,15 @@ export class GioSaveBarComponent {
 
     this.submitted.emit();
     if (this.hasSubmitLock) {
-      this.isSubmitted = true;
-      timer(2000).subscribe(() => (this.isSubmitted = false));
+      this.submitLockSubscription = of(undefined)
+        .pipe(
+          // Arrange js microtask queue to be sure that the disabled button state is set after triggering the ngSubmit event
+          delay(0),
+          tap(() => (this.isSubmitted = true)),
+          delay(2000),
+          tap(() => (this.isSubmitted = false)),
+        )
+        .subscribe();
     }
   }
 }

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
@@ -89,7 +89,7 @@ export const ReactiveForm: Story = {
 
     return {
       template: `
-      <form style="padding-bottom: 400px" [formGroup]="form" >
+      <form style="padding-bottom: 400px" [formGroup]="form" (ngSubmit)="ngSubmit($event)" >
         <div>A long form, with many many fields</div>
         <div style="display: flex; flex-direction: column;"
            *ngFor="let item of [].constructor(40)">
@@ -104,6 +104,7 @@ export const ReactiveForm: Story = {
       </form>
       `,
       props: {
+        ngSubmit: (e: unknown) => action('Submit')(e),
         form,
         formInitialValues,
       },


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

To keep the same logic to avoid double-clicking, but to allow the action to be restarted. Disable button during lock period

The choice of a 2s lock was made to avoid having to implement a lock mechanism on each use of the button. and to allow a new try if the 1st is in error for example. This is classic button save behavior.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.60.0-fix-save-bar-auto-lock-42967e6
```
```
yarn add @gravitee/ui-particles-angular@7.60.0-fix-save-bar-auto-lock-42967e6
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.60.0-fix-save-bar-auto-lock-42967e6
```
```
yarn add @gravitee/ui-policy-studio-angular@7.60.0-fix-save-bar-auto-lock-42967e6
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-bpnaahdoqz.chromatic.com)
<!-- Storybook placeholder end -->
