### PR TITLE
fix: update license expiry contact-us url

### DIFF
--- a/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.html
+++ b/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.html
@@ -24,7 +24,7 @@
       </div>
     </div>
     @if (showCallToAction) {
-      <a class="status__action" [href]="link ?? 'https://www.gravitee.io/contact-us-licence'" target="_blank">
+      <a class="status__action" [href]="link ?? 'https://www.gravitee.io/contact-us'" target="_blank">
         <div class="status__action__text">{{ callToActionMessage ?? 'Contact Gravitee' }}</div>
         <mat-icon svgIcon="gio:right-circle" class="status__action__icon"></mat-icon>
       </a>

--- a/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.spec.ts
+++ b/projects/ui-particles-angular/src/lib/gio-license-expiration-notification/gio-license-expiration-notification.component.spec.ts
@@ -144,7 +144,7 @@ describe('GioLicenseExpirationNotificationComponent', () => {
       fixture.detectChanges();
 
       const harness = await loader.getHarness(GioLicenseExpirationNotificationHarness);
-      expect(await harness.getLink()).toEqual('https://www.gravitee.io/contact-us-licence');
+      expect(await harness.getLink()).toEqual('https://www.gravitee.io/contact-us');
       expect(await harness.getCallToActionText()).toEqual('Contact Gravitee');
     });
 


### PR DESCRIPTION
**Issue**

n/a

**Description**

Replace default contact-us url in `GioLicenseExpirationNotificationComponent`.

`https://www.gravitee.io/contact-us-licence` dead link -> `https://www.gravitee.io/contact-us`

<!-- Storybook placeholder -->
---
#### 📚&nbsp;&nbsp;View the storybook of this branch [here](https://6183b02d73381a003a3be1a6-xmjvtqkwgh.chromatic.com)
<!-- Storybook placeholder end -->

Direct component preview:
https://6183b02d73381a003a3be1a6-xmjvtqkwgh.chromatic.com/?path=/story/components-license-expiration-notification--default
