### PR TITLE
fix: avoid double-clicking and disable the save/create button during lock time

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
+++ b/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.component.html
@@ -41,9 +41,10 @@
         mat-flat-button
         color="primary"
         [type]="form ? 'submit' : 'button'"
+        [disabled]="isSubmitted"
         (click)="onSubmitClicked()"
       >
-        {{ creationMode ? 'Create' : 'Save' }}
+        {{ creationMode ? 'Create' : 'Save' }}{{ isSubmitted ? '...' : '' }}
       </button>
     </div>
   </mat-card>

--- a/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-save-bar/gio-save-bar.stories.ts
@@ -87,7 +87,7 @@ export const ReactiveForm: StoryObj = {
 
     return {
       template: `
-      <form style="padding-bottom: 400px" [formGroup]="form" >
+      <form style="padding-bottom: 400px" [formGroup]="form" (ngSubmit)="ngSubmit($event)" >
         <div>A long form, with many many fields</div>
         <div style="display: flex; flex-direction: column;"
            *ngFor="let item of [].constructor(40)">
@@ -102,6 +102,7 @@ export const ReactiveForm: StoryObj = {
       </form>
       `,
       props: {
+        ngSubmit: (e: unknown) => action('Submit')(e),
         form,
         formInitialValues,
       },


### PR DESCRIPTION

**Issue**
CP from https://github.com/gravitee-io/gravitee-ui-particles/pull/411

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@12.21.0-fix-save-bar-auto-lock-2-8827e66
```
```
yarn add @gravitee/ui-schematics@12.21.0-fix-save-bar-auto-lock-2-8827e66
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@12.21.0-fix-save-bar-auto-lock-2-8827e66
```
```
yarn add @gravitee/ui-particles-angular@12.21.0-fix-save-bar-auto-lock-2-8827e66
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@12.21.0-fix-save-bar-auto-lock-2-8827e66
```
```
yarn add @gravitee/ui-policy-studio-angular@12.21.0-fix-save-bar-auto-lock-2-8827e66
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-bxhuinbozy.chromatic.com)
<!-- Storybook placeholder end -->
