### PR TITLE
fix: storybook with GioMonacoEditor

### DIFF
--- a/projects/ui-particles-angular/gio-el/gio-el-editor-input/gio-el-editor-input.component.ts
+++ b/projects/ui-particles-angular/gio-el/gio-el-editor-input/gio-el-editor-input.component.ts
@@ -25,7 +25,7 @@ import { GioMonacoEditorModule, MonacoEditorLanguageConfig } from '@gravitee/ui-
 @Component({
   selector: 'gio-el-editor-input',
   standalone: true,
-  imports: [GioMonacoEditorModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule, GioMonacoEditorModule],
   templateUrl: './gio-el-editor-input.component.html',
   styleUrl: './gio-el-editor-input.component.scss',
   providers: [{ provide: MatFormFieldControl, useExisting: GioElEditorInputComponent }],

--- a/projects/ui-particles-angular/gio-el/gio-el-editor-input/gio-el-editor-input.stories.ts
+++ b/projects/ui-particles-angular/gio-el/gio-el-editor-input/gio-el-editor-input.stories.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Meta, StoryObj } from '@storybook/angular';
-import { Component } from '@angular/core';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Component, importProvidersFrom } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { action } from '@storybook/addon-actions';
+import { GioMonacoEditorModule } from '@gravitee/ui-particles-angular';
 
 import { GioElEditorHelperToggleComponent } from '../gio-el-editor-helper/gio-el-editor-helper-toggle.component';
 import { GioElEditorHelperInputDirective } from '../gio-el-editor-helper/gio-el-editor-helper-input.directive';
@@ -71,6 +72,14 @@ class StoryInputComponent {
 export default {
   title: 'Components / EL / CodeEditor input for MatFormField',
   component: StoryInputComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [GioMonacoEditorModule.forRoot({ baseUrl: '.' })],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GioMonacoEditorModule.forRoot({ baseUrl: '.' })), GioMonacoEditorModule],
+    }),
+  ],
 } as Meta;
 
 export const Default: StoryObj = {};

--- a/projects/ui-particles-angular/src/lib/gio-form-cron/gio-form-cron.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-cron/gio-form-cron.component.ts
@@ -158,7 +158,7 @@ export class GioFormCronComponent implements ControlValueAccessor, OnInit, OnDes
             this._onChange(this.value);
           } catch (error) {
             this.hasError = true;
-            this.expressionDescription = `${error}` ?? 'Invalid cron expression.';
+            this.expressionDescription = `${error}`;
             this._onChange(null);
           }
         }),
@@ -190,7 +190,7 @@ export class GioFormCronComponent implements ControlValueAccessor, OnInit, OnDes
       this.refreshInternalForm();
     } catch (error) {
       this.hasError = true;
-      this.expressionDescription = `${error}` ?? 'Invalid cron expression.';
+      this.expressionDescription = `${error}`;
     }
   }
 

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.module.ts
@@ -134,7 +134,9 @@ import { GioFjsCronTypeComponent } from './type-component/cron-type.component';
     GioIconsModule,
     GioFormSlideToggleModule,
     GioFormHeadersModule,
-    GioMonacoEditorModule,
+    GioMonacoEditorModule.forRoot({
+      baseUrl: '.',
+    }),
     GioFormCronModule,
 
     MatSlideToggleModule,

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
@@ -66,7 +66,7 @@ import { uiBorderExample } from './json-schema-example/uiBorder';
     MatButtonModule,
     MatButtonToggleModule,
     GioFormJsonSchemaModule,
-    GioMonacoEditorModule.forRoot({ theme: 'vs-dark' }),
+    GioMonacoEditorModule.forRoot({ theme: 'vs-dark', baseUrl: '.' }),
   ],
   exports: [DemoComponent, GioFormJsonSchemaModule],
 })

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -66,6 +66,8 @@ export type MonacoEditorLanguageConfig =
   template: ` <div *ngIf="loaded$ | async">Loading...</div>`,
   styleUrls: ['./gio-monaco-editor.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+  providers: [GioMonacoEditorService, GioLanguageJsonService, GioLanguageElService],
 })
 export class GioMonacoEditorComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
   @Input()

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/models/GioMonacoEditorConfig.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/models/GioMonacoEditorConfig.ts
@@ -18,6 +18,7 @@ import { InjectionToken } from '@angular/core';
 import { MonacoEditorTheme } from './MonacoEditorTheme';
 
 export type GioMonacoEditorConfig = {
+  baseUrl?: string;
   theme?: MonacoEditorTheme;
 };
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9948

**Description**

Fix issue with monaco editor and custom base path

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<img width="1508" height="740" alt="Screenshot 2025-08-06 at 8 43 03 PM" src="https://github.com/user-attachments/assets/fa8fd859-e0c9-4946-a94b-ec1e609a178f" />


<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@13.12.3-apim-9948-resolver-parameter-for-jwt-plan-not-accessible-6992158
```
```
yarn add @gravitee/ui-policy-studio-angular@13.12.3-apim-9948-resolver-parameter-for-jwt-plan-not-accessible-6992158
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@13.12.3-apim-9948-resolver-parameter-for-jwt-plan-not-accessible-6992158
```
```
yarn add @gravitee/ui-schematics@13.12.3-apim-9948-resolver-parameter-for-jwt-plan-not-accessible-6992158
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@13.12.3-apim-9948-resolver-parameter-for-jwt-plan-not-accessible-6992158
```
```
yarn add @gravitee/ui-particles-angular@13.12.3-apim-9948-resolver-parameter-for-jwt-plan-not-accessible-6992158
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-hbvysanoyh.chromatic.com)
<!-- Storybook placeholder end -->
