### PR TITLE
feat: make the el helper as optin

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-el/gio-el.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-el/gio-el.service.ts
@@ -15,7 +15,6 @@
  */
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { delay, map } from 'rxjs/operators';
 
 import { ElAiPromptState } from './models/ElAiPromptState';
 
@@ -23,24 +22,22 @@ import { ElAiPromptState } from './models/ElAiPromptState';
   providedIn: 'root',
 })
 export class GioElService {
-  private _promptCallback: (prompt: string) => Observable<ElAiPromptState> = this.defaultPrompt;
+  private _promptCallback?: (prompt: string) => Observable<ElAiPromptState> = undefined;
 
   public prompt(prompt: string): Observable<ElAiPromptState> {
+    if (this._promptCallback === undefined) {
+      return of({
+        message: `Error: no handler given (input prompt: ${prompt})`,
+      });
+    }
     return this._promptCallback(prompt);
-  }
-
-  private defaultPrompt(prompt: string): Observable<ElAiPromptState> {
-    return of(prompt).pipe(
-      delay(300),
-      map(prompt => {
-        return {
-          message: `Error: no handler given (input prompt: ${prompt})`,
-        };
-      }),
-    );
   }
 
   public set promptCallback(value: (prompt: string) => Observable<ElAiPromptState>) {
     this._promptCallback = value;
+  }
+
+  public isEnabled(): boolean {
+    return this._promptCallback !== undefined;
   }
 }

--- a/projects/ui-particles-angular/src/lib/gio-el/index.ts
+++ b/projects/ui-particles-angular/src/lib/gio-el/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './gio-el-prompt/gio-el-prompt.component';
+export * from './models/ElAiPromptState';
+export * from './gio-el.service';

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-form-json-schema.stories.ts
@@ -25,6 +25,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { GioElService } from '@gravitee/ui-particles-angular';
+import { inject, provideAppInitializer } from '@angular/core';
+import { of } from 'rxjs';
 
 import { GioMonacoEditorModule } from '../gio-monaco-editor/gio-monaco-editor.module';
 import { GioFormFocusInvalidModule } from '../gio-form-focus-first-invalid/gio-form-focus-first-invalid.module';
@@ -73,6 +76,7 @@ import { uiBorderExample } from './json-schema-example/uiBorder';
     PopoverTriggerDirective,
   ],
   exports: [DemoComponent, GioFormJsonSchemaModule],
+  providers: [],
 })
 export class GioFJSStoryModule {}
 
@@ -83,7 +87,13 @@ export default {
       imports: [CommonModule, MatSelectModule, GioFJSStoryModule],
     }),
     applicationConfig({
-      providers: [importProvidersFrom(GioMonacoEditorModule.forRoot({ theme: 'vs-dark', baseUrl: '.' }))],
+      providers: [
+        importProvidersFrom(GioMonacoEditorModule.forRoot({ theme: 'vs-dark', baseUrl: '.' })),
+        GioElService,
+        provideAppInitializer(() => {
+          inject(GioElService).promptCallback = () => of({ el: 'Hello world!' });
+        }),
+      ],
     }),
   ],
   parameters: {

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-el-helper-wrapper.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/wrappers/gio-el-helper-wrapper.component.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, TemplateRef, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, TemplateRef, ViewChild, AfterViewInit, inject } from '@angular/core';
 import { FieldWrapper, FormlyFieldConfig } from '@ngx-formly/core';
+
+import { GioElService } from '../../gio-el';
 
 @Component({
   selector: 'gio-el-wrapper-wrapper',
@@ -22,18 +24,21 @@ import { FieldWrapper, FormlyFieldConfig } from '@ngx-formly/core';
     <ng-container #fieldComponent></ng-container>
 
     <ng-template #matSuffix>
-      <button gioPopoverTrigger [gioPopoverTriggerFor]="aiPopover" type="button">
-        <mat-icon svgIcon="gio:el" />
-      </button>
+      @if (isEnabled()) {
+        <button gioPopoverTrigger [gioPopoverTriggerFor]="aiPopover" type="button">
+          <mat-icon svgIcon="gio:el" />
+        </button>
 
-      <gio-popover #aiPopover [closeOnBackdropClick]="true">
-        <gio-el-prompt />
-      </gio-popover>
+        <gio-popover #aiPopover [closeOnBackdropClick]="true">
+          <gio-el-prompt />
+        </gio-popover>
+      }
     </ng-template>
   `,
   standalone: false,
 })
 export class GioElHelperWrapperComponent extends FieldWrapper implements AfterViewInit {
+  private readonly elService = inject(GioElService);
   @ViewChild('matSuffix', { static: true })
   public matSuffix!: TemplateRef<unknown>;
   public hide = true;
@@ -42,6 +47,10 @@ export class GioElHelperWrapperComponent extends FieldWrapper implements AfterVi
     if (this.matSuffix) {
       this.props.suffix = this.matSuffix;
     }
+  }
+
+  public isEnabled(): boolean {
+    return this.elService.isEnabled();
   }
 }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

APIM should be able to activate or not the EL helper
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@15.7.1-optin-el-helper-1503133
```
```
yarn add @gravitee/ui-schematics@15.7.1-optin-el-helper-1503133
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@15.7.1-optin-el-helper-32ded5c
```
```
yarn add @gravitee/ui-policy-studio-angular@15.7.1-optin-el-helper-32ded5c
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@15.7.1-optin-el-helper-32ded5c
```
```
yarn add @gravitee/ui-particles-angular@15.7.1-optin-el-helper-32ded5c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-oukjdokcgi.chromatic.com)
<!-- Storybook placeholder end -->
