### PR TITLE
fix: fix app name text overflow under API Plan Subscriptions

### DIFF
--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.scss
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.scss
@@ -13,6 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+::ng-deep {
+  gio-form-tags-input {
+    .mat-mdc-standard-chip {
+      height: unset !important;
+      min-height: var(--mdc-chip-container-height);
+    }
+
+    .mat-mdc-standard-chip .mdc-evolution-chip__text-label {
+      white-space: normal;
+    }
+  }
+}
+
 .loader-option {
   display: flex;
 

--- a/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
+++ b/ui-particles-angular/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
@@ -331,3 +331,31 @@ export const WithAsyncAutocompleteOnly: Story = {
     },
   },
 };
+
+export const WithLimitedWidth: Story = {
+  render: ({ tags, disabled }) => {
+    const tagsControl = new FormControl({ value: tags, disabled });
+
+    tagsControl.valueChanges.subscribe(value => {
+      action('Tags')(value);
+    });
+
+    return {
+      template: `
+      <mat-form-field appearance="fill" style="width:200px">
+        <gio-form-tags-input
+          [formControl]="tagsControl">
+        </gio-form-tags-input>
+      </mat-form-field>
+      `,
+      props: {
+        tags,
+        tagsControl,
+      },
+    };
+  },
+  args: {
+    tags: ['lorem ipsum dolor sit amet'],
+    disabled: false,
+  },
+};


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5870

**Description**

Fix text overflow for the 'gio-form-tags-input' component.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@7.60.0-apim-5870-app-name-text-overflow-fix-v2-ca34b3f
```
```
yarn add @gravitee/ui-particles-angular@7.60.0-apim-5870-app-name-text-overflow-fix-v2-ca34b3f
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@7.60.0-apim-5870-app-name-text-overflow-fix-v2-ca34b3f
```
```
yarn add @gravitee/ui-policy-studio-angular@7.60.0-apim-5870-app-name-text-overflow-fix-v2-ca34b3f
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-yrkdbfewij.chromatic.com)
<!-- Storybook placeholder end -->
