### PR TITLE
fix: resize images in application dropdown for consistent alignment

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-avatar/gio-avatar.component.ts
+++ b/projects/ui-particles-angular/src/lib/gio-avatar/gio-avatar.component.ts
@@ -49,6 +49,8 @@ export class GioAvatarComponent implements AfterViewInit, OnChanges {
 
   public ngOnChanges(): void {
     this.finalSize = this.size || this.defaultSize;
+    this.width = this.finalSize;
+    this.height = this.finalSize;
   }
 
   public ngAfterViewInit(): void {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10964

**Description**

This commit addresses a UI issue in the Plan > Create Subscription pop-up where application images in the dropdown menu appeared excessively large. The oversized images caused layout distortion, inconsistent spacing, and poor usability when browsing the list of applications.

Images are now resized to uniform thumbnail dimensions and aligned properly with the text to ensure a cleaner and more consistent dropdown experience.

**Additional context**

### Before fix
<img width="1728" height="946" alt="Screenshot 2025-09-09 at 2 04 06 PM" src="https://github.com/user-attachments/assets/1a4e58c5-ff4c-46d3-b425-8b4c325c8a5a" />

### After Fix
<img width="1726" height="935" alt="Screenshot 2025-09-09 at 2 01 08 PM" src="https://github.com/user-attachments/assets/d7318b07-dfc9-4897-968a-1658ef3c8c2f" />
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@14.2.2-apim-10964-image-appears-too-large-inside-subscription-dropdown-menu-0d8689c
```
```
yarn add @gravitee/ui-schematics@14.2.2-apim-10964-image-appears-too-large-inside-subscription-dropdown-menu-0d8689c
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@14.2.2-apim-10964-image-appears-too-large-inside-subscription-dropdown-menu-0d8689c
```
```
yarn add @gravitee/ui-policy-studio-angular@14.2.2-apim-10964-image-appears-too-large-inside-subscription-dropdown-menu-0d8689c
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@14.2.2-apim-10964-image-appears-too-large-inside-subscription-dropdown-menu-0d8689c
```
```
yarn add @gravitee/ui-particles-angular@14.2.2-apim-10964-image-appears-too-large-inside-subscription-dropdown-menu-0d8689c
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-llfmkvuftu.chromatic.com)
<!-- Storybook placeholder end -->
