### PR TITLE
fix: remove isNativeKafka logic from license service

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
+++ b/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.spec.ts
@@ -187,31 +187,6 @@ describe('GioLicenseService', () => {
         req.flush(oemLicense);
       });
 
-      it('should check if license is native kafka', done => {
-        const oemLicense: License = {
-          tier: '',
-          packs: ['not-native-kafka'],
-          features: [],
-        };
-
-        gioLicenseService
-          .isNativeKafka$()
-          .pipe(
-            tap(isNativeKafka => {
-              expect(isNativeKafka).toEqual(false);
-              done();
-            }),
-          )
-          .subscribe();
-
-        const req = httpTestingController.expectOne({
-          method: 'GET',
-          url: `https://url.test:3000/license`,
-        });
-
-        req.flush(oemLicense);
-      });
-
       // Need a workaround to be able to use both it.each and done callback https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34617#issuecomment-497760008
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       it.each<any>([
@@ -496,52 +471,6 @@ describe('GioLicenseService', () => {
       });
 
       req.flush(oemLicense);
-    });
-  });
-
-  describe('With Native Kafka license', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule, MatDialogModule],
-        providers: [
-          {
-            provide: 'LicenseConfiguration',
-            useValue: OEM_LICENSE_CONFIGURATION_TESTING,
-          },
-        ],
-      });
-
-      httpTestingController = TestBed.inject(HttpTestingController);
-      gioLicenseService = TestBed.inject<GioLicenseService>(GioLicenseService);
-    });
-
-    afterEach(() => {
-      httpTestingController.verify();
-    });
-
-    it('should check if license is native kafka', done => {
-      const nativeKafkaLicense: License = {
-        tier: '',
-        packs: ['native-kafka'],
-        features: [],
-      };
-
-      gioLicenseService
-        .isNativeKafka$()
-        .pipe(
-          tap(isNativeKafka => {
-            expect(isNativeKafka).toEqual(true);
-            done();
-          }),
-        )
-        .subscribe();
-
-      const req = httpTestingController.expectOne({
-        method: 'GET',
-        url: `https://oem.test:3000/license`,
-      });
-
-      req.flush(nativeKafkaLicense);
     });
   });
 });

--- a/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-license/gio-license.service.ts
@@ -149,10 +149,6 @@ export class GioLicenseService {
     return this.getLicense$().pipe(map(license => license !== null && license.features.includes('oem-customization')));
   }
 
-  public isNativeKafka$(): Observable<boolean> {
-    return this.getLicense$().pipe(map(license => license !== null && license.packs.includes('native-kafka')));
-  }
-
   public openDialog(licenseOptions: LicenseOptions, event?: Event) {
     event?.stopPropagation();
     event?.preventDefault();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Revert change to license service for calculating `isNativeKafka$`. The pack should not be used for evaluations.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@13.8.0-revert-is-native-kafka-changes-897596b
```
```
yarn add @gravitee/ui-policy-studio-angular@13.8.0-revert-is-native-kafka-changes-897596b
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@13.8.0-revert-is-native-kafka-changes-897596b
```
```
yarn add @gravitee/ui-particles-angular@13.8.0-revert-is-native-kafka-changes-897596b
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@13.8.0-revert-is-native-kafka-changes-897596b
```
```
yarn add @gravitee/ui-schematics@13.8.0-revert-is-native-kafka-changes-897596b
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xgyofertyj.chromatic.com)
<!-- Storybook placeholder end -->
