### PR TITLE
feat: Add optional autocomplete for form header table

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-headers/README.stories.mdx
+++ b/projects/ui-particles-angular/src/lib/gio-form-headers/README.stories.mdx
@@ -17,6 +17,7 @@ Key autocomplete is provided for common headers.
 
 - Work with ReactiveFormsModule
 - `headerFieldMapper` (optional): A mapping definition for the default key/value attributes in order to adapt the output of the component to the desired format. e.g. `{keyName: 'name', valueName: 'value'}`
+- `autocompleteDisabled` (optional): Used to disable autocomplete
 
 **Output**
 

--- a/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.html
+++ b/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.html
@@ -38,6 +38,7 @@
             cdkTextareaAutosize
             cdkAutosizeMinRows="1"
             [matAutocomplete]="headerNamesAutocomplete"
+            [matAutocompleteDisabled]="autocompleteDisabled"
           ></textarea>
         </div>
         <mat-error *ngIf="control.get('key')?.hasError('pattern')">

--- a/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-headers/gio-form-headers.component.ts
@@ -137,6 +137,9 @@ export class GioFormHeadersComponent implements OnInit, ControlValueAccessor, Va
     valueName: 'value',
   };
 
+  @Input()
+  public autocompleteDisabled?: boolean = false;
+
   public mainForm: UntypedFormGroup;
   public headersFormArray = new UntypedFormArray([
     new UntypedFormGroup({


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5157

**Description**

Made key autocomplete optional for table to be reused as other type than HTTP headers.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.19.0-apim-5157-optional-autocomplete-for-form-header-61e5e7f
```
```
yarn add @gravitee/ui-schematics@12.19.0-apim-5157-optional-autocomplete-for-form-header-61e5e7f
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.19.0-apim-5157-optional-autocomplete-for-form-header-61e5e7f
```
```
yarn add @gravitee/ui-policy-studio-angular@12.19.0-apim-5157-optional-autocomplete-for-form-header-61e5e7f
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.19.0-apim-5157-optional-autocomplete-for-form-header-61e5e7f
```
```
yarn add @gravitee/ui-particles-angular@12.19.0-apim-5157-optional-autocomplete-for-form-header-61e5e7f
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-exkybdfbky.chromatic.com)
<!-- Storybook placeholder end -->
