### PR TITLE
feat(form-json-schema): support relative paths in displayIf/disableIf

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/gio-formly-json-schema.service.ts
@@ -55,16 +55,8 @@ export class GioFormlyJsonSchemaService {
       mappedField.expressions = {
         ...mappedField.expressions,
         hide: field => {
-          let parentField = field;
-          while (parentField.parent) {
-            parentField = parentField.parent;
-          }
-
           try {
-            return !displayIf({
-              value: parentField.model,
-              context,
-            });
+            return !displayIf({ field, context });
           } catch (e) {
             // Ignore the error and display the field
             return false;
@@ -173,16 +165,8 @@ export class GioFormlyJsonSchemaService {
           return false;
         }
 
-        let parentField = field;
-        while (parentField.parent) {
-          parentField = parentField.parent;
-        }
-
         try {
-          const isDisabled = disableIf({
-            value: parentField.model,
-            context,
-          });
+          const isDisabled = disableIf({ field, context });
           // Useful when full form is re-enabled to sync the fromControl enable/disable state
           isDisabled ? field.formControl?.disable({ emitEvent: false }) : field.formControl?.enable({ emitEvent: false });
           return isDisabled;
@@ -357,23 +341,95 @@ const getBannerProperties = (banner: { title: string; text: string } | { text: s
 
 const getGioIf = (
   gioIf?: GioIfConfig,
-): ((objectToCheck?: { value?: FormlyFieldConfig['model']; context?: Record<string, unknown> }) => boolean) | undefined => {
+): ((args: { field: FormlyFieldConfig; context?: Record<string, unknown> }) => boolean) | undefined => {
   const $eq = gioIf?.$eq;
   if (isNil($eq) || !isObject($eq)) {
     return undefined;
   }
 
-  return objectToCheck => {
-    if (isEmpty(objectToCheck)) {
+  return ({ field, context }) => {
+    if (!field) {
       return false;
     }
 
     return Object.entries($eq)
       .map(([k, v]) => ({ path: k, eqValue: castArray(v) }))
       .every(({ path, eqValue }) => {
-        const value = get(objectToCheck, path);
+        const value = resolveGioIfPath(path, field, context);
 
-        return eqValue.includes(value);
+        return eqValue.includes(value as string | number | boolean);
       });
   };
 };
+
+/**
+ * Resolves a `displayIf` / `disableIf` path against the form state.
+ *
+ * Path syntax (backward compatible):
+ *   - `value.<dotPath>` / `context.<dotPath>` → root model / external context (legacy)
+ *   - `./<dotPath>`                          → current scope (`field.model`)
+ *   - `../<dotPath>` (any depth)             → walks up the ancestor chain by one
+ *                                              scope per `..`, where a "scope" is an
+ *                                              ancestor whose `model` differs from
+ *                                              the previous one (Formly wrappers that
+ *                                              share the same model are skipped).
+ *
+ * Relative paths let conditions inside an array item (or a sub-object of an item)
+ * reference siblings or item-level fields, which is impossible with `value.` since
+ * the array index of the current row is unknown.
+ */
+const resolveGioIfPath = (path: string, field: FormlyFieldConfig, context?: Record<string, unknown>): unknown => {
+  if (path === 'value' || path.startsWith('value.')) {
+    const root = getRootModel(field);
+    return path === 'value' ? root : get(root, path.slice('value.'.length));
+  }
+  if (path === 'context' || path.startsWith('context.')) {
+    return path === 'context' ? context : get(context, path.slice('context.'.length));
+  }
+  if (path.startsWith('./') || path.startsWith('../') || path === '.' || path === '..') {
+    let upCount = 0;
+    let rest = path;
+    let consumed = true;
+    while (consumed) {
+      consumed = false;
+      if (rest.startsWith('../')) {
+        upCount++;
+        rest = rest.slice(3);
+        consumed = true;
+      } else if (rest === '..') {
+        upCount++;
+        rest = '';
+      } else if (rest.startsWith('./')) {
+        rest = rest.slice(2);
+        consumed = true;
+      } else if (rest === '.') {
+        rest = '';
+      }
+    }
+    const scope = getModelChain(field)[upCount];
+    return rest === '' ? scope : get(scope, rest);
+  }
+  return undefined;
+};
+
+const getRootModel = (field: FormlyFieldConfig): unknown => {
+  let cur = field;
+  while (cur.parent) cur = cur.parent;
+  return cur.model;
+};
+
+const getModelChain = (field: FormlyFieldConfig): unknown[] => {
+  const chain: unknown[] = [];
+  let cur: FormlyFieldConfig | undefined = field;
+  let last: unknown = MODEL_CHAIN_SENTINEL;
+  while (cur) {
+    if (cur.model !== last) {
+      chain.push(cur.model);
+      last = cur.model;
+    }
+    cur = cur.parent;
+  }
+  return chain;
+};
+
+const MODEL_CHAIN_SENTINEL = Symbol('model-chain-sentinel');

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/disableIf.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/disableIf.ts
@@ -102,6 +102,62 @@ export const disableIfExample: GioJsonSchema = {
         },
       },
     },
+    arrayWithDisableIf: {
+      type: 'array',
+      title: 'Array — relative disableIf inside item',
+      description: 'Each item: the toggle disables a sibling field in the SAME row, using the relative path "./disableField".',
+      items: {
+        type: 'object',
+        properties: {
+          disableField: {
+            type: 'boolean',
+            title: 'Disable "field" in this row',
+          },
+          field: {
+            type: 'string',
+            title: 'Field',
+            gioConfig: {
+              disableIf: {
+                $eq: {
+                  './disableField': true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    arrayWithNestedDisableIf: {
+      type: 'array',
+      title: 'Array — relative disableIf inside a sub-object',
+      description: 'Each item has a sub-object whose field references the item-level toggle via "../disableField" (one level up).',
+      items: {
+        type: 'object',
+        properties: {
+          disableField: {
+            type: 'boolean',
+            title: 'Disable nested "field"',
+          },
+          sub: {
+            type: 'object',
+            title: 'Sub-object',
+            properties: {
+              field: {
+                type: 'string',
+                title: 'Field',
+                gioConfig: {
+                  disableIf: {
+                    $eq: {
+                      '../disableField': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   gioConfig: {
     banner: {

--- a/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/displayIf.ts
+++ b/projects/ui-particles-angular/src/lib/gio-form-json-schema/json-schema-example/displayIf.ts
@@ -114,6 +114,62 @@ export const displayIfExample: GioJsonSchema = {
         },
       },
     },
+    arrayWithDisplayIf: {
+      type: 'array',
+      title: 'Array — relative displayIf inside item',
+      description: 'Each item: the toggle controls visibility of a sibling field in the SAME row, using the relative path "./showField".',
+      items: {
+        type: 'object',
+        properties: {
+          showField: {
+            type: 'boolean',
+            title: 'Show "field" in this row',
+          },
+          field: {
+            type: 'string',
+            title: 'Field',
+            gioConfig: {
+              displayIf: {
+                $eq: {
+                  './showField': true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    arrayWithNestedDisplayIf: {
+      type: 'array',
+      title: 'Array — relative displayIf inside a sub-object',
+      description: 'Each item has a sub-object whose field references the item-level toggle via "../showField" (one level up).',
+      items: {
+        type: 'object',
+        properties: {
+          showField: {
+            type: 'boolean',
+            title: 'Show nested "field"',
+          },
+          sub: {
+            type: 'object',
+            title: 'Sub-object',
+            properties: {
+              field: {
+                type: 'string',
+                title: 'Field',
+                gioConfig: {
+                  displayIf: {
+                    $eq: {
+                      '../showField': true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   gioConfig: {
     banner: {


### PR DESCRIPTION
## Summary
- Add `./x` / `../x` path syntax for `displayIf` and `disableIf` so conditions inside an array item — or a sub-object of an item — can reference siblings or item-level fields.
- Previously impossible: `value.x` resolves from the form root, with no way to address "the current row" of an array.
- `value.` and `context.` keep their existing semantics — fully backward compatible.

## Path syntax

| Path | Resolves against |
|---|---|
| `value.x` | root model (legacy, unchanged) |
| `context.x` | external context (legacy, unchanged) |
| `./x` | current scope (`field.model`) |
| `../x` | one scope up |
| `../../x` | two scopes up, etc. |

The ancestor chain dedupes Formly wrappers that share the same `model`, so each `..` corresponds to a real model boundary.

## Storybook
- `displayIf.ts` — added an array-of-objects example using `./showField`, and an array containing a sub-object using `../showField`.
- `disableIf.ts` — same two patterns with `./disableField` and `../disableField`.

<!-- Prerelease placeholder ui-schematics -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-schematics
```
npm install @gravitee/ui-schematics@17.7.5-improve-displayif-disabledif-d7261b3
```
```
yarn add @gravitee/ui-schematics@17.7.5-improve-displayif-disabledif-d7261b3
```
<!-- Prerelease placeholder ui-schematics end -->
<!-- Prerelease placeholder ui-policy-studio-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-policy-studio-angular
```
npm install @gravitee/ui-policy-studio-angular@17.7.5-improve-displayif-disabledif-d7261b3
```
```
yarn add @gravitee/ui-policy-studio-angular@17.7.5-improve-displayif-disabledif-d7261b3
```
<!-- Prerelease placeholder ui-policy-studio-angular end -->
<!-- Prerelease placeholder ui-particles-angular -->
---
#### 🧪&nbsp;&nbsp;Gravitee.io Automatic Prerelease @gravitee/ui-particles-angular
```
npm install @gravitee/ui-particles-angular@17.7.5-improve-displayif-disabledif-d7261b3
```
```
yarn add @gravitee/ui-particles-angular@17.7.5-improve-displayif-disabledif-d7261b3
```
<!-- Prerelease placeholder ui-particles-angular end -->
<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-jvfbfhvayp.chromatic.com)
<!-- Storybook placeholder end -->
