### PR TITLE
fix: fix display of gio-button-toggle-group component with only icons

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-button-toggle-group/README.mdx
+++ b/projects/ui-particles-angular/src/lib/gio-button-toggle-group/README.mdx
@@ -11,20 +11,24 @@ Custom style for Angular Material button toggle group.
 
 {/* <Story id="components-button-toggle-group--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
 
-<Story id="components-button-toggle-group--default" />
+<Story id="components-button-toggle-group--all" />
 
 ## Usage
 
-Add class `gio-button-toggle-group` to `mat-button-toggle-group` component.
+Add class `gio-button-toggle-group` or `gio-button-toggle-group-icons` to `mat-button-toggle-group` component.
 
 OR
 
-Use include mixin `gio-button-toggle-group` in your own class like :
+Use include mixin `gio-button-toggle-group` or `gio-button-toggle-group-icons` in your own class like :
 
 ```scss
 @use '@gravitee/ui-particles-angular' as gio;
 
 .my-class {
   @include gio.gio-button-toggle-group()
+}
+
+.my-class-icons-only {
+  @include gio.gio-button-toggle-group-icons()
 }
 ```

--- a/projects/ui-particles-angular/src/lib/gio-button-toggle-group/gio-button-toggle-group.scss
+++ b/projects/ui-particles-angular/src/lib/gio-button-toggle-group/gio-button-toggle-group.scss
@@ -52,8 +52,24 @@ $typography: map.get(theme.$mat-theme, typography);
   }
 }
 
+@mixin gio-button-toggle-group-icons {
+  .mat-button-toggle.mat-button-toggle + .mat-button-toggle {
+    border: none;
+    margin-left: 4px;
+  }
+
+  .mat-button-toggle .mat-button-toggle-label-content {
+    padding: 0 6px;
+  }
+}
+
 @mixin theme() {
   .gio-button-toggle-group {
     @include gio-button-toggle-group;
+  }
+
+  .gio-button-toggle-group-icons {
+    @include gio-button-toggle-group;
+    @include gio-button-toggle-group-icons;
   }
 }

--- a/projects/ui-particles-angular/src/lib/gio-button-toggle-group/gio-button-toggle-group.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-button-toggle-group/gio-button-toggle-group.stories.ts
@@ -15,25 +15,35 @@
  */
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { GioIconsModule } from '@gravitee/ui-particles-angular';
 
 export default {
   title: 'Components / Button Toggle Group',
   decorators: [
     moduleMetadata({
-      imports: [MatButtonToggleModule],
+      imports: [MatButtonToggleModule, GioIconsModule],
     }),
   ],
   render: () => ({}),
 } as Meta;
 
-export const Default: StoryObj = {
+export const All: StoryObj = {
   render: () => ({
     template: `
+    <h4>Text Only</h4>
     <p style="background-color: #fff; padding:16px;">
       <mat-button-toggle-group class="gio-button-toggle-group" aria-label="Font Style">
         <mat-button-toggle value="bold">Bold</mat-button-toggle>
         <mat-button-toggle value="italic">Italic</mat-button-toggle>
         <mat-button-toggle value="underline">Underline</mat-button-toggle>
+      </mat-button-toggle-group>
+    </p>
+    
+    <h4>Icons Only</h4>
+    <p style="background-color: #fff; padding:16px;">
+      <mat-button-toggle-group class="gio-button-toggle-group-icons" aria-label="Font Style" hideSingleSelectionIndicator="true">
+        <mat-button-toggle value="LIST"><mat-icon svgIcon="gio:list"></mat-icon></mat-button-toggle>
+        <mat-button-toggle value="TILE"><mat-icon svgIcon="gio:4x4-cell"></mat-icon></mat-button-toggle>
       </mat-button-toggle-group>
     </p>
     `,


### PR DESCRIPTION
**Issue**

**Description**
Regarding the cloud issue, we need the `gio-button-toggle` component to display correctly with only icons.

Before:
![Screenshot 2025-04-09 at 15 21 13](https://github.com/user-attachments/assets/bfe7e8b6-5a1d-45db-a7c3-0892fe22e8a4)

After:
![Screenshot 2025-04-09 at 15 20 59](https://github.com/user-attachments/assets/22c5b94e-ac42-4dad-b319-62e97d0577cf)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@14.0.0-improve-btn-toggle-5b36bb5
```
```
yarn add @gravitee/ui-policy-studio-angular@14.0.0-improve-btn-toggle-5b36bb5
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@14.0.0-improve-btn-toggle-5b36bb5
```
```
yarn add @gravitee/ui-schematics@14.0.0-improve-btn-toggle-5b36bb5
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@14.0.0-improve-btn-toggle-5b36bb5
```
```
yarn add @gravitee/ui-particles-angular@14.0.0-improve-btn-toggle-5b36bb5
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-quyicpganq.chromatic.com)
<!-- Storybook placeholder end -->
