### PR TITLE
fix(gio-form-json-schema): validation message for exclusive min and max

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/util/validation-message.util.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/util/validation-message.util.ts
@@ -44,11 +44,11 @@ export function multipleOfValidationMessage(error: unknown, field: FormlyFieldCo
 }
 
 export function exclusiveMinimumValidationMessage(error: unknown, field: FormlyFieldConfig): string {
-  return `Should be > ${field.props?.step}`;
+  return `Should be > ${field.props?.exclusiveMinimum}`;
 }
 
 export function exclusiveMaximumValidationMessage(error: unknown, field: FormlyFieldConfig): string {
-  return `Should be < ${field.props?.step}`;
+  return `Should be < ${field.props?.exclusiveMaximum}`;
 }
 
 export function constValidationMessage(error: unknown, field: FormlyFieldConfig): string {


### PR DESCRIPTION
**Description**

Fix validation message when using `exclusiveMinimum` and `exclusiveMaximum` in JSON schema

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

