### PR TITLE
feat: emit event on tag clicked in gio-form-tags-input

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.mdx
+++ b/projects/ui-particles-angular/src/lib/gio-form-tags-input/README.mdx
@@ -26,6 +26,11 @@ Documentation and examples for Form Tags Input, a component to specify a list of
 * `autocompleteOptions`: `AutocompleteOptions | ((search: string) => Observable<AutocompleteOptions>)` - List of options to autocomplete the input. Can be a static list or a function returning an observable to filter the options.
 * `displayValueWith`: `(value: string) => Observable<string>` - Function to display the label of the input value. Useful to display the label of an value id, for instance.
 * `useAutocompleteOptionsOnly`: `boolean` - Whether the input should only accept values from the autocomplete options.
+
+**Outputs**
+
+* `tagClicked`: `EventEmitter<string>` - Emitted when a tag is clicked.
+
   Example:
 
 ```html

--- a/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
+++ b/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.html
@@ -16,7 +16,13 @@
 
 -->
 <mat-chip-grid #tagChipList [attr.aria-label]="ariaLabel" multiple [disabled]="disabled">
-  <mat-chip-row *ngFor="let tag of value" [removable]="!disabled" (removed)="removeChipToFormControl(tag)" [disabled]="disabled">
+  <mat-chip-row
+    *ngFor="let tag of value"
+    [removable]="!disabled"
+    (removed)="removeChipToFormControl(tag)"
+    [disabled]="disabled"
+    (click)="tagClicked.emit(tag)"
+  >
     {{ _displayValueWith ? (_displayValueWith(tag) | async) : tag }}
     <mat-icon matChipRemove>cancel</mat-icon>
   </mat-chip-row>

--- a/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.component.ts
@@ -23,10 +23,12 @@ import {
   Component,
   DoCheck,
   ElementRef,
+  EventEmitter,
   HostBinding,
   Input,
   OnDestroy,
   Optional,
+  Output,
   Self,
   ViewChild,
 } from '@angular/core';
@@ -87,6 +89,10 @@ export class GioFormTagsInputComponent implements MatFormFieldControl<Tags>, Con
   public set autocompleteOptions(v: AutocompleteOptions | ((search: string) => Observable<AutocompleteOptions>) | undefined) {
     this._autocompleteOptions = v;
   }
+
+  @Output()
+  public tagClicked = new EventEmitter<string>();
+
   public _autocompleteOptions?: AutocompleteOptions | ((search: string) => Observable<AutocompleteOptions>);
 
   /**

--- a/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.harness.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.harness.ts
@@ -84,4 +84,14 @@ export class GioFormTagsInputHarness extends ComponentHarness {
 
     return matAutocompleteHarness;
   }
+
+  public async clickTag(tag: string): Promise<void> {
+    const matChipGrid = await this.getMatChipGridHarness();
+
+    const chips = await matChipGrid.getRows({ text: tag });
+    if (chips[0]) {
+      const host = await chips[0].host();
+      await host.click();
+    }
+  }
 }

--- a/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.spec.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.module.spec.ts
@@ -29,6 +29,8 @@ import { GioFormTagsInputHarness } from './gio-form-tags-input.harness';
 import { GioFormTagsInputModule } from './gio-form-tags-input.module';
 
 describe('GioFormTagsInputModule - Static input', () => {
+  const onTagClickMock = jest.fn();
+
   @Component({
     template: `
       <mat-form-field appearance="fill">
