### PR TITLE
feat: add auto-format on init for Monaco editor

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -51,8 +51,11 @@ export default {
     disableMiniMap: {
       control: { type: 'boolean' },
     },
+    disableAutoFormat: {
+      control: { type: 'boolean' },
+    },
   },
-  render: ({ value, disabled, languageConfig, disableMiniMap }) => {
+  render: ({ value, disabled, languageConfig, disableMiniMap, disableAutoFormat }) => {
     const control = new UntypedFormControl({ value, disabled });
     control.valueChanges.subscribe(value => {
       action('valueChanges')(value);
@@ -62,7 +65,7 @@ export default {
     });
     return {
       template: `
-      <gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig" [disableMiniMap]="disableMiniMap"></gio-monaco-editor>
+      <gio-monaco-editor [formControl]="control" [languageConfig]="languageConfig" [disableMiniMap]="disableMiniMap" [disableAutoFormat]="disableAutoFormat"></gio-monaco-editor>
       <br>
       <pre>{{ control.status }}</pre>
       <pre>{{ control.dirty ? 'DIRTY' : 'PRISTINE' }}</pre>
@@ -73,6 +76,7 @@ export default {
         control,
         languageConfig,
         disableMiniMap,
+        disableAutoFormat,
       },
     };
   },
@@ -80,41 +84,6 @@ export default {
 
 export const Default: StoryObj = {
   args: {},
-};
-
-export const LanguageJson: StoryObj = {
-  args: {
-    languageConfig: {
-      language: 'json',
-      schemas: [
-        {
-          uri: 'http://myserver/foo-schema.json',
-          schema: GioJsonSchema,
-        },
-      ],
-    },
-  },
-};
-
-export const LanguageCss: StoryObj = {
-  args: {
-    languageConfig: {
-      language: 'css',
-    },
-    value: `.style {
-  border: 1px solid black;
-}`,
-  },
-};
-
-export const LanguageEL: StoryObj = {
-  args: {
-    languageConfig: {
-      language: 'spel',
-      schema: ElSchema,
-    },
-    value: `{#request.headers['x-story'] == 'true'}`,
-  },
 };
 
 export const Disabled: StoryObj = {
@@ -199,6 +168,104 @@ export const FormControlName: StoryObj = {
     };
   },
   args: {},
+};
+
+export const LanguageAutoDetectJSON: StoryObj = {
+  args: {
+    value: `{
+      "type": "object",
+      "properties": { "firstName": { "type": "string" } }
+    }`,
+  },
+};
+
+export const LanguageJson: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'json',
+      schemas: [
+        {
+          uri: 'http://myserver/foo-schema.json',
+          schema: GioJsonSchema,
+        },
+      ],
+    },
+  },
+};
+
+export const LanguageCss: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'css',
+    },
+    value: `.style {
+  border: 1px solid black;
+}`,
+  },
+};
+
+export const LanguageEL: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'spel',
+      schema: ElSchema,
+    },
+    value: `{#request.headers['x-story'] == 'true'}`,
+  },
+};
+
+export const LanguageJsonAutoFormat: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'json',
+    },
+    value: `{
+      "type": "object",
+      "properties": { "firstName": { "type": "string" } }
+    }`,
+  },
+};
+
+export const LanguageJsonDisableAutoFormat: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'json',
+    },
+    disableAutoFormat: true,
+    value: `{
+      "type": "object",
+      "properties": { "firstName": { "type": "string" } }
+    }`,
+  },
+};
+
+export const LanguageJsonWithSchemaValidation: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'json',
+      schemas: [
+        {
+          uri: 'http://myserver/foo-schema.json',
+          schema: GioJsonSchema,
+        },
+      ],
+    },
+    value: `{
+      "type": "object",
+      "properties": { "firstName": { "type": "string" } }
+    }`,
+  },
+};
+
+export const LanguageYaml: StoryObj = {
+  args: {
+    languageConfig: {
+      language: 'yaml',
+    },
+    value: `openapi: 3.0.0
+info:
+  title: Sample API`,
+  },
 };
 
 export const LanguageMarkdown: StoryObj = {

--- a/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.ts
@@ -19,6 +19,7 @@ import { GIO_DIALOG_WIDTH, GioIconsModule } from '@gravitee/ui-particles-angular
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { CommonModule } from '@angular/common';
+import { isEmpty, isNil } from 'lodash';
 
 import {
   GioPolicyStudioStepEditDialogComponent,
@@ -61,7 +62,7 @@ export class GioPolicyStudioDetailsPhaseStepComponent implements OnChanges {
   constructor(private readonly matDialog: MatDialog) {}
 
   public ngOnChanges(changes: SimpleChanges): void {
-    if (changes.policies || changes.step) {
+    if ((changes.policies || changes.step) && !isEmpty(this.policies) && !isNil(this.step.policy)) {
       this.policy = this.policies.find(policy => policy.id === this.step.policy);
     }
   }


### PR DESCRIPTION
Really use full for json language

**Issue**

https://github.com/gravitee-io/issues/issues/APIM-4332

**Description**

- Add auto-format on init for Monaco editor 
- small fix for PS

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.17.0-monac-auto-format-01238d9
```
```
yarn add @gravitee/ui-particles-angular@12.17.0-monac-auto-format-01238d9
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.17.0-monac-auto-format-01238d9
```
```
yarn add @gravitee/ui-policy-studio-angular@12.17.0-monac-auto-format-01238d9
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.17.0-monac-auto-format-01238d9
```
```
yarn add @gravitee/ui-schematics@12.17.0-monac-auto-format-01238d9
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-yuzhgugwxl.chromatic.com)
<!-- Storybook placeholder end -->
