### PR TITLE
fix(policy-studio): hide entrypoint connect phase for plan flows

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
+++ b/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.html
@@ -150,20 +150,22 @@
       @if (apiType === 'NATIVE') {
         <mat-tab-group class="content__tabs" dynamicHeight>
           <mat-tab label="Global" bodyClass="content__tabs__body">
-            <gio-ps-flow-details-phase
-              class="content__phase"
-              name="Entrypoint Connect phase"
-              description="Policies will be applied when client connects to entrypoint before authentication and message processing"
-              [readOnly]="readOnly"
-              [startConnector]="entrypointConnectStartConnector"
-              [endConnector]="entrypointConnectEndConnector"
-              [steps]="flow.entrypointConnect ?? []"
-              [apiType]="apiType"
-              [genericPolicies]="genericPolicies"
-              [trialUrl]="trialUrl"
-              policyFlowPhase="ENTRYPOINT_CONNECT"
-              (stepsChange)="onStepsChange('entrypointConnect', $event)"
-            ></gio-ps-flow-details-phase>
+            @if (!isPlanFlow) {
+              <gio-ps-flow-details-phase
+                class="content__phase"
+                name="Entrypoint Connect phase"
+                description="Policies will be applied when client connects to entrypoint before authentication and message processing"
+                [readOnly]="readOnly"
+                [startConnector]="entrypointConnectStartConnector"
+                [endConnector]="entrypointConnectEndConnector"
+                [steps]="flow.entrypointConnect ?? []"
+                [apiType]="apiType"
+                [genericPolicies]="genericPolicies"
+                [trialUrl]="trialUrl"
+                policyFlowPhase="ENTRYPOINT_CONNECT"
+                (stepsChange)="onStepsChange('entrypointConnect', $event)"
+              ></gio-ps-flow-details-phase>
+            }
             <gio-ps-flow-details-phase
               class="content__phase"
               name="Interact phase"

--- a/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -72,6 +72,9 @@ export class GioPolicyStudioDetailsComponent implements OnChanges {
   public apiType!: ApiType;
 
   @Input()
+  public isPlanFlow = false;
+
+  @Input()
   public flow?: FlowVM = undefined;
 
   @Input()

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.html
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.html
@@ -77,6 +77,7 @@
       [loading]="loading"
       [apiType]="apiType"
       [flow]="selectedFlow"
+      [isPlanFlow]="selectedFlowIsPlan"
       [entrypointsInfo]="entrypointsInfo"
       [endpointsInfo]="endpointsInfo"
       [policies]="policies"

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.native-kafka.spec.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.native-kafka.spec.ts
@@ -197,6 +197,45 @@ describe('GioPolicyStudioComponent - Native Kafka', () => {
       expect(await detailsHarness.matchText(/Edited flow name/)).toEqual(true);
     });
 
+    it('should not display entrypoint connect phase for plan flows', async () => {
+      const planFlows = [
+        fakeNativeFlow({
+          name: 'Plan flow 1',
+          interact: [fakeTestPolicyStep()],
+          entrypointConnect: [fakeTestPolicyStep()],
+        }),
+      ];
+      const plans = [fakePlan({ name: 'My plan', flows: planFlows })];
+      component.plans = plans;
+      component.ngOnChanges({
+        plans: new SimpleChange(null, null, true),
+      });
+
+      await expect(policyStudioHarness.getSelectedFlowPhase('ENTRYPOINT_CONNECT')).rejects.toThrow();
+
+      const interactPhase = await policyStudioHarness.getSelectedFlowPhase('INTERACT');
+      expect(interactPhase).toBeDefined();
+    });
+
+    it('should show entrypoint connect phase when switching from plan flow to common flow', async () => {
+      const plans = [fakePlan({ name: 'My plan', flows: [fakeNativeFlow({ name: 'Plan flow' })] })];
+      const commonFlows = [fakeNativeFlow({ name: 'Common flow', entrypointConnect: [fakeTestPolicyStep()] })];
+      component.plans = plans;
+      component.commonFlows = commonFlows;
+      component.ngOnChanges({
+        plans: new SimpleChange(null, null, true),
+        commonFlows: new SimpleChange(null, null, true),
+      });
+
+      // Plan flow selected first — entrypoint connect hidden
+      await expect(policyStudioHarness.getSelectedFlowPhase('ENTRYPOINT_CONNECT')).rejects.toThrow();
+
+      // Switch to common flow — entrypoint connect should reappear
+      await policyStudioHarness.selectFlowInMenu('Common flow');
+      const entrypointConnectPhase = await policyStudioHarness.getSelectedFlowPhase('ENTRYPOINT_CONNECT');
+      expect(entrypointConnectPhase).toBeDefined();
+    });
+
     it('should display phases steps', async () => {
       const commonFlows = [
         fakeNativeFlow({

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.ts
@@ -164,6 +164,8 @@ export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
 
   public selectedFlow?: FlowVM = undefined;
 
+  public selectedFlowIsPlan = false;
+
   public flowsGroups: FlowGroupVM[] = [];
 
   public disableSaveButton = true;
@@ -208,7 +210,9 @@ export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
       this.disableSaveButton = true;
       this.flowsGroups = getFlowsGroups(this.apiType, this.commonFlows, this.plans);
       this.initialFlowsGroups = cloneDeep(this.flowsGroups);
-      this.selectedFlow = this.flowsGroups[this.selectedFlowIndexes?.planIndex ?? 0]?.flows[this.selectedFlowIndexes?.flowIndex ?? 0];
+      const planIndex = this.selectedFlowIndexes?.planIndex ?? 0;
+      this.selectedFlow = this.flowsGroups[planIndex]?.flows[this.selectedFlowIndexes?.flowIndex ?? 0];
+      this.selectedFlowIsPlan = this.flowsGroups[planIndex]?._isPlan ?? false;
 
       // Reset saving state when flowsGroups are updated
       this.saving = false;
@@ -275,6 +279,7 @@ export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
     this.selectedFlowIndexes = { planIndex: newPlanIndex, flowIndex: newFlowIndex };
 
     this.selectedFlow = this.flowsGroups[newPlanIndex].flows[newFlowIndex];
+    this.selectedFlowIsPlan = this.flowsGroups[newPlanIndex]?._isPlan ?? false;
 
     this.selectedFlowChanged.emit(this.selectedFlowIndexes);
   }


### PR DESCRIPTION
The Kafka reactor only executes entrypoint connect policies on API-level flows. Plan-level entrypoint connect policies are silently ignored, so the phase should not be shown for plan flows.

**Issue**

https://gravitee.atlassian.net/browse/APIM-13633

**Description**

Why this approach over alternatives:

- I considered putting _isPlanFlow directly on FlowVM (set during the initial getFlowsGroups() mapping). This broke for dynamically created flows (add, drag-drop) because those mutations bypass getFlowsGroups() and the flag was never set.
- Deriving from the group via @Input is correct because _isPlan on FlowGroupVM is the authoritative source — it's always set, never stale, and doesn't depend on how the flow was created.

**Additional context**

<img width="1648" height="547" alt="image" src="https://github.com/user-attachments/assets/428a370b-cdc1-4dbf-b529-a0706fe9f14f" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@17.7.4-fix-hide-entrypoint-connect-for-plan-flows-efdbab0
```
```
yarn add @gravitee/ui-particles-angular@17.7.4-fix-hide-entrypoint-connect-for-plan-flows-efdbab0
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@17.7.4-fix-hide-entrypoint-connect-for-plan-flows-efdbab0
```
```
yarn add @gravitee/ui-schematics@17.7.4-fix-hide-entrypoint-connect-for-plan-flows-efdbab0
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-zfvwjjcpbv.chromatic.com)
<!-- Storybook placeholder end -->
