### PR TITLE
Improve: Policy Group Studio & Policy Studio

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-confirm-dialog/README.stories.mdx
+++ b/projects/ui-particles-angular/src/lib/gio-confirm-dialog/README.stories.mdx
@@ -17,6 +17,7 @@ Documentation and examples for Confirm dialog, a component to asking for confirm
  - `content`: `string` | `{ componentOutlet: Type<unknown>; componentInputs?: Record<string, unknown>; }` - The dialog content override.
  - `confirmButton`: `string` - The dialog confirmation button override.
  - `confirmCancel`: `string` - The dialog cancel button override.
+ - `disableCancel`: `boolean` - Disable the cancel button.
 
 Example:
 

--- a/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.html
+++ b/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.html
@@ -26,9 +26,11 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="confirm-dialog__actions">
-  <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">
-    {{ cancelButton }}
-  </button>
+  @if (!disableCancel) {
+    <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">
+      {{ cancelButton }}
+    </button>
+  }
   <button
     class="confirm-dialog__confirm-button"
     color="warn"

--- a/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.component.ts
@@ -27,7 +27,10 @@ export type GioConfirmDialogData = {
       };
   confirmButton?: string;
   cancelButton?: string;
+  disableCancel?: boolean;
 };
+
+export type GioConfirmDialogResult = boolean;
 
 @Component({
   selector: 'gio-confirm-dialog',
@@ -42,9 +45,10 @@ export class GioConfirmDialogComponent {
   public contentComponentInjector: Injector;
   public confirmButton: string;
   public cancelButton: string;
+  public disableCancel: boolean;
 
   constructor(
-    public dialogRef: MatDialogRef<GioConfirmDialogComponent>,
+    public dialogRef: MatDialogRef<GioConfirmDialogComponent, GioConfirmDialogResult>,
     @Inject(MAT_DIALOG_DATA) confirmDialogData: GioConfirmDialogData,
     private readonly parentInjector: Injector,
   ) {
@@ -64,5 +68,6 @@ export class GioConfirmDialogComponent {
 
     this.confirmButton = confirmDialogData?.confirmButton ?? 'Confirm';
     this.cancelButton = confirmDialogData?.cancelButton ?? 'Cancel';
+    this.disableCancel = confirmDialogData?.disableCancel ?? false;
   }
 }

--- a/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.stories.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.stories.component.ts
@@ -18,7 +18,7 @@ import { Component, Inject, Input, Type } from '@angular/core';
 import { tap } from 'rxjs/operators';
 import { action } from '@storybook/addon-actions';
 
-import { GioConfirmDialogComponent, GioConfirmDialogData } from './gio-confirm-dialog.component';
+import { GioConfirmDialogComponent, GioConfirmDialogData, GioConfirmDialogResult } from './gio-confirm-dialog.component';
 
 @Component({
   selector: 'gio-confirm-dialog-story',
@@ -34,17 +34,19 @@ export class ConfirmDialogStoryComponent {
       };
   @Input() public confirmButton?: string;
   @Input() public cancelButton?: string;
+  @Input() public disableCancel?: boolean;
 
   constructor(private readonly matDialog: MatDialog) {}
 
   public openConfirmDialog() {
     this.matDialog
-      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, GioConfirmDialogResult>(GioConfirmDialogComponent, {
         data: {
           title: this.title,
           content: this.content,
           confirmButton: this.confirmButton,
           cancelButton: this.cancelButton,
+          disableCancel: this.disableCancel,
         },
         role: 'alertdialog',
         id: 'confirmDialog',

--- a/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-confirm-dialog/gio-confirm-dialog.stories.ts
@@ -42,6 +42,9 @@ export default {
     cancelButton: {
       type: { name: 'string', required: false },
     },
+    disableCancel: {
+      type: { name: 'boolean', required: false },
+    },
   },
   parameters: {
     chromatic: { delay: 2000 },
@@ -84,4 +87,17 @@ CustomContentComponent.args = {
   },
   confirmButton: 'Yes, I want',
   cancelButton: 'Nope',
+};
+
+export const OnlyConfirmChoice: StoryObj = {
+  play: context => {
+    const button = context.canvasElement.querySelector('#open-confirm-dialog') as HTMLButtonElement;
+    button.click();
+  },
+};
+OnlyConfirmChoice.args = {
+  title: 'For your information',
+  content: 'This is an information message.',
+  confirmButton: 'OK',
+  disableCancel: true,
 };

--- a/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.html
+++ b/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase-step/gio-ps-flow-details-phase-step.component.html
@@ -22,9 +22,19 @@
 
     <span *ngIf="step.name" class="info__head__name">{{ step.name }}</span>
 
-    <span *ngIf="genericPolicy?.type === 'SHARED_POLICY_GROUP'" class="gio-badge-neutral" matTooltip="Shared Policy Group"
-      ><mat-icon svgIcon="gio:users"></mat-icon
-    ></span>
+    <span *ngIf="genericPolicy?.type === 'SHARED_POLICY_GROUP'" class="gio-badge-neutral" matTooltip="Shared Policy Group">
+      <mat-icon svgIcon="gio:users"></mat-icon>
+    </span>
+    <span
+      *ngIf="policyNotFound !== false"
+      class="gio-badge-error"
+      [matTooltip]="policyNotFound === 'SHARED_POLICY_GROUP' ? 'Shared Policy Group not found' : 'Policy not found'"
+    >
+      @if (policyNotFound === 'SHARED_POLICY_GROUP') {
+        <mat-icon svgIcon="gio:users"></mat-icon>&nbsp;
+      }
+      <mat-icon svgIcon="gio:alert-circle"></mat-icon>
+    </span>
   </div>
 
   <div *ngIf="step.description" class="info__description">{{ step.description }}</div>

--- a/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/step-form/gio-ps-step-form.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { ReactiveFormsModule, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
-import { map, takeUntil } from 'rxjs/operators';
+import { catchError, map, takeUntil } from 'rxjs/operators';
 import { Observable, of, Subject } from 'rxjs';
 import {
   GioFormJsonSchemaComponent,
@@ -89,9 +89,10 @@ export class GioPolicyStudioStepFormComponent implements OnChanges, OnInit, OnDe
           }),
         );
 
-        this.policyDocumentation$ = this.policyStudioService
-          .getPolicyDocumentation(toPolicy(this.genericPolicy))
-          .pipe(map(doc => (isEmpty(doc) ? 'No documentation available.' : doc)));
+        this.policyDocumentation$ = this.policyStudioService.getPolicyDocumentation(toPolicy(this.genericPolicy)).pipe(
+          map(doc => (isEmpty(doc) ? 'No documentation available.' : doc)),
+          catchError(() => of('No documentation available.')),
+        );
       }
       if (isSharedPolicyGroupPolicy(this.genericPolicy)) {
         this.policySchema$ = of({});

--- a/projects/ui-policy-studio-angular/src/lib/policy-group-studio/gio-policy-group-studio.apim.stories.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-group-studio/gio-policy-group-studio.apim.stories.ts
@@ -53,6 +53,24 @@ export const Loading = () => ({
   },
 });
 
+export const ReadOnly = () => ({
+  props: {
+    policyGroupChange: action('policyGroupChange'),
+    policies: fakeAllPolicies(),
+    policySchemaFetcher: (policy: Policy) => of(fakePolicySchema(policy.id)).pipe(delay(600)),
+    policyDocumentationFetcher: (policy: Policy) => of(fakePolicyDocumentation(policy.id)).pipe(delay(600)),
+    executionPhase: 'REQUEST',
+    apiType: 'PROXY',
+    policyGroup: [
+      {
+        policy: fakeTestPolicy().id,
+        name: 'Policy Test',
+      },
+    ],
+    readOnly: true,
+  },
+});
+
 export const ProxyAPIRequestPhase = () => ({
   props: {
     policyGroupChange: action('policyGroupChange'),

--- a/projects/ui-policy-studio-angular/src/lib/policy-group-studio/gio-policy-group-studio.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-group-studio/gio-policy-group-studio.component.ts
@@ -59,6 +59,12 @@ export class GioPolicyGroupStudioComponent implements OnChanges {
   public policies: Policy[] = [];
 
   /**
+   * Whether the Policy Group Studio is in read-only mode
+   */
+  @Input()
+  public readOnly = false;
+
+  /**
    * Type of the API targeted by the Policy Group Studio
    */
   @Input({ required: true })
@@ -94,7 +100,6 @@ export class GioPolicyGroupStudioComponent implements OnChanges {
   public policyGroupChange: EventEmitter<PolicyGroupOutput> = new EventEmitter<PolicyGroupOutput>();
 
   protected isLoading = true;
-  protected readOnly = false;
   protected startConnector: (name: string) => ConnectorInfo[] = name => [
     {
       name,

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.apim.stories.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.apim.stories.ts
@@ -458,7 +458,15 @@ export const ProxyWithSharedPolicyGroup: StoryObj = {
         name: 'Second plan',
         flows: [
           fakeHttpFlow({
-            request: [fakeSharedPolicyGroupPolicyStep()],
+            request: [
+              fakeSharedPolicyGroupPolicyStep(),
+              fakeSharedPolicyGroupPolicyStep({
+                name: 'SPG Not found',
+                configuration: {
+                  sharedPolicyGroupId: 'undefined',
+                },
+              }),
+            ],
           }),
         ],
       }),


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-6289
**Description**

- add readOnly input for Policy Group Studio

![image](https://github.com/user-attachments/assets/e17b6966-bc72-42f8-acbc-fc4894be04b3)


- handle the case when policy or SPG is not found
![image](https://github.com/user-attachments/assets/ac56a16f-3588-4356-86fd-28ff4fac8de3)
![image](https://github.com/user-attachments/assets/f84869b4-90b8-4b9c-abba-48a1a5a0c9b0)


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.19.0-spg-readonly-1e485b0
```
```
yarn add @gravitee/ui-policy-studio-angular@12.19.0-spg-readonly-1e485b0
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.19.0-spg-readonly-e5e34c4
```
```
yarn add @gravitee/ui-particles-angular@12.19.0-spg-readonly-e5e34c4
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.19.0-spg-readonly-e5e34c4
```
```
yarn add @gravitee/ui-schematics@12.19.0-spg-readonly-e5e34c4
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-qtpboyqdzn.chromatic.com)
<!-- Storybook placeholder end -->
