### PR TITLE
APIM-9860-Search-Flows-In-Policy-Studio

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.html
@@ -28,10 +28,19 @@
     </div>
   }
 </div>
+<div class="searchBar" *ngIf="!loading">
+  <mat-form-field class="searchBar__input">
+    <mat-icon matPrefix>search</mat-icon>
+    <input matInput placeholder="Search by name, path, or group..." [formControl]="searchControl" />
+    <button *ngIf="searchControl.value" matSuffix mat-icon-button aria-label="Clear" (click)="resetSearchTerm()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
 
 <div class="list" *ngIf="!loading; else loadingList" cdkDropListGroup>
   <div
-    *ngFor="let flowsGroup of flowGroupMenuItems"
+    *ngFor="let flowsGroup of filteredFlowGroupMenuItems"
     class="list__flowsGroup"
     cdkDropList
     [cdkDropListData]="flowsGroup"
@@ -58,74 +67,79 @@
     </div>
 
     <div class="list__flowsGroup__flows">
-      @for (flow of flowsGroup.flows; track flow._id) {
-        <div
-          class="list__flowsGroup__flows__flow"
-          [class.selected]="flow.selected"
-          [class.disabled]="!flow.enabled"
-          (click)="selectFlow(flowsGroup._id, flow._id)"
-          (mouseout)="flow.mouseOver = false"
-          (mouseover)="flow.mouseOver = true"
-          cdkDrag
-        >
-          <div class="list__flowsGroup__flows__flow__left">
-            <div *ngIf="flow.name" class="list__flowsGroup__flows__flow__left__name" [attr.title]="flow.name">
-              {{ flow.name }}
-            </div>
-            @if (apiType !== 'NATIVE') {
-              <div class="list__flowsGroup__flows__flow__left__infos">
-                <div class="list__flowsGroup__flows__flow__left__infos__badges">
-                  <span
-                    *ngFor="let badge of flow.badges"
-                    class="list__flowsGroup__flows__flow__left__infos__badges__badge"
-                    [ngClass]="badge.class"
-                    >{{ badge.label }}</span
-                  >
-                </div>
-                <div class="list__flowsGroup__flows__flow__left__infos__pathOrChannelLabel">
-                  <span *ngIf="flow.pathOrChannelLabel; else emptyPathOrChannelLabel" [attr.title]="flow.pathOrChannelLabel">{{
-                    flow.pathOrChannelLabel
-                  }}</span>
-                  <ng-template #emptyPathOrChannelLabel>
-                    <em>Empty</em>
-                  </ng-template>
-                </div>
-
-                <span
-                  *ngIf="flow.hasCondition"
-                  class="list__flowsGroup__flows__flow__left__infos__conditionBadge gio-badge-neutral"
-                  matTooltip="Conditioned"
-                  ><mat-icon svgIcon="gio:if"></mat-icon
-                ></span>
+      <ng-container *ngIf="flowsGroup.flows.length > 0; else noFlows">
+        @for (flow of flowsGroup.flows; track flow._id) {
+          <div
+            class="list__flowsGroup__flows__flow"
+            [class.selected]="flow.selected"
+            [class.disabled]="!flow.enabled"
+            (click)="selectFlow(flowsGroup._id, flow._id)"
+            (mouseout)="flow.mouseOver = false"
+            (mouseover)="flow.mouseOver = true"
+            cdkDrag
+          >
+            <div class="list__flowsGroup__flows__flow__left">
+              <div *ngIf="flow.name" class="list__flowsGroup__flows__flow__left__name" [attr.title]="flow.name">
+                {{ flow.name }}
               </div>
-            }
-          </div>
-          <div class="list__flowsGroup__flows__flow__right">
-            <button
-              class="list__flowsGroup__flows__flow__right__name__menu"
-              mat-button
-              [disabled]="readOnly"
-              [matMenuTriggerFor]="flowMenu"
-              (click)="$event.stopPropagation()"
-            >
-              <mat-icon svgIcon="gio:more-vertical"></mat-icon>
-            </button>
-            <mat-menu #flowMenu="matMenu">
-              <button [disabled]="readOnly" mat-menu-item (click)="onDisableFlow(flow._id)">
-                <mat-icon [svgIcon]="flow.enabled ? 'gio:prohibition' : 'gio:check-circled-outline'"></mat-icon>
-                <span>{{ flow.enabled ? 'Disable' : 'Enable' }}</span>
-              </button>
-              <button mat-menu-item (click)="onEditFlow(flow._id)"><mat-icon svgIcon="gio:edit-pencil"></mat-icon> Edit</button>
-              <button mat-menu-item (click)="onDeleteFlow(flow._id)"><mat-icon svgIcon="gio:trash"></mat-icon> Delete</button>
               @if (apiType !== 'NATIVE') {
-                <button mat-menu-item (click)="onDuplicateFlow(flowsGroup._id, flow._id)">
-                  <mat-icon svgIcon="gio:copy"></mat-icon> Duplicate
-                </button>
+                <div class="list__flowsGroup__flows__flow__left__infos">
+                  <div class="list__flowsGroup__flows__flow__left__infos__badges">
+                    <span
+                      *ngFor="let badge of flow.badges"
+                      class="list__flowsGroup__flows__flow__left__infos__badges__badge"
+                      [ngClass]="badge.class"
+                      >{{ badge.label }}</span
+                    >
+                  </div>
+                  <div class="list__flowsGroup__flows__flow__left__infos__pathOrChannelLabel">
+                    <span *ngIf="flow.pathOrChannelLabel; else emptyPathOrChannelLabel" [attr.title]="flow.pathOrChannelLabel">{{
+                      flow.pathOrChannelLabel
+                    }}</span>
+                    <ng-template #emptyPathOrChannelLabel>
+                      <em>Empty</em>
+                    </ng-template>
+                  </div>
+
+                  <span
+                    *ngIf="flow.hasCondition"
+                    class="list__flowsGroup__flows__flow__left__infos__conditionBadge gio-badge-neutral"
+                    matTooltip="Conditioned"
+                    ><mat-icon svgIcon="gio:if"></mat-icon
+                  ></span>
+                </div>
               }
-            </mat-menu>
+            </div>
+            <div class="list__flowsGroup__flows__flow__right">
+              <button
+                class="list__flowsGroup__flows__flow__right__name__menu"
+                mat-button
+                [disabled]="readOnly"
+                [matMenuTriggerFor]="flowMenu"
+                (click)="$event.stopPropagation()"
+              >
+                <mat-icon svgIcon="gio:more-vertical"></mat-icon>
+              </button>
+              <mat-menu #flowMenu="matMenu">
+                <button [disabled]="readOnly" mat-menu-item (click)="onDisableFlow(flow._id)">
+                  <mat-icon [svgIcon]="flow.enabled ? 'gio:prohibition' : 'gio:check-circled-outline'"></mat-icon>
+                  <span>{{ flow.enabled ? 'Disable' : 'Enable' }}</span>
+                </button>
+                <button mat-menu-item (click)="onEditFlow(flow._id)"><mat-icon svgIcon="gio:edit-pencil"></mat-icon> Edit</button>
+                <button mat-menu-item (click)="onDeleteFlow(flow._id)"><mat-icon svgIcon="gio:trash"></mat-icon> Delete</button>
+                @if (apiType !== 'NATIVE') {
+                  <button mat-menu-item (click)="onDuplicateFlow(flowsGroup._id, flow._id)">
+                    <mat-icon svgIcon="gio:copy"></mat-icon> Duplicate
+                  </button>
+                }
+              </mat-menu>
+            </div>
           </div>
-        </div>
-      }
+        }
+      </ng-container>
+      <ng-template #noFlows>
+        <div class="list__flowsGroup__no-flows">No flows yet</div>
+      </ng-template>
     </div>
   </div>
 </div>

