### PR TITLE
fix: when the menu is invisible, there's no need to give it a height

### DIFF
--- a/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.component.ts
+++ b/projects/ui-particles-angular/src/lib/oem-theme/gio-submenu/gio-submenu.component.ts
@@ -68,6 +68,7 @@ export class GioSubmenuComponent implements AfterViewInit, OnDestroy {
         this.reduced = true;
         this.loaded = true;
         this.gioSubmenu.nativeElement.style.height = 'auto';
+        this.gioSubmenu.nativeElement.style.maxHeight = `0vh`;
       }),
       // On hover root menu item, open the submenu with top position
       switchMap(() => this.gioMenuService.overlayObservable),


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5438

**Description**

Avoid adding an unnecessary scrollbar

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@13.1.4-apim-5438-612fa60
```
```
yarn add @gravitee/ui-schematics@13.1.4-apim-5438-612fa60
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@13.1.4-apim-5438-612fa60
```
```
yarn add @gravitee/ui-policy-studio-angular@13.1.4-apim-5438-612fa60
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@13.1.4-apim-5438-612fa60
```
```
yarn add @gravitee/ui-particles-angular@13.1.4-apim-5438-612fa60
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-tjzwuzqzjn.chromatic.com)
<!-- Storybook placeholder end -->
