### PR TITLE
fix: ps - remove id of duplicated flow

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -426,6 +426,8 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges {
       throw new Error(`Flow ${flowId} not found`);
     }
     const duplicatedFlow = cloneDeep(flowToDuplicate);
+    delete duplicatedFlow.id;
+
     duplicatedFlow._id = uniqueId('flow_');
     duplicatedFlow.name = `${duplicatedFlow.name} - Copy`;
     duplicatedFlow._hasChanged = true;

--- a/projects/ui-policy-studio-angular/src/lib/models/flow/Flow.ts
+++ b/projects/ui-policy-studio-angular/src/lib/models/flow/Flow.ts
@@ -17,6 +17,7 @@ import { Selector } from './Selector';
 import { Step } from './Step';
 
 export interface Flow {
+  id?: string;
   /**
    * Flow's name.
    */

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.spec.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.spec.ts
@@ -1281,6 +1281,7 @@ describe('GioPolicyStudioComponent', () => {
       it('should duplicate flow', async () => {
         component.commonFlows = [
           fakeChannelFlow({
+            id: 'id',
             name: 'name',
             enabled: false,
           }),
@@ -1301,6 +1302,7 @@ describe('GioPolicyStudioComponent', () => {
         const duplicatedFlow = saveOutput?.commonFlows?.[1];
         expect(duplicatedFlow).toBeDefined();
         expect(duplicatedFlow?.name).toEqual('name - Copy');
+        expect(duplicatedFlow?.id).toEqual(undefined);
       });
     });
   });


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7958

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@13.12.1-13-x-fix-4e5ebb1
```
```
yarn add @gravitee/ui-schematics@13.12.1-13-x-fix-4e5ebb1
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@13.12.1-13-x-fix-4e5ebb1
```
```
yarn add @gravitee/ui-policy-studio-angular@13.12.1-13-x-fix-4e5ebb1
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@13.12.1-13-x-fix-4e5ebb1
```
```
yarn add @gravitee/ui-particles-angular@13.12.1-13-x-fix-4e5ebb1
```
<!-- Prerelease placeholder ui-particles-angular end -->
