### PR TITLE
fix: disable save button after save

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.spec.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.spec.ts
@@ -1234,7 +1234,7 @@ describe('GioPolicyStudioComponent', () => {
         expect(firstSaveFlows?.request).toEqual([fakeTestPolicyStep({ description: 'description', enabled: false })]);
       });
 
-      it('should re enable save button after 5s', fakeAsync(async () => {
+      it('should keep save button disabled after saving', fakeAsync(async () => {
         const commonFlows = [fakeChannelFlow({ name: '' }), fakeChannelFlow({ name: 'Flow to delete' })];
         component.commonFlows = commonFlows;
         component.enableSavingTimer = true;
@@ -1251,8 +1251,9 @@ describe('GioPolicyStudioComponent', () => {
         await policyStudioHarness.save();
         expect(await policyStudioHarness.getSaveButtonState()).toEqual('SAVING');
 
+        // After 5s, save button should stay disabled until new changes are made
         tick(5000);
-        expect(await policyStudioHarness.getSaveButtonState()).toEqual('VISIBLE');
+        expect(await policyStudioHarness.getSaveButtonState()).toEqual('DISABLED');
       }));
 
       it('should disable flow', async () => {

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.ts
@@ -213,6 +213,9 @@ export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
     if (changes.policies || changes.sharedPolicyGroupPolicies) {
       this.initGenericPolicies();
     }
+    if (changes.loading && this.loading && !this.saving) {
+      this.saving = true;
+    }
   }
 
   public ngOnDestroy() {
@@ -290,6 +293,7 @@ export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
       ...(this.hasFlowExecutionChanged ? { flowExecution: this.flowExecution } : {}),
     });
     this.saving = true;
+    this.disableSaveButton = true;
 
     this.unSavingButtonSubscription?.unsubscribe();
     if (this.enableSavingTimer) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10888

**Description**

Disable save button after save in policy studio.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

