### PR TITLE
fix: avoid avatar overflow with wide images

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-avatar/gio-avatar.component.scss
+++ b/projects/ui-particles-angular/src/lib/gio-avatar/gio-avatar.component.scss
@@ -27,6 +27,8 @@
   height: 100%;
 
   &.rounded img {
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
     object-fit: cover;
   }

--- a/projects/ui-particles-angular/src/lib/gio-avatar/gio-avatar.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-avatar/gio-avatar.stories.ts
@@ -93,3 +93,9 @@ ImageWithRoundedBorder.args = {
   src: 'https://i.pravatar.cc/100?u=a042581f4e29020504d',
   roundedBorder: true,
 };
+
+export const ImageToCropWithRoundedBorder: StoryObj<GioAvatarComponent> = {};
+ImageToCropWithRoundedBorder.args = {
+  src: 'https://images.stockcake.com/public/2/d/8/2d81ce52-116c-47ca-9e41-66514c56de6c_large/sunset-city-view-stockcake.jpg',
+  roundedBorder: true,
+};


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10167

**Description**

cherry picked from commit 6869a7f16b7c0fc2367e0041c6896dcc0cda3b1a from PR https://github.com/gravitee-io/gravitee-ui-particles/pull/474

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@14.2.1-apim-10167-14x-5767db8
```
```
yarn add @gravitee/ui-policy-studio-angular@14.2.1-apim-10167-14x-5767db8
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@14.2.1-apim-10167-14x-5767db8
```
```
yarn add @gravitee/ui-schematics@14.2.1-apim-10167-14x-5767db8
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@14.2.1-apim-10167-14x-5767db8
```
```
yarn add @gravitee/ui-particles-angular@14.2.1-apim-10167-14x-5767db8
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-veaigqzcqf.chromatic.com)
<!-- Storybook placeholder end -->
