### PR TITLE
fix: allow monaco to format content even when is readonly

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.component.ts
@@ -213,9 +213,17 @@ export class GioMonacoEditorComponent implements ControlValueAccessor, AfterView
     });
 
     if (!this.disableAutoFormat) {
+      this.standaloneCodeEditor.updateOptions({
+        readOnly: false,
+      });
+
       setTimeout(() => {
         this.standaloneCodeEditor?.getAction('editor.action.formatDocument')?.run();
       }, 80);
+
+      this.standaloneCodeEditor.updateOptions({
+        readOnly: options.readOnly,
+      });
     }
 
     if (this.singleLineMode) {

--- a/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-monaco-editor/gio-monaco-editor.stories.ts
@@ -394,7 +394,6 @@ export const DisabledWithCopy: StoryObj = {
                 border: 1px solid grey;
                 border-radius: 4px;
                 height: 180px;
-                width: 500px important!;
                 overflow: hidden;
             }
             
@@ -418,15 +417,15 @@ export const DisabledWithCopy: StoryObj = {
     };
   },
   args: {
-    disabled: true,
-    value: `{
-  "headers": {
-    "Host": "api.gravitee.io",
-    "foo": "bar",
-    "User-Agent": "Gravitee.io/4.6.15-SNAPSHOT"
-  },
-  "query_params": {},
-  "bodySize": 0
-}`,
+    value: `
+        {
+          "headers": {
+            "Host": "api.gravitee.io",
+            "foo": "bar",
+            "User-Agent": "Gravitee.io/4.6.15-SNAPSHOT"
+          },
+          "query_params": {},
+          "bodySize": 0
+        }`,
   },
 };


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8652

**Description**

allow monaco to format content even when is readonly

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-rfofcilewk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@15.7.1-apim-8652-fix-monaco-parser-5bc5bcf
```
```
yarn add @gravitee/ui-policy-studio-angular@15.7.1-apim-8652-fix-monaco-parser-5bc5bcf
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@15.7.1-apim-8652-fix-monaco-parser-5bc5bcf
```
```
yarn add @gravitee/ui-schematics@15.7.1-apim-8652-fix-monaco-parser-5bc5bcf
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@15.7.1-apim-8652-fix-monaco-parser-5bc5bcf
```
```
yarn add @gravitee/ui-particles-angular@15.7.1-apim-8652-fix-monaco-parser-5bc5bcf
```
<!-- Prerelease placeholder ui-particles-angular end -->