@@ -39,6 +41,7 @@ describe('GioFormTagsInputModule - Static input', () => {
           [formControl]="tagsControl"
           [tagValidationHook]="tagValidationHook"
           [autocompleteOptions]="autocompleteOptions"
+          (tagClicked)="onTagClick($event)"
         ></gio-form-tags-input>
         <mat-error>Error</mat-error>
       </mat-form-field>
@@ -52,6 +55,7 @@ describe('GioFormTagsInputModule - Static input', () => {
     public autocompleteOptions?: string[] = undefined;
 
     public tagsControl = new FormControl(null, Validators.required);
+    public onTagClick = onTagClickMock;
   }
 
   let component: TestComponent;
@@ -146,6 +150,23 @@ describe('GioFormTagsInputModule - Static input', () => {
     component.tagsControl.markAsTouched();
 
     expect(await matFormFieldHarness.hasErrors()).toBe(true);
+  });
+
+  it('should send a tagClicked event', async () => {
+    fixture.detectChanges();
+
+    const formTagsInputHarness = await loader.getHarness(GioFormTagsInputHarness);
+    expect(await formTagsInputHarness.getTags()).toEqual([]);
+
+    await formTagsInputHarness.addTag('tag1');
+    await formTagsInputHarness.addTag('tag2', 'blur');
+
+    expect(await formTagsInputHarness.getTags()).toEqual(['tag1', 'tag2']);
+
+    await formTagsInputHarness.clickTag('tag2');
+    expect(await formTagsInputHarness.getTags()).toEqual(['tag1', 'tag2']);
+
+    expect(onTagClickMock).toHaveBeenNthCalledWith(1, 'tag2');
   });
 
   describe('with autocomplete', () => {

--- a/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-tags-input/gio-form-tags-input.stories.ts
@@ -56,7 +56,7 @@ export default {
 export const WithoutFormField: StoryObj = {
   render: ({ tags = ['A', 'B'], placeholder, required, disabled }) => ({
     template: `
-      <gio-form-tags-input [disabled]="disabled" [required]="required" [placeholder]="placeholder" [ngModel]="tags" (ngModelChange)="onTagsChange($event)">
+      <gio-form-tags-input [disabled]="disabled" [required]="required" [placeholder]="placeholder" [ngModel]="tags" (ngModelChange)="onTagsChange($event)" (tagClicked)="onTagClicked($event)">
       </gio-form-tags-input>
     `,
     props: {
@@ -65,6 +65,7 @@ export const WithoutFormField: StoryObj = {
       required,
       disabled,
       onTagsChange: (e: Tags[]) => action('Tags')(e),
+      onTagClicked: (e: string) => action('TagClicked')(e),
     },
   }),
   args: {},
@@ -81,6 +82,7 @@ export const EmptyModel: StoryObj = {
         [placeholder]="placeholder" 
         [ngModel]="tags" 
         (ngModelChange)="onTagsChange($event)"
+        (tagClicked)="onTagClicked($event)"
       >
       </gio-form-tags-input>
     </mat-form-field>
@@ -91,6 +93,7 @@ export const EmptyModel: StoryObj = {
       required,
       disabled,
       onTagsChange: (e: Tags[]) => action('Tags')(e),
+      onTagClicked: (e: string) => action('TagClicked')(e),
     },
   }),
   args: {},


### PR DESCRIPTION
**Description**

In Cockpit, this component is used to edit the sharding tags of gateways. We want to provide users with the ability to copy these tags to the clipboard by clicking on them. 
This PR simply emits an event to indicate that a tag has been clicked.
You can see small demo here: https://github.com/gravitee-io/gravitee-cockpit/pull/6090

https://gravitee.atlassian.net/browse/CJ-3402
https://gravitee.atlassian.net/browse/CJ-3255

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@15.8.1-click-tag-0d8451a
```
```
yarn add @gravitee/ui-schematics@15.8.1-click-tag-0d8451a
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@15.8.1-click-tag-0d8451a
```
```
yarn add @gravitee/ui-policy-studio-angular@15.8.1-click-tag-0d8451a
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@15.8.1-click-tag-0d8451a
```
```
yarn add @gravitee/ui-particles-angular@15.8.1-click-tag-0d8451a
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-yfchfektdi.chromatic.com)
<!-- Storybook placeholder end -->
