### PR TITLE
fix: keep ui type map as first field config transformation to construct tree

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
@@ -33,8 +33,8 @@ export class GioFormlyJsonSchemaService {
   public toFormlyFieldConfig(jsonSchema: GioJsonSchema, context?: GioJsonSchemaContext): FormlyFieldConfig {
     return this.formlyJsonschema.toFieldConfig(jsonSchema, {
       map: (mappedField: FormlyFieldConfig, mapSource: JSONSchema7) => {
+        mappedField = this.uiTypeMap(mappedField, mapSource); // Keep first in order to correctly construct tree
         mappedField = this.displayIfMap(mappedField, mapSource, context);
-        mappedField = this.uiTypeMap(mappedField, mapSource);
         mappedField = this.uiBorder(mappedField, mapSource);
         mappedField = this.formatMap(mappedField, mapSource);
         mappedField = this.bannerMap(mappedField, mapSource);


### PR DESCRIPTION

**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

It was not possible to use `displayIf` and `gioConfig.uiType` in the same schema. 
This fix reorders how the tree is created if the `uiType` is specified.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@14.1.2-fix-ps-ui-type-map-d793575
```
```
yarn add @gravitee/ui-policy-studio-angular@14.1.2-fix-ps-ui-type-map-d793575
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@14.1.2-fix-ps-ui-type-map-d793575
```
```
yarn add @gravitee/ui-schematics@14.1.2-fix-ps-ui-type-map-d793575
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@14.1.2-fix-ps-ui-type-map-d793575
```
```
yarn add @gravitee/ui-particles-angular@14.1.2-fix-ps-ui-type-map-d793575
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-fxqrkndnqg.chromatic.com)
<!-- Storybook placeholder end -->
