### PR TITLE
feat(mcp-studio): Added new api type "MCP_STUDIO"

### DIFF
--- a/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flow-details/gio-ps-flow-details.component.ts
@@ -194,6 +194,7 @@ export class GioPolicyStudioDetailsComponent implements OnChanges {
           .afterClosed();
         break;
       case 'MCP_PROXY':
+      case 'MCP_STUDIO':
         dialogResult = this.matDialog
           .open<GioPolicyStudioFlowMcpFormDialogComponent, GioPolicyStudioFlowMcpFormDialogData, GioPolicyStudioFlowFormDialogResult>(
             GioPolicyStudioFlowMcpFormDialogComponent,

--- a/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/flows-menu/gio-ps-flows-menu.component.ts
@@ -383,6 +383,7 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges, OnDestroy {
           .afterClosed();
         break;
       case 'MCP_PROXY':
+      case 'MCP_STUDIO':
         dialogResult = this.matDialog
           .open<GioPolicyStudioFlowMcpFormDialogComponent, GioPolicyStudioFlowMcpFormDialogData, GioPolicyStudioFlowFormDialogResult>(
             GioPolicyStudioFlowMcpFormDialogComponent,
@@ -549,6 +550,7 @@ export class GioPolicyStudioFlowsMenuComponent implements OnChanges, OnDestroy {
           .afterClosed();
         break;
       case 'MCP_PROXY':
+      case 'MCP_STUDIO':
         dialogResult = this.matDialog
           .open<GioPolicyStudioFlowMcpFormDialogComponent, GioPolicyStudioFlowMcpFormDialogData, GioPolicyStudioFlowFormDialogResult>(
             GioPolicyStudioFlowMcpFormDialogComponent,

--- a/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/components/policies-catalog-dialog/gio-ps-policies-catalog-dialog.component.ts
@@ -124,6 +124,7 @@ export class GioPolicyStudioPoliciesCatalogDialogComponent implements OnDestroy 
             case 'NATIVE':
               return genericPolicy.flowPhaseCompatibility?.NATIVE_KAFKA?.includes(flowDialogData.flowPhase);
             case 'MCP_PROXY':
+            case 'MCP_STUDIO':
               return genericPolicy.flowPhaseCompatibility?.MCP_PROXY?.includes(flowDialogData.flowPhase);
             case 'LLM_PROXY':
               return genericPolicy.flowPhaseCompatibility?.LLM_PROXY?.includes(flowDialogData.flowPhase);

--- a/projects/ui-policy-studio-angular/src/lib/models/ApiProtocolType.ts
+++ b/projects/ui-policy-studio-angular/src/lib/models/ApiProtocolType.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export type ApiProtocolType = 'A2A_PROXY' | 'HTTP_MESSAGE' | 'HTTP_PROXY' | 'LLM_PROXY' | 'MCP_PROXY' | 'NATIVE_KAFKA';
+export type ApiProtocolType = 'A2A_PROXY' | 'HTTP_MESSAGE' | 'HTTP_PROXY' | 'LLM_PROXY' | 'MCP_PROXY' | 'MCP_STUDIO' | 'NATIVE_KAFKA';

--- a/projects/ui-policy-studio-angular/src/lib/models/ApiType.ts
+++ b/projects/ui-policy-studio-angular/src/lib/models/ApiType.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export type ApiType = 'A2A_PROXY' | 'LLM_PROXY' | 'MCP_PROXY' | 'MESSAGE' | 'NATIVE' | 'PROXY';
+export type ApiType = 'A2A_PROXY' | 'LLM_PROXY' | 'MCP_PROXY' | 'MCP_STUDIO' | 'MESSAGE' | 'NATIVE' | 'PROXY';

--- a/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.fixture.ts
+++ b/projects/ui-policy-studio-angular/src/lib/models/policy/Policy.fixture.ts
@@ -141,6 +141,7 @@ export function fakeTestPolicy(modifier?: Partial<Policy> | ((base: Policy) => P
       HTTP_PROXY: ['REQUEST', 'RESPONSE'],
       LLM_PROXY: ['REQUEST', 'RESPONSE'],
       MCP_PROXY: ['REQUEST', 'RESPONSE'],
+      MCP_STUDIO: ['REQUEST', 'RESPONSE'],
       NATIVE_KAFKA: ['INTERACT', 'PUBLISH', 'SUBSCRIBE', 'ENTRYPOINT_CONNECT'],
     },
   };

--- a/projects/ui-policy-studio-angular/src/lib/policy-group-studio/gio-policy-group-studio.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-group-studio/gio-policy-group-studio.component.ts
@@ -191,6 +191,13 @@ export class GioPolicyGroupStudioComponent implements OnChanges {
     MCP_PROXY__SUBSCRIBE: null, // n/a
     MCP_PROXY__INTERACT: null, // n/a
     MCP_PROXY__ENTRYPOINT_CONNECT: null, // n/a
+    // MCP Studio
+    MCP_STUDIO__REQUEST: PROXY_REQUEST_PHASE,
+    MCP_STUDIO__RESPONSE: PROXY_RESPONSE_PHASE,
+    MCP_STUDIO__PUBLISH: null, // n/a
+    MCP_STUDIO__SUBSCRIBE: null, // n/a
+    MCP_STUDIO__INTERACT: null, // n/a
+    MCP_STUDIO__ENTRYPOINT_CONNECT: null, // n/a
     // HTTP Message
     MESSAGE__REQUEST: {
       name: 'Request phase',

--- a/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.ts
+++ b/projects/ui-policy-studio-angular/src/lib/policy-studio/gio-policy-studio.component.ts
@@ -180,6 +180,7 @@ export class GioPolicyStudioComponent implements OnChanges, OnDestroy {
       MESSAGE: 'HTTP Message',
       NATIVE: 'Native',
       MCP_PROXY: 'MCP Proxy',
+      MCP_STUDIO: 'MCP Studio',
     };
 
     return apiTypeMap[this.apiType];


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/GMA-341

**Description**

Added MCP_STUDIO as a supported API type across the policy studio library, mirroring the existing MCP_PROXY behaviour:

- Added MCP_STUDIO to ApiType and ApiProtocolType union types
- Added display label 'MCP Studio' in the policy studio component
- Routed MCP_STUDIO to the MCP flow dialog in flows-menu and flow-details (same dialog as MCP_PROXY)
- Added MCP_STUDIO phase mappings (REQUEST, RESPONSE) in the policy group studio
- Added MCP_STUDIO case in the policies catalog dialog, falling through to MCP_PROXY compatibility check
- Updated Policy.fixture.ts with MCP_STUDIO: ['REQUEST', 'RESPONSE']

**Additional context**


https://github.com/user-attachments/assets/c69888b3-f370-4938-bcb0-67a970f65659



