### PR TITLE
fix: do not show enabled flows created by GKO as disabled in the console

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.html
+++ b/projects/ui-policy-studio-angular/src/lib/components/flow-details-phase/gio-ps-flow-details-phase.component.html
@@ -77,7 +77,7 @@
               <gio-ps-flow-details-phase-step
                 class="content__step__step"
                 [readOnly]="readOnly"
-                [class.disabled]="readOnly || !stepVM.step.enabled"
+                [class.disabled]="!stepVM.step.enabled"
                 [genericPolicies]="genericPolicies"
                 [step]="stepVM.step"
                 [flowPhase]="policyFlowPhase"


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1186
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@14.2.0-gko-1186-disable-flows-a69fe20
```
```
yarn add @gravitee/ui-schematics@14.2.0-gko-1186-disable-flows-a69fe20
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@14.2.0-gko-1186-disable-flows-a69fe20
```
```
yarn add @gravitee/ui-particles-angular@14.2.0-gko-1186-disable-flows-a69fe20
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@14.2.0-gko-1186-disable-flows-a69fe20
```
```
yarn add @gravitee/ui-policy-studio-angular@14.2.0-gko-1186-disable-flows-a69fe20
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-jfvjbjzenp.chromatic.com)
<!-- Storybook placeholder end -->
