### PR TITLE
fix: make nested gio config disabled fields visible

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
@@ -35,6 +35,7 @@ import { integerExample } from './json-schema-example/integer';
 import { stringExample } from './json-schema-example/string';
 import { mixedExample } from './json-schema-example/mixed';
 import { oneOfExample } from './json-schema-example/oneOf';
+import { oneOfNestedGioConfigDisableExample } from './json-schema-example/oneOfNestedGioConfigDisable';
 import { entrypointsGetResponse, getEntrypointConnectorSchema } from './json-schema-example/entrypoints';
 import { endpointsGetResponse, getEndpointConnectorSchema } from './json-schema-example/endpoints';
 import { enumExample } from './json-schema-example/enum';
@@ -197,6 +198,31 @@ export const WithUiBorder: StoryObj = {
 export const OneOf: StoryObj = {
   args: {
     jsonSchema: oneOfExample,
+  },
+};
+
+export const OneOfNestedGioConfigDisable: StoryObj = {
+  name: 'One Of with disableIf and parent disabled',
+  args: {
+    disabled: true,
+    jsonSchema: oneOfNestedGioConfigDisableExample,
+    initialValue: {
+      maxTotal: 8,
+      password: 'redispassword',
+      releaseCache: false,
+      sentinel: {
+        enabled: false,
+        masterId: 'sentinel-master',
+      },
+      standalone: {
+        enabled: true,
+        host: 'localhost',
+        port: 6379,
+      },
+      timeToLiveSeconds: 0,
+      timeout: 2000,
+      useSsl: true,
+    },
   },
 };
 

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
@@ -160,7 +160,8 @@ export class GioFormlyJsonSchemaService {
         if (isParentDisabled || isReadOnly) {
           // Useful when field is readonly to avoid to enable it
           field.formControl?.disable({ emitEvent: false });
-          return true;
+          // if the parent is already disabled there is no need to change anything at the child level
+          return false;
         }
 
         let parentField = field;

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/oneOfNestedGioConfigDisable.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/oneOfNestedGioConfigDisable.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GioJsonSchema } from '../model/GioJsonSchema';
+
+export const oneOfNestedGioConfigDisableExample: GioJsonSchema = {
+  type: 'object',
+  properties: {
+    standalone: {
+      type: 'object',
+      oneOf: [
+        {
+          title: 'Configure standalone',
+          properties: {
+            enabled: {
+              const: true,
+            },
+            host: {
+              title: 'Host',
+              description: 'The host of the instance. (Supports EL)',
+              type: 'string',
+              default: 'localhost',
+            },
+            port: {
+              title: 'Port',
+              description: 'The port of the instance.',
+              type: 'integer',
+              default: 6379,
+            },
+          },
+          required: ['host', 'port'],
+        },
+        {
+          title: 'Standalone disabled',
+          properties: {
+            enabled: {
+              const: false,
+            },
+          },
+        },
+      ],
+      default: {
+        enabled: true,
+      },
+      gioConfig: {
+        disableIf: {
+          $eq: {
+            'value.sentinel.enabled': true,
+          },
+        },
+      },
+    },
+    sentinel: {
+      type: 'object',
+      oneOf: [
+        {
+          title: 'Configure sentinel',
+          properties: {
+            enabled: {
+              const: true,
+            },
+            masterId: {
+              title: 'Master',
+              description: 'The sentinel master id. (Supports EL)',
+              type: 'string',
+              default: 'sentinel-master',
+            },
+            password: {
+              title: 'Sentinel password',
+              description: 'The sentinel password. (Supports EL and secrets)',
+              type: 'string',
+              writeOnly: true,
+            },
+            nodes: {
+              type: 'array',
+              title: 'Sentinel nodes',
+              items: {
+                type: 'object',
+                title: 'Node',
+                properties: {
+                  host: {
+                    title: 'The host of node',
+                    type: 'string',
+                    default: 'localhost',
+                  },
+                  port: {
+                    title: 'The port of node',
+                    type: 'integer',
+                    default: 26379,
+                  },
+                },
+                required: ['host', 'port'],
+              },
+              default: [
+                {
+                  host: 'localhost',
+                  port: 26379,
+                },
+              ],
+            },
+          },
+          required: ['masterId', 'nodes'],
+        },
+        {
+          title: 'Sentinel disabled',
+          description:
+            'Sentinel provides high availability for Redis. In practical terms this means that using Sentinel you can create a Redis deployment that resists without human intervention certain kinds of failures.',
+          properties: {
+            enabled: {
+              const: false,
+            },
+          },
+        },
+      ],
+      default: {
+        enabled: false,
+      },
+    },
+  },
+};


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1354

When the parent view is disabled (e.g. GKO context) the disable if makes the value of the field completely hidden.

seen with @ThibaudAV 
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@15.4.0-gko-1354-hidden-disabled-fields-14a4657
```
```
yarn add @gravitee/ui-schematics@15.4.0-gko-1354-hidden-disabled-fields-14a4657
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@15.4.0-gko-1354-hidden-disabled-fields-14a4657
```
```
yarn add @gravitee/ui-policy-studio-angular@15.4.0-gko-1354-hidden-disabled-fields-14a4657
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@15.4.0-gko-1354-hidden-disabled-fields-14a4657
```
```
yarn add @gravitee/ui-particles-angular@15.4.0-gko-1354-hidden-disabled-fields-14a4657
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-mqqdlsfmup.chromatic.com)
<!-- Storybook placeholder end -->
