### PR TITLE
fix: avoid error when user clear editor value

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -27,7 +27,7 @@ import {
   Self,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
-import { isString, uniqueId } from 'lodash';
+import { isEqual, isString, uniqueId } from 'lodash';
 import Monaco, { editor } from 'monaco-editor';
 import { ReplaySubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -215,7 +215,7 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
     const onDidChangeContent = this.textModel?.onDidChangeContent(() => {
       const newValue = this.textModel?.getValue();
       this.ngZone.run(() => {
-        if (!this.readOnly) {
+        if (!this.readOnly && !isEqual(this.value, newValue)) {
           setTimeout(() => {
             this.value = newValue ?? '';
             this._onChange(newValue ?? '');


### PR DESCRIPTION
**Issue**

na

**Description**
Fix an error that makes it impossible to enter a value after deleting the previous one

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@13.3.0-fix-codeeditor-395847c
```
```
yarn add @gravitee/ui-particles-angular@13.3.0-fix-codeeditor-395847c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@13.3.0-fix-codeeditor-395847c
```
```
yarn add @gravitee/ui-policy-studio-angular@13.3.0-fix-codeeditor-395847c
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-uswinkqbzj.chromatic.com)
<!-- Storybook placeholder end -->