--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.scss
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.scss
@@ -32,7 +32,7 @@ $typography: map.get(gio.$mat-theme, typography);
   display: flex;
   align-items: center;
   padding: 0 16px;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 
   &__label {
     @include gio.subtitle-typography;
@@ -46,6 +46,15 @@ $typography: map.get(gio.$mat-theme, typography);
 
   &__configBtn {
     margin-left: 8px;
+  }
+}
+
+.searchBar {
+  display: flex;
+  padding: 0 16px;
+
+  &__input {
+    flex: 1 1 auto;
   }
 }
 
@@ -172,6 +181,10 @@ $typography: map.get(gio.$mat-theme, typography);
           }
         }
       }
+    }
+
+    &__no-flows {
+      font-style: italic;
     }
 
     &.cdk-drop-list-dragging {

--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.harness.ts
@@ -19,6 +19,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatIconHarness } from '@angular/material/icon/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
 import { MatMenuHarness } from '@angular/material/menu/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
 
 export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
   public static hostSelector = 'gio-ps-flows-menu';
@@ -115,5 +116,9 @@ export class GioPolicyStudioFlowsMenuHarness extends ComponentHarness {
 
     const matMenu = await flow?.childLocatorFor(MatMenuHarness.with({ selector: '.list__flowsGroup__flows__flow__right__name__menu' }))();
     await matMenu?.clickItem({ text: /Duplicate/ });
+  }
+
+  public async getSearchInput(): Promise<MatInputHarness> {
+    return this.locatorFor(MatInputHarness.with({ selector: '.searchBar__input input[matInput]' }))();
   }
 }

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.harness.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.harness.ts
@@ -17,6 +17,7 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatTabGroupHarness } from '@angular/material/tabs/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
 
 import { ChannelSelector, ConditionSelector, Flow, FlowExecution, HttpSelector } from '../models';
 import { GioPolicyStudioFlowsMenuHarness } from '../components/flows-menu/gio-ps-flows-menu.harness';
@@ -242,5 +243,10 @@ export class GioPolicyStudioHarness extends ComponentHarness {
     const flowExecutionDialog = await this.documentRootLocatorFactory().locatorFor(GioPolicyStudioFlowExecutionFormDialogHarness)();
     await flowExecutionDialog.setFlowFormValues(flowExecution);
     await flowExecutionDialog.save();
+  }
+
+  public async getSearchInput(): Promise<MatInputHarness> {
+    const menu = await this.menuHarness();
+    return menu.getSearchInput();
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9860

**Description**

Added search box to filter flows based on name, plan name, channel name, PUB/SUB, GET/PUT, etc.
Display "No flows yet" if a plan has no flows.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@15.3.0-apim-9860-search-flows-in-policy-studio-f12d3c2
```
```
yarn add @gravitee/ui-particles-angular@15.3.0-apim-9860-search-flows-in-policy-studio-f12d3c2
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@15.3.0-apim-9860-search-flows-in-policy-studio-f12d3c2
```
```
yarn add @gravitee/ui-schematics@15.3.0-apim-9860-search-flows-in-policy-studio-f12d3c2
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@15.3.0-apim-9860-search-flows-in-policy-studio-f12d3c2
```
```
yarn add @gravitee/ui-policy-studio-angular@15.3.0-apim-9860-search-flows-in-policy-studio-f12d3c2
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-eaevpcxabr.chromatic.com)
<!-- Storybook placeholder end -->
