### PR TITLE
Fix some issues with ui-particles

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.module.ts
@@ -20,6 +20,9 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { GioMonacoEditorFormFieldDirective } from './gio-monaco-editor-form-field.directive';
 import { GioMonacoEditorComponent } from './gio-monaco-editor.component';
 import { GioMonacoEditorConfig, GIO_MONACO_EDITOR_CONFIG } from './models/GioMonacoEditorConfig';
+import { GioMonacoEditorService } from './services/gio-monaco-editor.service';
+import { GioLanguageJsonService } from './services/gio-language-json.service';
+import { GioLanguageElService } from './services/gio-language-el.service';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule],
@@ -30,6 +33,9 @@ import { GioMonacoEditorConfig, GIO_MONACO_EDITOR_CONFIG } from './models/GioMon
       provide: GIO_MONACO_EDITOR_CONFIG,
       useValue: {} as GioMonacoEditorConfig,
     },
+    GioMonacoEditorService,
+    GioLanguageJsonService,
+    GioLanguageElService,
   ],
 })
 export class GioMonacoEditorModule {
@@ -41,6 +47,9 @@ export class GioMonacoEditorModule {
           provide: GIO_MONACO_EDITOR_CONFIG,
           useValue: config,
         },
+        GioMonacoEditorService,
+        GioLanguageJsonService,
+        GioLanguageElService,
       ],
     };
   }

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -29,7 +29,13 @@ export default {
   component: GioMonacoEditorComponent,
   decorators: [
     moduleMetadata({
-      imports: [GioMonacoEditorModule, ReactiveFormsModule, MatFormFieldModule],
+      imports: [
+        GioMonacoEditorModule.forRoot({
+          baseUrl: '.',
+        }),
+        ReactiveFormsModule,
+        MatFormFieldModule,
+      ],
     }),
   ],
   parameters: {

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/models/GioMonacoEditorConfig.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/models/GioMonacoEditorConfig.ts
@@ -18,6 +18,7 @@ import { InjectionToken } from '@angular/core';
 import { MonacoEditorTheme } from './MonacoEditorTheme';
 
 export type GioMonacoEditorConfig = {
+  baseUrl?: string;
   theme?: MonacoEditorTheme;
 };
 

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-language-el.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-language-el.service.ts
@@ -59,9 +59,7 @@ function getPropertyPath(model: editor.ITextModel, position: Position): string[]
   );
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class GioLanguageElService implements OnDestroy {
   private unsubscribe$ = new Subject<void>();
 

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-language-json.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-language-json.service.ts
@@ -21,9 +21,7 @@ import type Monaco from 'monaco-editor';
 
 import { GioMonacoEditorService } from './gio-monaco-editor.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class GioLanguageJsonService implements OnDestroy {
   private unsubscribe$ = new Subject<void>();
   private monaco?: typeof Monaco;

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-monaco-editor.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/services/gio-monaco-editor.service.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { ReplaySubject } from 'rxjs';
 import Monaco from 'monaco-editor';
+
+import { GIO_MONACO_EDITOR_CONFIG, GioMonacoEditorConfig } from '../models/GioMonacoEditorConfig';
 
 declare global {
   interface Window {
@@ -25,10 +27,9 @@ declare global {
   }
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class GioMonacoEditorService {
+  private readonly config: GioMonacoEditorConfig = inject(GIO_MONACO_EDITOR_CONFIG);
   public loaded$ = new ReplaySubject<{ monaco: typeof Monaco }>(1);
   private loaded = false;
 
@@ -47,8 +48,11 @@ export class GioMonacoEditorService {
       }
 
       const onGotAmdLoader = () => {
+        const baseUrl = this.config.baseUrl || (window.location.origin + window.location.pathname).replace(/\/$/, '');
         // Load Monaco
-        window.require.config({ paths: { vs: window.location.origin + '/assets/monaco-editor/min/vs' } });
+        window.require.config({
+          paths: { vs: baseUrl + '/assets/monaco-editor/min/vs' },
+        });
 
         window.require(['vs/editor/editor.main'], () => {
           resolve();

--- a/projects/ui-particles-angular/src/scss/mat-override/mat-card-mdc.stories.ts
+++ b/projects/ui-particles-angular/src/scss/mat-override/mat-card-mdc.stories.ts
@@ -39,12 +39,18 @@ export const MatCardMDC: StoryObj = {
           <br>
   
           <mat-card>
+            <mat-card-header>
+              <mat-card-title>My Title si subtitle-1</mat-card-title>
+            </mat-card-header>
             <mat-card-content>
               MatCard inside MatCard keep elevation to lvl 1 by default
             </mat-card-content>
           </mat-card>
           <br>
           <mat-card class="mat-mdc-elevation-specific mat-elevation-z2">
+            <mat-card-header>
+              <mat-card-title>My Title si subtitle-1</mat-card-title>
+            </mat-card-header>
             <mat-card-content>
               MatCard inside MatCard with custom elevation to lvl 2
             </mat-card-content>
@@ -53,6 +59,9 @@ export const MatCardMDC: StoryObj = {
       </mat-card>
       <br>
       <mat-card appearance="outlined">
+        <mat-card-header>
+          <mat-card-title>My Title si subtitle-1</mat-card-title>
+        </mat-card-header>
         <mat-card-content>
         Mat card appearance="outlined". No default elevation
         </mat-card-content>

--- a/projects/ui-particles-angular/src/scss/mat-override/mat-card.scss
+++ b/projects/ui-particles-angular/src/scss/mat-override/mat-card.scss
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use 'sass:map';
 @use '@angular/material' as mat;
+
+@use '../gio-mat-theme-variable' as theme;
+
+$typography: map.get(theme.$mat-theme, typography);
 
 @mixin mat-card() {
   // Mat card MDC
@@ -25,6 +30,14 @@
   @for $i from 0 through 24 {
     .mat-mdc-card.mat-elevation-z#{$i} {
       @include mat.elevation($i);
+    }
+  }
+
+  .mat-mdc-card {
+    .mat-mdc-card-title {
+      @include mat.m2-typography-level($typography, subtitle-1);
+
+      padding-bottom: 4px;
     }
   }
 }

--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -427,6 +427,7 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
     const duplicatedFlow = cloneDeep(flowToDuplicate);
     duplicatedFlow._id = uniqueId('flow_');
     duplicatedFlow.name = `${duplicatedFlow.name} - Copy`;
+    duplicatedFlow._hasChanged = true;
     const index = flowsGroupToEdit.flows.indexOf(flowToDuplicate);
     flowsGroupToEdit.flows.splice(index + 1, 0, duplicatedFlow);
     this.flowsGroupsChange.emit(this.flowsGroups);

--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
@@ -18,6 +18,7 @@ import { ComponentHarness, parallel } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatIconHarness } from '@angular/material/icon/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
 
 export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
   public static hostSelector = 'gio-ps-flows-menu';
@@ -106,5 +107,12 @@ export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
 
   public async openFlowExecutionConfig(): Promise<void> {
     await (await this.locatorFor(MatButtonHarness.with({ selector: '.header__configBtn_edit' }))())?.click();
+  }
+
+  public async clickDuplicateFlowBtn(flowText: string | RegExp): Promise<void> {
+    const flow = await this.locateFlowByText(flowText)();
+
+    const matMenu = await flow?.childLocatorFor(MatMenuHarness.with({ selector: '.list__flowsGroup__flows__flow__right__name__menu' }))();
+    await matMenu?.clickItem({ text: /Duplicate/ });
   }
 }

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.spec.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.spec.ts
@@ -1277,6 +1277,31 @@ describe('GioPolicyStudioComponent', () => {
         expect(firstSaveFlows).toBeDefined();
         expect(firstSaveFlows?.enabled).toEqual(true);
       });
+
+      it('should duplicate flow', async () => {
+        component.commonFlows = [
+          fakeChannelFlow({
+            name: 'name',
+            enabled: false,
+          }),
+        ];
+        component.ngOnChanges({
+          commonFlows: new SimpleChange(null, null, true),
+        });
+
+        // Enable flow
+        await policyStudioHarness.duplicateFlow('name');
+
+        let saveOutput: SaveOutput | undefined;
+        component.save.subscribe(value => (saveOutput = value));
+        await policyStudioHarness.save();
+
+        expect(saveOutput?.commonFlows).toBeDefined();
+        expect(saveOutput?.commonFlows?.length).toEqual(2);
+        const duplicatedFlow = saveOutput?.commonFlows?.[1];
+        expect(duplicatedFlow).toBeDefined();
+        expect(duplicatedFlow?.name).toEqual('name - Copy');
+      });
     });
   });
 

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.harness.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.harness.ts
@@ -98,6 +98,15 @@ export class GioPolicyStudioHarness extends ComponentHarness {
   }
 
   /**
+   * Duplicate a flow
+   *
+   * @param flowName Flow name to clone
+   */
+  public async duplicateFlow(flowName: string): Promise<void> {
+    await (await this.menuHarness()).clickDuplicateFlowBtn(new RegExp(flowName, 'i'));
+  }
+
+  /**
    * Select a flow in the menu
    *
    * @param flowName Flow name to select


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7958
https://gravitee.atlassian.net/browse/APIM-9285

**Description**

commits : 

- A proposal to override default mat-card-title (Sync with Figma)
![image](https://github.com/user-attachments/assets/6fc41b49-4a85-4c47-b99d-a5a7ad600173)



- PS - Fix issue when we duplicate a flow (without any change)
- issue with monaco editor and custom base path 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-awbydykfdy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@14.0.0-various-fixs-2151f1f
```
```
yarn add @gravitee/ui-particles-angular@14.0.0-various-fixs-2151f1f
```
<!-- Prerelease placeholder ui-particles-angular end -->
