### PR TITLE
fix: make monaco editor work with new angular version

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-monaco-editor.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-monaco-editor.service.ts
@@ -48,7 +48,7 @@ export class GioMonacoEditorService {
 
       const onGotAmdLoader = () => {
         // Load Monaco
-        window.require.config({ paths: { vs: 'assets/monaco-editor/min/vs' } });
+        window.require.config({ paths: { vs: window.location.origin + '/assets/monaco-editor/min/vs' } });
 
         window.require(['vs/editor/editor.main'], () => {
           resolve();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@13.9.1-fix-angular19-c65ab98
```
```
yarn add @gravitee/ui-policy-studio-angular@13.9.1-fix-angular19-c65ab98
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@13.9.1-fix-angular19-c65ab98
```
```
yarn add @gravitee/ui-schematics@13.9.1-fix-angular19-c65ab98
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-lvsyidwxiz.chromatic.com)
<!-- Storybook placeholder end -->
